### PR TITLE
docs/test/fix: refactoring plan, Phase 0 safety net, and remote_model feature-gate fix

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -82,3 +82,36 @@ jobs:
           else
             cargo test --target "${{ matrix.platform.target }}" --all-features
           fi
+
+  feature-check:
+    name: Feature check
+    needs: [format]
+    runs-on: ubuntu-latest
+    # TODO(refactoring Phase 1): currently fails because perceptron.rs uses
+    # reqwest without a `remote_model` feature gate. Make this job required
+    # (remove continue-on-error) once that bug is fixed.
+    continue-on-error: true
+    steps:
+      - name: Run checkout
+        uses: actions/checkout@v6
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+
+      - name: Cache Cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-feature-check-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Check without default features
+        run: cargo check -p litsea --no-default-features
+
+      - name: Check wasm32 target
+        run: cargo check -p litsea --target wasm32-unknown-unknown --no-default-features

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -87,10 +87,6 @@ jobs:
     name: Feature check
     needs: [format]
     runs-on: ubuntu-latest
-    # TODO(refactoring Phase 1): currently fails because perceptron.rs uses
-    # reqwest without a `remote_model` feature gate. Make this job required
-    # (remove continue-on-error) once that bug is fixed.
-    continue-on-error: true
     steps:
       - name: Run checkout
         uses: actions/checkout@v6

--- a/REFACTORING_PLAN.md
+++ b/REFACTORING_PLAN.md
@@ -70,9 +70,21 @@
 
 ## 3. フェーズ計画
 
-### フェーズ 0: 安全網の整備(挙動不変・追加のみ)
+### フェーズ 0: 安全網の整備(挙動不変・追加のみ) — ✅ 実施済み
 
 **目的**: 以降のすべてのリファクタリングの回帰を機械的に検出できる状態を作る。
+
+**実施結果**(2026-06-12):
+- `litsea/tests/golden.rs` を追加(全 8 モデルのスナップショット 10 テスト、すべて green)。
+- round-trip テスト(AdaBoost / Perceptron)を同ファイルに追加。
+- regression.yml に `feature-check` ジョブを追加(`--no-default-features` と wasm32。B1 未修正のため `continue-on-error: true`。Phase 1 で必須化する)。
+- criterion ベースライン(`--save-baseline pre-refactor`、短縮計測の参考値、median):
+  `segment_short/adaboost` ja 56.8µs / zh 37.1µs / ko 51.3µs、
+  `segment_short/averaged_perceptron` ja 293µs / zh 211µs / ko 286µs、
+  `segment_long_japanese` adaboost 611ms / perceptron **4.48s**、
+  `add_corpus` 161µs、`predict_adaboost` 2.9µs、`get_type_hiragana` 61ns、
+  `char_type_patterns_japanese`(パターン構築)205µs。
+  ※ コンテナ環境は使い捨てのため、Phase 4 では比較対象の数値を都度取り直すこと。
 
 **作業項目**:
 1. **ゴールデンテストの追加**(`litsea/tests/golden.rs`):

--- a/REFACTORING_PLAN.md
+++ b/REFACTORING_PLAN.md
@@ -1,0 +1,261 @@
+# Litsea コードベース リファクタリング計画
+
+作成日: 2026-06-12
+対象バージョン: 0.4.0(workspace: `litsea` / `litsea-cli`、約 4,200 行)
+
+本計画は、コードベース全体の調査に基づき、蓄積した重複・設計上の負債・性能上の無駄を
+**6 フェーズ**に分けて解消するためのものです。各フェーズは独立してレビュー・マージ可能な
+単位とし、「挙動を変えないフェーズ」と「意図的に API を変えるフェーズ」を明確に分離します。
+
+---
+
+## 1. 現状調査サマリ
+
+### 1.1 確認済みのバグ(最優先)
+
+| # | 内容 | 根拠 |
+|---|------|------|
+| B1 | **`--no-default-features` でビルド不能**。`perceptron.rs` が `reqwest` を feature gate なしで使用しており(`perceptron.rs:9` の `use reqwest::Client;` と `load_model_from_url`)、`remote_model` を無効にするとコンパイルエラーになる。`adaboost.rs` は正しく `#[cfg(feature = "remote_model")]` で保護されているのに対し、後から追加された perceptron 側が追従していない。 | `cargo check -p litsea --no-default-features` が E0432/E0282 で失敗することを確認済み |
+| B2 | `AveragedPerceptron::save_model` の doc コメントが「モデルを**JSON形式**でファイルに保存する」と記述しているが、実際はクラスヘッダ + TSV のテキスト形式(`perceptron.rs:231-242`)。 | コード読解 |
+| B3 | CI(regression.yml / periodic.yml)に feature マトリクスがなく、B1 のようなビルド破壊が検出されない。 | ワークフロー確認 |
+
+### 1.2 重複コード(本計画の主対象)
+
+| # | 内容 | 場所 | 規模 |
+|---|------|------|------|
+| D1 | **モデル I/O の全面重複**。URI スキーム解決・HTTP ダウンロード・wasm32 向け cfg 分岐・ファイル読み込みのロジックが `AdaBoost` と `AveragedPerceptron` でほぼコピペ。 | `adaboost.rs:334-524` / `perceptron.rs:271-438` | 約 170 行 × 2 |
+| D2 | **Segmenter のパイプライン 4 重複**。`B3/B2/B1`・`E1/E2/E3` パディングと chars/types 配列の構築が `process_corpus`、`process_corpus_with_pos`、`segment`、`segment_with_pos` の 4 箇所に展開されている。 | `segmenter.rs:86-128, 134-201, 328-361, 378-432` | 約 30 行 × 4 |
+| D3 | **Extractor の 2 メソッド重複**。`extract` と `extract_with_pos` はラベル型(`i8` / `SegmentLabel`)以外ほぼ同一で、`RefCell<Option<io::Error>>` によるエラー伝播ハックも両方に存在。 | `extractor.rs:51-153` | 約 50 行 × 2 |
+| D4 | **Metrics 構造体が 2 つ**(`adaboost::Metrics` と `perceptron::Metrics`)。名前が衝突するため `trainer.rs` では `perceptron::Metrics` とフルパス参照している。 | `adaboost.rs:14-32` / `perceptron.rs:34-50` | 小 |
+| D5 | **Trainer / PosTrainer の構造重複**。`new → load_model → train(保存込み)` の同型ラッパーが 2 つ。 | `trainer.rs:15-148` | 約 60 行 × 2 |
+| D6 | **言語別パターンの共通部分重複**。句読点・Latin・数字の正規表現が日本語/中国語/韓国語の 3 関数にコピペ。`expect("hardcoded regex pattern is valid")` も全行に重複。 | `language.rs:138-302` | 中 |
+| D7 | エラー生成の `std::io::Error::new(InvalidData, format!(...))` ボイラープレートが全ファイルに散在(20 箇所以上)。 | 全域 | 中 |
+
+### 1.3 設計・API 上の負債
+
+- **エラー型がない**: ライブラリ全体が `std::io::Error` の流用と `Box<dyn Error>`(`trainer.rs`、`extractor.rs`)の混在。呼び出し側がエラー種別で分岐できない。
+- **async の伝播**: `load_model` だけが async なため、CLI 全体が tokio 必須、doc テストが `tokio_test::block_on` 必須、ベンチでも `tokio::runtime::Runtime` を手作り(`bench.rs:14-30`)。実際に非同期が必要なのは `remote_model` の HTTP 取得のみ。
+- **同一ファイルの 2 回読み**: `Trainer::new` が `initialize_features` と `initialize_instances` で同じ特徴量ファイルを 2 回パースする(`trainer.rs:46-47`、`adaboost.rs:95-203`)。
+- **API の非一貫性**: `AdaBoost::predict(HashSet<String>)` は所有権を取るが `AveragedPerceptron::predict(&HashSet<String>)` は借用。`add_instance` のラベル型も `i8` vs `String`。
+- **内部状態の露出**: `Segmenter::learner` / `pos_learner` が pub フィールド。`lib.rs` に re-export がなく、利用者は `litsea::segmenter::Segmenter` のようにモジュールパスを辿る必要がある。
+- **`segment_with_pos` の先頭単語処理が不自然**: ループ後に「結果が空の場合だけ」先頭位置を再予測する後付けロジック(`segmenter.rs:420-428`)。先頭単語の品詞はループ内の最初の予測から自然に決まる構造にすべき。
+- **`util` モジュールの形骸化**: 中身は `ModelScheme` のみ。モデル I/O 共通化の際に吸収すべき。
+- **doc コメントの日英混在**: `adaboost.rs`・`language.rs` は英語、`perceptron.rs`・`upos.rs` は日本語、`segmenter.rs`・`trainer.rs` は混在。crates.io に公開されるライブラリとして不統一。
+
+### 1.4 パフォーマンス上の無駄
+
+- **文字種分類が正規表現の線形走査**: 1 文字ごとに最大 9 個の `Regex::is_match` を順に試す(`language.rs`)。しかも呼び出し側で `char` → `String` 変換してから渡している(`segmenter.rs:108, 341` の `ch.to_string()`)。`char` の数値範囲 `match` にすれば正規表現自体が不要。
+- **特徴量生成のアロケーション過多**: `get_attributes` が 1 文字位置あたり約 40 個の `String` を `format!` で生成し `HashSet` に格納(`segmenter.rs:453-532`)。セグメント処理のホットパス。
+- **内部表現がすべて `String`**: `chars: Vec<String>`(1 文字ずつ!)、`tags: Vec<String>`("B"/"O"/"U" の 3 値)、`types: Vec<String>`(数種の固定コード)。enum / `char` / `&'static str` で十分。
+- **AveragedPerceptron の学習ループ**: epoch ごとに `self.instances` を丸ごと clone し(`perceptron.rs:208`)、インスタンスごとに `Vec<String>` → `HashSet<String>` を再構築(`perceptron.rs:220`)。重み構造も `HashMap<String, HashMap<String, f64>>` の二重ハッシュ。
+
+### 1.5 その他(体裁・周辺)
+
+- `rustfmt.toml` の大半がコメントアウト行で占められている。
+- doc コメントの様式が不統一(`# Returns: ...` インライン型と `# Returns` セクション型の混在)。
+- CLI の `--language` が生 `String` 受け → 手動 `parse`(clap の `ValueEnum` 未使用)。
+- ベンチ・doc テストが tokio に不必要に依存(async 整理で解消)。
+
+---
+
+## 2. リファクタリング方針(全フェーズ共通の原則)
+
+1. **モデルファイルの後方互換を維持する**。`models/` 配下の 8 モデル(AdaBoost テキスト形式・Perceptron TSV 形式)は再学習なしでロードできること。フォーマット変更は本計画のスコープ外。
+2. **フェーズ 0 で固定したゴールデンテストを全フェーズの合格基準にする**。挙動変更が必要な場合(例: `segment_with_pos` の先頭単語処理)は、変更内容を PR で明記してゴールデンを更新する。
+3. **「挙動不変フェーズ」(0〜2, 4)と「API 変更フェーズ」(3)を分離**し、破壊的変更は v0.5.0 として一括リリースする。
+4. 各フェーズの完了条件: `cargo fmt --check` / `cargo clippy --workspace --all-targets -- -D warnings` / `cargo test --workspace` / `cargo check -p litsea --no-default-features`(Phase 1 以降)/ ゴールデンテスト / criterion ベースライン比較(性能フェーズ)。
+5. 1 フェーズ = 1 PR を基本とし、Phase 3・4 は内容ごとに複数 PR に分割してよい。
+
+---
+
+## 3. フェーズ計画
+
+### フェーズ 0: 安全網の整備(挙動不変・追加のみ)
+
+**目的**: 以降のすべてのリファクタリングの回帰を機械的に検出できる状態を作る。
+
+**作業項目**:
+1. **ゴールデンテストの追加**(`litsea/tests/golden.rs`):
+   - `models/` の各モデル(ja/zh/ko × segment / segment_with_pos)について、代表文 5〜10 文の分割結果をスナップショットとして固定。
+   - `JEITA_Genpaku_ChaSen_IPAdic.model`・`RWCP.model` も最低 1 ケース。
+2. **モデルファイル round-trip テスト**: `load_model → save_model → load_model` で予測結果が一致することを検証(フォーマット互換の監視)。
+3. **criterion ベースラインの記録**: `cargo bench -- --save-baseline pre-refactor` を実行し、結果を PR に記録(数値はリポジトリにはコミットしない)。
+4. **CI 強化**(regression.yml):
+   - `cargo check -p litsea --no-default-features` ジョブを追加。**現状は B1 により失敗するため、Phase 1 と同一 PR で導入するか、Phase 1 マージまで `continue-on-error` とする。**
+   - wasm32 ターゲットの `cargo check`(`--target wasm32-unknown-unknown --no-default-features`)も追加候補(現状 cfg 分岐があるのに検証されていない)。
+
+**完了条件**: 新規テストが green、CI にフィーチャーチェックが入る。
+**リスク**: ほぼなし(追加のみ)。
+**規模目安**: 小(テスト +200〜300 行、CI 数十行)。
+
+---
+
+### フェーズ 1: バグ修正とモデル I/O の共通化(挙動不変)
+
+**目的**: 確認済みバグの解消と、最大の重複(D1)の排除。
+
+**作業項目**:
+1. **B1 修正**: `perceptron.rs` の `reqwest` 利用を `adaboost.rs:358-372` と同じ構造で `#[cfg(feature = "remote_model")]` ゲートに統一。
+2. **モデル I/O 共通モジュール `litsea/src/model_io.rs` の新設**:
+   - `util::ModelScheme` を移動し、`util.rs` を廃止。
+   - URI 解決 → 読み取りソース取得を一本化する関数を提供:
+     ```rust
+     // 概形。詳細はフェーズ内で確定する。
+     pub(crate) async fn read_model(uri: &str) -> io::Result<Vec<u8>>;
+     // 内部に: ファイルパス解決 / file:// / http(s):// (remote_model 時のみ) / wasm32 cfg 分岐
+     ```
+   - `AdaBoost` / `AveragedPerceptron` は各自の `parse_model_content` のみ保持し、
+     `load_model` は `read_model` + `parse_model_content` の 2 行に縮退させる。
+   - HTTP クライアント生成(User-Agent 付与)も同モジュールへ移動。
+   - これにより `adaboost.rs:334-524` / `perceptron.rs:271-438` の重複約 340 行を 1 実装に集約。
+3. **B2 修正**: `save_model` の doc コメントを実フォーマット(ヘッダ + TSV)の記述に修正。
+4. **エラー生成ヘルパ**: `invalid_data(format!(...))` 的な内部ヘルパを `model_io.rs` に置き、散在する `io::Error::new(InvalidData, ...)` ボイラープレートを削減(完全なエラー型再設計は Phase 3 に送る)。
+5. Phase 0 で `continue-on-error` にした feature チェック CI を必須化。
+
+**完了条件**: 全テスト・ゴールデン green、`--no-default-features` / `remote_model` 双方でビルド成功、重複 I/O コードの消滅。
+**リスク**: 低。I/O 経路の挙動はゴールデン + round-trip テストで担保。
+**規模目安**: 中(差分 ±400 行程度、純減)。
+
+---
+
+### フェーズ 2: Segmenter / Extractor / Trainer の構造統一(挙動不変)
+
+**目的**: D2・D3・D5 の重複排除と、コールバック設計の歪み(RefCell ハック)の解消。
+
+**作業項目**:
+1. **文コンテキスト構築の一本化**(`segmenter.rs`):
+   - パディング付き chars/types 配列の構築を担う内部型を導入:
+     ```rust
+     struct SentenceContext { chars: Vec<String>, types: Vec<String> }
+     impl SentenceContext {
+         fn from_sentence(seg: &Segmenter, s: &str) -> Self;       // segment 系
+         fn from_tokens(seg: &Segmenter, tokens: ...) -> Self;     // corpus 系
+         fn positions(&self) -> Range<usize>;                      // 4..len-3
+     }
+     ```
+   - 現在 4 箇所にある `B3/B2/B1` / `E1/E2/E3` パディング構築をこの型に集約。
+     (`String` → `char`/enum 化は Phase 4 で行い、ここでは構造だけ直す)
+2. **コーパス処理の統合**: `process_corpus` と `process_corpus_with_pos` を、ラベル生成だけが異なる単一実装に統合。`i8` ラベルは `SegmentLabel` から導出(`B(_) → 1`, `O → -1`)する変換を挟み、ラベル付けロジックを 1 箇所にする。
+3. **推論の統合**: `segment` と `segment_with_pos` の走査ループを共通化(境界判定を返すクロージャ/内部 trait で差し替え)。あわせて `segment_with_pos` の先頭単語品詞の後付けロジック(`segmenter.rs:420-428`)を「最初の予測位置で先頭単語の品詞を決める」素直な構造に整理する。**ゴールデンテストで出力差を確認し、差が出る場合は PR に明記**。
+4. **Extractor の統合と RefCell 排除**(`extractor.rs`):
+   - コールバックを `FnMut(...) -> io::Result<()>` に変更し(または特徴量行のイテレータを返す設計にし)、`RefCell<Option<io::Error>>` による帯域外エラー伝播を廃止。
+   - `extract` / `extract_with_pos` は「ラベルの文字列化」だけが異なる単一実装に統合。
+5. **Trainer / PosTrainer の整理**(`trainer.rs`):
+   - `AdaBoost::initialize_features` + `initialize_instances` の 2 回ファイル読みを、1 パスで両方を構築する `AdaBoost::load_training_data(path)`(仮)に置き換え。
+   - 2 つの Trainer は共通の流れ(`load → train → save → metrics`)を持つため、薄い共通ヘルパに寄せるか、いっそ CLI 側へ吸収するかを判断(公開 API 変更を伴う場合は Phase 3 で実施)。
+
+**完了条件**: 全テスト・ゴールデン green。`segmenter.rs` のパディング構築が 1 箇所、`extractor.rs` から `RefCell` が消える。
+**リスク**: 中。境界条件(`tags[3] = "U"` の扱い、`labels` のインデックスずれ等)が複雑なため、Phase 0 のゴールデンに先頭 1 文字・1 単語文・空白連続などのエッジケースを必ず含めておく。
+**規模目安**: 中〜大(`segmenter.rs` を中心に ±600 行程度、純減)。
+
+---
+
+### フェーズ 3: エラー型と公開 API の再設計(破壊的変更 → v0.5.0)
+
+**目的**: 利用者向け API の一貫性確保。破壊的変更をこのフェーズに集約する。
+
+**作業項目**:
+1. **エラー型の導入**(`thiserror` 採用、`litsea/src/error.rs`):
+   ```rust
+   #[derive(Debug, thiserror::Error)]
+   pub enum LitseaError {
+       #[error("I/O error: {0}")]            Io(#[from] std::io::Error),
+       #[error("invalid model (line {line}): {reason}")] InvalidModel { line: usize, reason: String },
+       #[error("unsupported URI scheme: {0}")] UnsupportedScheme(String),
+       #[error("unsupported in this build/environment: {0}")] Unsupported(&'static str),
+       // ...
+   }
+   pub type Result<T> = std::result::Result<T, LitseaError>;
+   ```
+   - `Box<dyn Error>`(trainer / extractor)と `io::Error` 流用をすべて置換。手書き `map_err` 祭り(D7)を `#[from]` と専用バリアントで削減。
+2. **async の限定**:
+   - ローカル読み込みを sync の基本 API にする: `load_model_from_path(&Path)` / `load_model_from_reader(R: BufRead)`(公開)。
+   - URI 対応の `async fn load_model(uri)` は `remote_model` feature 時のみ提供(または常時提供だがリモートのみ非同期)。
+   - 効果: CLI 以外から tokio 依存が消え、doc テストの `tokio_test::block_on`、ベンチの手製ランタイム(`bench.rs:14-30`)が不要になる。
+3. **公開面の整理**:
+   - `lib.rs` で主要型を re-export: `pub use {Segmenter, Language, AdaBoost, AveragedPerceptron, Upos, SegmentLabel, LitseaError};`
+   - `Segmenter::learner` / `pos_learner` の pub フィールドを廃止し、コンストラクタ/アクセサ経由に。
+   - `parse_model_content` 等の内部メソッドの可視性を `pub(crate)` に統一・点検。
+4. **API 一貫性**:
+   - `predict` を両学習器とも借用(`&` 受け)に統一。
+   - メソッド命名を Rust 慣習に統一(`get_bias` → `bias`、`get_type` → `char_type` 等。`get_metrics` → `metrics`)。
+   - `adaboost::Metrics` → `BinaryMetrics`、`perceptron::Metrics` → `MulticlassMetrics` に改名し `litsea/src/metrics.rs` に同居(D4 解消)。
+5. **CLI の整備**(`litsea-cli`):
+   - `Language` に `clap::ValueEnum` を実装(または CLI 側ラッパー)し、生 `String` + 手動 parse を廃止。
+   - `--pos` フラグの分岐を、共通化された Trainer/Segmenter API の上に薄く載せ直す。
+6. **CHANGELOG / 移行ガイド**を作成し、v0.5.0 としてのリリース準備(公開は本計画外)。
+
+**完了条件**: 全テスト green、`litsea-cli` と docs のコード例が新 API でコンパイル可、semver 上の変更点が CHANGELOG に列挙されている。
+**リスク**: 中。破壊的変更だが利用箇所(CLI・ベンチ・doc テスト・docs)はすべてリポジトリ内なので追従可能。外部利用者向けには移行ガイドで対応。
+**規模目安**: 大(全ファイルに波及、ただし機械的な置換が中心)。
+
+---
+
+### フェーズ 4: 内部データ表現とパフォーマンス最適化(挙動不変)
+
+**目的**: ホットパス(文字種分類・特徴量生成・Perceptron 学習)のアロケーション削減。
+**前提**: Phase 0 の criterion ベースラインと比較し、各変更の効果を PR に記録する。
+
+**作業項目**(独立した PR に分割可、効果の大きい順):
+1. **文字種分類の match 化**(`language.rs`):
+   - `CharTypePatterns` の正規表現線形走査を、`char` の数値範囲による `match` 実装(`enum CharType` + `fn classify(ch: char) -> CharType`)に置換。韓国語の받침判定クロージャも自然に統合できる。
+   - 共通パターン(句読点・Latin・数字)の 3 言語コピペ(D6)もここで解消。
+   - 効果次第で `regex` 依存を削除(依存ゼロ化は wasm ビルドにも有利)。
+   - 公開 API(`get_type(&str) -> &str`)は型コード文字列を返す互換層を残すか Phase 3 と合わせて整理。
+2. **Segmenter 内部表現の脱 String**:
+   - `chars: Vec<String>` → `Vec<char>`(`B1/E1` 等のセンチネルは私用領域の `char` 定数または enum)。
+   - `tags` → `enum Tag { U, B, O }`、`types` → `CharType` enum。
+   - `get_attributes` の `format!` × 40 を、事前確保バッファへの書き込み + 必要箇所のみ `String` 化に変更。`HashSet<String>` は重複がほぼ発生しない構造のため `Vec<String>` 化を検討(モデルの特徴名文字列フォーマットは**変更しない**)。
+3. **AveragedPerceptron の学習ループ最適化**:
+   - epoch ごとの `instances.clone()`(`perceptron.rs:208`)を撤廃(借用分割 or インデックス走査)。
+   - インスタンスごとの `HashSet` 再構築をやめ、`Vec<String>`(または ID 列)のまま予測。
+   - 重みを「feature ID × class ID」の密/疎 Vec に変更(文字列キーの二重 HashMap を排除)。保存・読み込み時のみ文字列に変換し、**モデルファイル形式は不変**。
+4. **AdaBoost の軽微な最適化**: `predict` の借用化(Phase 3 で実施済みのはず)、`initialize_*` の 1 パス化(Phase 2 で実施済み)に伴う残課題の整理。
+
+**完了条件**: ゴールデンテスト完全一致(出力不変)、criterion で segment 系ベンチの改善を確認(目安: 文字種分類と特徴量生成で数倍規模の改善が見込める)、リグレッションなし。
+**リスク**: 中。最適化は 1 PR = 1 テーマで小さく刻み、各 PR でベースライン比較を必須にする。
+**規模目安**: 大(ただし分割実施)。
+
+---
+
+### フェーズ 5: ドキュメント・体裁の統一(仕上げ)
+
+**目的**: コードコメント・ドキュメント・周辺ファイルの一貫性確保。
+
+**作業項目**:
+1. **doc コメント言語の統一**: crates.io 公開ライブラリのため**英語に統一**(`perceptron.rs`・`upos.rs`・`trainer.rs` 後半・`segmenter.rs` の日本語コメントを翻訳)。日本語ドキュメントは既存の `docs/ja`(mdbook)に集約する。
+2. **doc コメント様式の統一**: `# Returns:` インライン型と `# Returns` セクション型の混在を後者に統一。冗長な逐語説明(処理手順の箇条書きをそのまま書いたもの)を要点のみに圧縮。
+3. **docs(mdbook)/ README の更新**: Phase 3 の新 API にコード例を追従。EN/JA の同期。
+4. **周辺ファイルの掃除**: `rustfmt.toml` のコメントアウト行削除、`Makefile` ターゲットの点検(`lint` に `--no-default-features` チェック追加等)。
+5. `cargo doc --no-deps` の警告ゼロ化、`#![warn(missing_docs)]` の導入検討。
+
+**完了条件**: ドキュメント言語・様式が統一され、docs のコード例がすべてコンパイル可能(doc テスト化)。
+**リスク**: 低。
+**規模目安**: 中(コード挙動への影響なし)。
+
+---
+
+## 4. 実施順序と依存関係
+
+```
+Phase 0 (安全網)
+  └─> Phase 1 (バグ修正 + モデルI/O共通化)   … 0 とまとめて着手可
+        └─> Phase 2 (Segmenter/Extractor/Trainer 統一)
+              └─> Phase 3 (エラー型・公開API再設計 = v0.5.0)
+                    └─> Phase 4 (性能最適化)  … 3 と並行可能な項目もあるが、API 確定後が手戻りなし
+                          └─> Phase 5 (ドキュメント統一・仕上げ)
+```
+
+- **Phase 0+1 は最初の 1 PR にまとめてよい**(CI の feature チェックが B1 修正に依存するため)。
+- Phase 4 の各最適化は独立 PR に分割し、それぞれゴールデン一致とベンチ比較を添付する。
+- リリース戦略: Phase 1〜2 完了時点で 0.4.x パッチ/マイナーを出すことも可能。Phase 3 マージ後に v0.5.0。
+
+## 5. リスク管理
+
+| リスク | 緩和策 |
+|--------|--------|
+| 分割結果の意図しない変化 | Phase 0 のゴールデンテスト(エッジケース込み)を全フェーズの必須ゲートにする |
+| モデルファイル互換の破壊 | round-trip テスト + 既存 8 モデルのロードテストを CI に常設 |
+| 性能リグレッション | criterion ベースライン比較を Phase 4 の各 PR で必須化 |
+| 破壊的変更の散発 | API 変更を Phase 3 に集約し、CHANGELOG と移行ガイドで一括提示 |
+| wasm32 / no-default-features の退行 | Phase 0〜1 で CI にターゲット・フィーチャーマトリクスを追加 |

--- a/REFACTORING_PLAN.md
+++ b/REFACTORING_PLAN.md
@@ -15,7 +15,7 @@
 
 | # | 内容 | 根拠 |
 |---|------|------|
-| B1 | **`--no-default-features` でビルド不能**。`perceptron.rs` が `reqwest` を feature gate なしで使用しており(`perceptron.rs:9` の `use reqwest::Client;` と `load_model_from_url`)、`remote_model` を無効にするとコンパイルエラーになる。`adaboost.rs` は正しく `#[cfg(feature = "remote_model")]` で保護されているのに対し、後から追加された perceptron 側が追従していない。 | `cargo check -p litsea --no-default-features` が E0432/E0282 で失敗することを確認済み |
+| B1 | ✅ **修正済み(Phase 0 PR に前倒しで含めた)** — **`--no-default-features` でビルド不能**。`perceptron.rs` が `reqwest` を feature gate なしで使用しており(`perceptron.rs:9` の `use reqwest::Client;` と `load_model_from_url`)、`remote_model` を無効にするとコンパイルエラーになる。`adaboost.rs` は正しく `#[cfg(feature = "remote_model")]` で保護されているのに対し、後から追加された perceptron 側が追従していない。 | `cargo check -p litsea --no-default-features` が E0432/E0282 で失敗することを確認済み |
 | B2 | `AveragedPerceptron::save_model` の doc コメントが「モデルを**JSON形式**でファイルに保存する」と記述しているが、実際はクラスヘッダ + TSV のテキスト形式(`perceptron.rs:231-242`)。 | コード読解 |
 | B3 | CI(regression.yml / periodic.yml)に feature マトリクスがなく、B1 のようなビルド破壊が検出されない。 | ワークフロー確認 |
 
@@ -77,7 +77,7 @@
 **実施結果**(2026-06-12):
 - `litsea/tests/golden.rs` を追加(全 8 モデルのスナップショット 10 テスト、すべて green)。
 - round-trip テスト(AdaBoost / Perceptron)を同ファイルに追加。
-- regression.yml に `feature-check` ジョブを追加(`--no-default-features` と wasm32。B1 未修正のため `continue-on-error: true`。Phase 1 で必須化する)。
+- regression.yml に `feature-check` ジョブを追加(`--no-default-features` と wasm32)。B1 修正も本 PR に前倒しで含めたため、当初予定と異なり最初から必須ジョブとした。
 - criterion ベースライン(`--save-baseline pre-refactor`、短縮計測の参考値、median):
   `segment_short/adaboost` ja 56.8µs / zh 37.1µs / ko 51.3µs、
   `segment_short/averaged_perceptron` ja 293µs / zh 211µs / ko 286µs、
@@ -107,7 +107,7 @@
 **目的**: 確認済みバグの解消と、最大の重複(D1)の排除。
 
 **作業項目**:
-1. **B1 修正**: `perceptron.rs` の `reqwest` 利用を `adaboost.rs:358-372` と同じ構造で `#[cfg(feature = "remote_model")]` ゲートに統一。
+1. ✅ **B1 修正**(Phase 0 PR で実施済み): `perceptron.rs` の `reqwest` 利用を `adaboost.rs:358-372` と同じ構造で `#[cfg(feature = "remote_model")]` ゲートに統一。
 2. **モデル I/O 共通モジュール `litsea/src/model_io.rs` の新設**:
    - `util::ModelScheme` を移動し、`util.rs` を廃止。
    - URI 解決 → 読み取りソース取得を一本化する関数を提供:

--- a/litsea/src/perceptron.rs
+++ b/litsea/src/perceptron.rs
@@ -6,8 +6,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use reqwest::Client;
-
 use crate::util::ModelScheme;
 
 /// 多クラスAveraged Perceptron分類器。
@@ -283,9 +281,19 @@ impl AveragedPerceptron {
             })?;
             match scheme {
                 ModelScheme::Http | ModelScheme::Https => {
-                    self.load_model_from_url(uri).await.map_err(|e| {
-                        std::io::Error::other(format!("Failed to load model from URL: {}", e))
-                    })
+                    #[cfg(not(feature = "remote_model"))]
+                    {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::Unsupported,
+                            "http:// and https:// scheme is not supported in this build. Use file:// URLs.",
+                        ));
+                    }
+                    #[cfg(feature = "remote_model")]
+                    {
+                        self.load_model_from_url(uri).await.map_err(|e| {
+                            std::io::Error::other(format!("Failed to load model from URL: {}", e))
+                        })
+                    }
                 }
                 ModelScheme::File => {
                     #[cfg(target_arch = "wasm32")]
@@ -319,7 +327,10 @@ impl AveragedPerceptron {
     }
 
     /// URLからモデルを読み込む。
+    #[cfg(feature = "remote_model")]
     async fn load_model_from_url(&mut self, url: &str) -> std::io::Result<()> {
+        use reqwest::Client;
+
         let client = Client::builder()
             .user_agent(format!("Litsea/{}", env!("CARGO_PKG_VERSION")))
             .build()

--- a/litsea/tests/golden.rs
+++ b/litsea/tests/golden.rs
@@ -1,0 +1,377 @@
+//! Golden tests: snapshot the segmentation output of every pre-trained model
+//! in `models/` so that refactoring can be verified to preserve behavior.
+//!
+//! These snapshots capture the CURRENT behavior of v0.4.0. If a behavior
+//! change is intentional (e.g. fixing the first-word POS handling in
+//! `segment_with_pos`), update the affected expectations in the same PR and
+//! call the change out explicitly in the PR description.
+
+use std::path::PathBuf;
+
+use litsea::adaboost::AdaBoost;
+use litsea::language::Language;
+use litsea::perceptron::AveragedPerceptron;
+use litsea::segmenter::Segmenter;
+use litsea::upos::Upos;
+
+fn model_path(name: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../models")
+        .join(name)
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
+async fn adaboost_segmenter(language: Language, model: &str) -> Segmenter {
+    let mut learner = AdaBoost::new(0.01, 100);
+    learner
+        .load_model(&model_path(model))
+        .await
+        .unwrap_or_else(|e| panic!("failed to load {}: {}", model, e));
+    Segmenter::new(language, Some(learner))
+}
+
+async fn pos_segmenter(language: Language, model: &str) -> Segmenter {
+    let mut learner = AveragedPerceptron::new();
+    learner
+        .load_model(&model_path(model))
+        .await
+        .unwrap_or_else(|e| panic!("failed to load {}: {}", model, e));
+    Segmenter::with_pos_learner(language, learner)
+}
+
+fn assert_segment(segmenter: &Segmenter, cases: &[(&str, &[&str])]) {
+    for (input, expected) in cases {
+        let actual = segmenter.segment(input);
+        assert_eq!(&actual, expected, "segment({:?}) diverged from golden output", input);
+    }
+}
+
+fn assert_segment_with_pos(segmenter: &Segmenter, cases: &[(&str, &[(&str, &str)])]) {
+    for (input, expected) in cases {
+        let actual: Vec<(String, Upos)> = segmenter.segment_with_pos(input);
+        let actual_str: Vec<(String, String)> =
+            actual.into_iter().map(|(w, p)| (w, p.to_string())).collect();
+        let expected_owned: Vec<(String, String)> =
+            expected.iter().map(|(w, p)| (w.to_string(), p.to_string())).collect();
+        assert_eq!(
+            actual_str, expected_owned,
+            "segment_with_pos({:?}) diverged from golden output",
+            input
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Word segmentation (AdaBoost models)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn golden_segment_japanese() {
+    let segmenter = adaboost_segmenter(Language::Japanese, "japanese.model").await;
+    assert_segment(
+        &segmenter,
+        &[
+            ("これはテストです。", &["これ", "は", "テスト", "で", "す", "。"]),
+            ("私の猫は可愛い。", &["私", "の", "猫", "は", "可愛", "い", "。"]),
+            (
+                "東京都に住んでいます。",
+                &["東京", "都", "に", "住ん", "で", "いま", "す", "。"],
+            ),
+            // Edge case: single character (whole sentence is one word)
+            ("字", &["字"]),
+            ("こんにちは", &["こん", "にち", "は"]),
+            // Digits and mixed scripts
+            ("価格は1000円です。", &["価格", "は", "1000", "円", "で", "す", "。"]),
+            ("RustでNLPを実装する。", &["Rust", "で", "NLP", "を", "実装", "する", "。"]),
+        ],
+    );
+    assert!(segmenter.segment("").is_empty());
+}
+
+#[tokio::test]
+async fn golden_segment_japanese_rwcp() {
+    let segmenter = adaboost_segmenter(Language::Japanese, "RWCP.model").await;
+    assert_segment(
+        &segmenter,
+        &[
+            ("これはテストです。", &["これ", "は", "テスト", "です", "。"]),
+            ("私の猫は可愛い。", &["私", "の", "猫", "は", "可愛い", "。"]),
+            ("東京都に住んでいます。", &["東京都", "に", "住ん", "でい", "ます", "。"]),
+            ("字", &["字"]),
+            // Edge case: whole sentence is a single word
+            ("こんにちは", &["こんにちは"]),
+            ("価格は1000円です。", &["価格", "は", "1", "0", "0", "0", "円", "です", "。"]),
+            ("RustでNLPを実装する。", &["Rust", "で", "NLP", "を", "実装", "する", "。"]),
+        ],
+    );
+}
+
+#[tokio::test]
+async fn golden_segment_japanese_jeita() {
+    let segmenter =
+        adaboost_segmenter(Language::Japanese, "JEITA_Genpaku_ChaSen_IPAdic.model").await;
+    assert_segment(
+        &segmenter,
+        &[
+            ("これはテストです。", &["これ", "は", "テスト", "です", "。"]),
+            ("私の猫は可愛い。", &["私", "の", "猫", "は", "可愛", "い", "。"]),
+            (
+                "東京都に住んでいます。",
+                &["東京", "都", "に", "住ん", "で", "い", "ます", "。"],
+            ),
+            ("字", &["字"]),
+            ("こんにちは", &["こん", "にち", "は"]),
+            ("価格は1000円です。", &["価格", "は", "1000", "円", "です", "。"]),
+            ("RustでNLPを実装する。", &["Rust", "で", "NLP", "を", "実装", "する", "。"]),
+        ],
+    );
+}
+
+#[tokio::test]
+async fn golden_segment_chinese() {
+    let segmenter = adaboost_segmenter(Language::Chinese, "chinese.model").await;
+    assert_segment(
+        &segmenter,
+        &[
+            ("这是一个测试。", &["这", "是", "一个", "测试", "。"]),
+            ("我喜欢吃中国菜。", &["我喜", "欢吃", "中国", "菜", "。"]),
+            ("他在北京工作。", &["他", "在", "北京", "工作", "。"]),
+            ("好", &["好"]),
+            ("2024年的春天。", &["2024", "年", "的", "春天", "。"]),
+        ],
+    );
+    assert!(segmenter.segment("").is_empty());
+}
+
+#[tokio::test]
+async fn golden_segment_korean() {
+    let segmenter = adaboost_segmenter(Language::Korean, "korean.model").await;
+    assert_segment(
+        &segmenter,
+        &[
+            ("이것은 테스트입니다.", &["이것은", " ", "테스트", "입니다", "."]),
+            ("나는 고양이를 좋아한다.", &["나는", " ", "고양이를", " ", "좋아한다", "."]),
+            ("한국어 형태소 분석기.", &["한국어", " ", "형태소", " ", "분석기", "."]),
+            ("글", &["글"]),
+            ("2024년 봄.", &["2024년", " ", "봄."]),
+        ],
+    );
+    assert!(segmenter.segment("").is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Joint segmentation + POS tagging (Averaged Perceptron models)
+//
+// Note: the first word of every sentence is currently tagged "X" because
+// segment_with_pos() determines the first word's POS from a prediction made
+// before any boundary context exists (see segmenter.rs). This is a known
+// quirk snapshotted as-is; Phase 2 of the refactoring plan may change it
+// intentionally.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn golden_segment_with_pos_japanese() {
+    let segmenter = pos_segmenter(Language::Japanese, "japanese_pos.model").await;
+    assert_segment_with_pos(
+        &segmenter,
+        &[
+            (
+                "これはテストです。",
+                &[
+                    ("これ", "X"),
+                    ("は", "ADP"),
+                    ("テスト", "NOUN"),
+                    ("です", "AUX"),
+                    ("。", "PUNCT"),
+                ],
+            ),
+            (
+                "私の猫は可愛い。",
+                &[
+                    ("私", "X"),
+                    ("の", "ADP"),
+                    ("猫", "NOUN"),
+                    ("は", "ADP"),
+                    ("可愛い", "ADJ"),
+                    ("。", "PUNCT"),
+                ],
+            ),
+            (
+                "東京都に住んでいます。",
+                &[
+                    ("東京", "X"),
+                    ("都", "NOUN"),
+                    ("に", "ADP"),
+                    ("住ん", "VERB"),
+                    ("で", "SCONJ"),
+                    ("い", "VERB"),
+                    ("ます", "AUX"),
+                    ("。", "PUNCT"),
+                ],
+            ),
+            ("字", &[("字", "SYM")]),
+            ("こんにちは", &[("こん", "X"), ("にち", "ADP"), ("は", "ADP")]),
+            (
+                "価格は1000円です。",
+                &[
+                    ("価格", "X"),
+                    ("は", "ADP"),
+                    ("1000", "NUM"),
+                    ("円", "NOUN"),
+                    ("です", "AUX"),
+                    ("。", "PUNCT"),
+                ],
+            ),
+            (
+                "RustでNLPを実装する。",
+                &[
+                    ("Rust", "X"),
+                    ("で", "ADP"),
+                    ("NLP", "PROPN"),
+                    ("を", "ADP"),
+                    ("実装", "VERB"),
+                    ("する", "AUX"),
+                    ("。", "PUNCT"),
+                ],
+            ),
+        ],
+    );
+    assert!(segmenter.segment_with_pos("").is_empty());
+}
+
+#[tokio::test]
+async fn golden_segment_with_pos_chinese() {
+    let segmenter = pos_segmenter(Language::Chinese, "chinese_pos.model").await;
+    assert_segment_with_pos(
+        &segmenter,
+        &[
+            (
+                "这是一个测试。",
+                &[
+                    ("这", "X"),
+                    ("是", "AUX"),
+                    ("一", "NUM"),
+                    ("个", "NOUN"),
+                    ("测试", "NOUN"),
+                    ("。", "PUNCT"),
+                ],
+            ),
+            (
+                "我喜欢吃中国菜。",
+                &[
+                    ("我", "X"),
+                    ("喜欢", "VERB"),
+                    ("吃中", "VERB"),
+                    ("国菜", "VERB"),
+                    ("。", "PUNCT"),
+                ],
+            ),
+            (
+                "他在北京工作。",
+                &[("他", "X"), ("在", "ADP"), ("北京", "PROPN"), ("工作", "NOUN"), ("。", "PUNCT")],
+            ),
+            ("好", &[("好", "PUNCT")]),
+            (
+                "2024年的春天。",
+                &[("2024", "X"), ("年", "NOUN"), ("的", "PART"), ("春天", "NOUN"), ("。", "PUNCT")],
+            ),
+        ],
+    );
+    assert!(segmenter.segment_with_pos("").is_empty());
+}
+
+#[tokio::test]
+async fn golden_segment_with_pos_korean() {
+    let segmenter = pos_segmenter(Language::Korean, "korean_pos.model").await;
+    assert_segment_with_pos(
+        &segmenter,
+        &[
+            (
+                "이것은 테스트입니다.",
+                &[("이것은", "X"), (" ", "PUNCT"), ("테스트입니다", "NOUN"), (".", "PUNCT")],
+            ),
+            (
+                "나는 고양이를 좋아한다.",
+                &[
+                    ("나는", "X"),
+                    (" ", "PUNCT"),
+                    ("고양이를", "NOUN"),
+                    (" ", "PUNCT"),
+                    ("좋아한다", "VERB"),
+                    (".", "PUNCT"),
+                ],
+            ),
+            (
+                "한국어 형태소 분석기.",
+                &[
+                    ("한국어", "X"),
+                    (" ", "PUNCT"),
+                    ("형태소", "NOUN"),
+                    (" ", "PUNCT"),
+                    ("분석기", "NOUN"),
+                    (".", "PUNCT"),
+                ],
+            ),
+            ("글", &[("글", "PUNCT")]),
+            ("2024년 봄.", &[("2024년", "X"), (" ", "PUNCT"), ("봄", "NOUN"), (".", "PUNCT")]),
+        ],
+    );
+    assert!(segmenter.segment_with_pos("").is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Model file round-trip: load -> save -> load must preserve predictions.
+// Guards the on-disk model format compatibility across refactoring.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn roundtrip_adaboost_model() {
+    let sentences = ["これはテストです。", "私の猫は可愛い。", "価格は1000円です。", "こんにちは"];
+
+    let mut original = AdaBoost::new(0.01, 100);
+    original.load_model(&model_path("japanese.model")).await.unwrap();
+
+    let temp = tempfile::NamedTempFile::new().unwrap();
+    original.save_model(temp.path()).unwrap();
+
+    let mut reloaded = AdaBoost::new(0.01, 100);
+    reloaded.load_model(temp.path().to_str().unwrap()).await.unwrap();
+
+    let seg_original = Segmenter::new(Language::Japanese, Some(original));
+    let seg_reloaded = Segmenter::new(Language::Japanese, Some(reloaded));
+    for s in sentences {
+        assert_eq!(
+            seg_original.segment(s),
+            seg_reloaded.segment(s),
+            "round-tripped AdaBoost model diverged on {:?}",
+            s
+        );
+    }
+}
+
+#[tokio::test]
+async fn roundtrip_perceptron_model() {
+    let sentences = ["これはテストです。", "私の猫は可愛い。", "価格は1000円です。"];
+
+    let mut original = AveragedPerceptron::new();
+    original.load_model(&model_path("japanese_pos.model")).await.unwrap();
+
+    let temp = tempfile::NamedTempFile::new().unwrap();
+    original.save_model(temp.path()).unwrap();
+
+    let mut reloaded = AveragedPerceptron::new();
+    reloaded.load_model(temp.path().to_str().unwrap()).await.unwrap();
+
+    let seg_original = Segmenter::with_pos_learner(Language::Japanese, original);
+    let seg_reloaded = Segmenter::with_pos_learner(Language::Japanese, reloaded);
+    for s in sentences {
+        assert_eq!(
+            seg_original.segment_with_pos(s),
+            seg_reloaded.segment_with_pos(s),
+            "round-tripped Perceptron model diverged on {:?}",
+            s
+        );
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a 6-phase refactoring plan (`REFACTORING_PLAN.md`) based on a full survey of the codebase, the implementation of **Phase 0 (safety net)**, and a fix for the confirmed feature-gate build bug (originally scheduled for Phase 1, pulled forward so the new CI job can be required from the start).

## Contents

### REFACTORING_PLAN.md
- Current-state analysis: confirmed bugs, 7 areas of code duplication, design/API debt, and performance waste (with file/line references)
- Phased plan: Phase 0 (safety net) → 1 (bug fixes + shared model I/O) → 2 (unify Segmenter/Extractor/Trainer) → 3 (error type & public API redesign = v0.5.0) → 4 (performance optimization) → 5 (documentation cleanup)

### Phase 0 implementation
- **`litsea/tests/golden.rs`**: snapshots the segment / segment_with_pos output of all 8 pre-trained models in `models/` (10 tests), including edge cases such as single-character sentences, single-word sentences, and mixed digits/Latin text. Also adds load → save → load round-trip tests to guard on-disk model format compatibility.
- **`regression.yml`**: adds a required `feature-check` job (`cargo check --no-default-features` + wasm32 check).
- Records the criterion baseline (indicative numbers) in the plan document.

### Bug fix: `--no-default-features` build failure
`perceptron.rs` used `reqwest` unconditionally, so `cargo check -p litsea --no-default-features` failed to compile (`adaboost.rs` was gated correctly). The reqwest usage is now gated behind the `remote_model` feature with the same cfg structure as `adaboost.rs`; non-remote builds return an `Unsupported` error for `http(s)://` URIs. This is the only behavior-affecting change in the PR, and it only affects build configurations that previously did not compile.

## Known quirk discovered (snapshotted as-is)

`segment_with_pos` always tags **the first word of every sentence as "X"** (confirmed for all languages). This is caused by the after-the-fact logic that determines the first word's POS, and is a fix candidate for Phase 2. This PR snapshots the current behavior unchanged.

## Verification

- `cargo check -p litsea --no-default-features` and wasm32 check now pass locally
- `cargo fmt --all -- --check` / `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace`: 69 lib tests + 10 golden tests + 6 CLI tests, all green

https://claude.ai/code/session_01V7mvuY55PG8Q7zKhMC62hJ