### PR TITLE
refactor: consolidate model loading I/O into a shared model_io module (Phase 1)

### DIFF
--- a/REFACTORING_PLAN.md
+++ b/REFACTORING_PLAN.md
@@ -16,7 +16,7 @@
 | # | 内容 | 根拠 |
 |---|------|------|
 | B1 | ✅ **修正済み(Phase 0 PR に前倒しで含めた)** — **`--no-default-features` でビルド不能**。`perceptron.rs` が `reqwest` を feature gate なしで使用しており(`perceptron.rs:9` の `use reqwest::Client;` と `load_model_from_url`)、`remote_model` を無効にするとコンパイルエラーになる。`adaboost.rs` は正しく `#[cfg(feature = "remote_model")]` で保護されているのに対し、後から追加された perceptron 側が追従していない。 | `cargo check -p litsea --no-default-features` が E0432/E0282 で失敗することを確認済み |
-| B2 | `AveragedPerceptron::save_model` の doc コメントが「モデルを**JSON形式**でファイルに保存する」と記述しているが、実際はクラスヘッダ + TSV のテキスト形式(`perceptron.rs:231-242`)。 | コード読解 |
+| B2 | ✅ **修正済み(Phase 1)** — `AveragedPerceptron::save_model` の doc コメントが「モデルを**JSON形式**でファイルに保存する」と記述しているが、実際はクラスヘッダ + TSV のテキスト形式(`perceptron.rs:231-242`)。 | コード読解 |
 | B3 | CI(regression.yml / periodic.yml)に feature マトリクスがなく、B1 のようなビルド破壊が検出されない。 | ワークフロー確認 |
 
 ### 1.2 重複コード(本計画の主対象)
@@ -102,13 +102,19 @@
 
 ---
 
-### フェーズ 1: バグ修正とモデル I/O の共通化(挙動不変)
+### フェーズ 1: バグ修正とモデル I/O の共通化(挙動不変) — ✅ 実施済み
 
 **目的**: 確認済みバグの解消と、最大の重複(D1)の排除。
 
+**実施結果**(2026-06-12):
+- 内部モジュール `litsea/src/model_io.rs` を新設し、URI 解決・`file://`・HTTP(S) ダウンロード・wasm32 分岐を `read_model_bytes()` に一本化。`AdaBoost::load_model` / `AveragedPerceptron::load_model` は「バイト列取得 + `parse_model_content`」の 2 行に縮退(両学習器あわせて約 340 行の重複を削除、net -226 行 + 新モジュール約 130 行)。
+- 当初計画からの変更点: `util::ModelScheme` の移動と `util.rs` 廃止は**公開 API の互換維持のため Phase 3 に延期**(`model_io` は `util::ModelScheme` を利用する内部モジュールとした)。エラー生成ヘルパも Phase 3 のエラー型導入に統合する形で見送り。
+- 副次効果: wasm32 + `--no-default-features` ビルドで出ていた到達不能コード警告 3 件が解消。
+- `model_io` に単体テスト 4 件を追加(プレーンパス / `file://` / 不正スキーム / 存在しないファイル)。
+
 **作業項目**:
 1. ✅ **B1 修正**(Phase 0 PR で実施済み): `perceptron.rs` の `reqwest` 利用を `adaboost.rs:358-372` と同じ構造で `#[cfg(feature = "remote_model")]` ゲートに統一。
-2. **モデル I/O 共通モジュール `litsea/src/model_io.rs` の新設**:
+2. ✅ **モデル I/O 共通モジュール `litsea/src/model_io.rs` の新設**:
    - `util::ModelScheme` を移動し、`util.rs` を廃止。
    - URI 解決 → 読み取りソース取得を一本化する関数を提供:
      ```rust
@@ -120,9 +126,9 @@
      `load_model` は `read_model` + `parse_model_content` の 2 行に縮退させる。
    - HTTP クライアント生成(User-Agent 付与)も同モジュールへ移動。
    - これにより `adaboost.rs:334-524` / `perceptron.rs:271-438` の重複約 340 行を 1 実装に集約。
-3. **B2 修正**: `save_model` の doc コメントを実フォーマット(ヘッダ + TSV)の記述に修正。
-4. **エラー生成ヘルパ**: `invalid_data(format!(...))` 的な内部ヘルパを `model_io.rs` に置き、散在する `io::Error::new(InvalidData, ...)` ボイラープレートを削減(完全なエラー型再設計は Phase 3 に送る)。
-5. Phase 0 で `continue-on-error` にした feature チェック CI を必須化。
+3. ✅ **B2 修正**: `save_model` の doc コメントを実フォーマット(ヘッダ + TSV)の記述に修正。
+4. ⏭ **エラー生成ヘルパ**(Phase 3 へ統合): `invalid_data(format!(...))` 的な内部ヘルパを `model_io.rs` に置き、散在する `io::Error::new(InvalidData, ...)` ボイラープレートを削減(完全なエラー型再設計は Phase 3 に送る)。
+5. ✅ Phase 0 で `continue-on-error` にした feature チェック CI を必須化(B1 修正と同時に Phase 0 PR で実施済み)。
 
 **完了条件**: 全テスト・ゴールデン green、`--no-default-features` / `remote_model` 双方でビルド成功、重複 I/O コードの消滅。
 **リスク**: 低。I/O 経路の挙動はゴールデン + round-trip テストで担保。

--- a/litsea/src/adaboost.rs
+++ b/litsea/src/adaboost.rs
@@ -2,11 +2,8 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-
-use crate::util::ModelScheme;
 
 type Label = i8;
 
@@ -332,7 +329,8 @@ impl AdaBoost {
     }
 
     /// Loads a model from a URI.
-    /// The URI can be a file path or a URL (http, https or file).
+    /// The URI can be a file path, a `file://` path, or an `http(s)://` URL
+    /// (the latter requires the `remote_model` feature).
     /// The model should contain lines with a feature and its weight,
     /// with the last line containing the bias term.
     ///
@@ -343,107 +341,8 @@ impl AdaBoost {
     ///
     /// # Errors: Returns an error if the URI is invalid or the file cannot be read.
     pub async fn load_model(&mut self, uri: &str) -> std::io::Result<()> {
-        if uri.contains("://") {
-            let parts: Vec<&str> = uri.splitn(2, "://").collect();
-            if parts.len() != 2 {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    format!("Invalid URI: {}", uri),
-                ));
-            }
-            let scheme = ModelScheme::from_str(parts[0]).map_err(|e| {
-                std::io::Error::new(std::io::ErrorKind::InvalidInput, e.to_string())
-            })?;
-            match scheme {
-                ModelScheme::Http | ModelScheme::Https => {
-                    #[cfg(not(feature = "remote_model"))]
-                    {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::Unsupported,
-                            "http:// and https:// scheme is not supported in this build. Use file:// URLs.",
-                        ));
-                    }
-                    #[cfg(feature = "remote_model")]
-                    {
-                        self.load_model_from_url(uri).await.map_err(|e| {
-                            std::io::Error::other(format!("Failed to load model from URL: {}", e))
-                        })
-                    }
-                }
-                ModelScheme::File => {
-                    #[cfg(target_arch = "wasm32")]
-                    {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::Unsupported,
-                            "file:// scheme is not supported in WASM environment. Use http:// or https:// URLs.",
-                        ));
-                    }
-                    #[cfg(not(target_arch = "wasm32"))]
-                    {
-                        let path = Path::new(parts[1]);
-                        self.load_model_from_file(path)
-                    }
-                }
-            }
-        } else {
-            #[cfg(target_arch = "wasm32")]
-            {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Unsupported,
-                    "Local file paths are not supported in WASM environment. Use http:// or https:// URLs.",
-                ));
-            }
-            #[cfg(not(target_arch = "wasm32"))]
-            {
-                let path = Path::new(uri);
-                self.load_model_from_file(path)
-            }
-        }
-    }
-
-    /// Loads a model from a URL.
-    /// The URL should point to a file containing lines with a feature and its weight,
-    /// with the last line containing the bias term.
-    ///
-    /// # Arguments
-    /// * `url`: The URL of the file containing the model.
-    ///
-    /// # Returns: A result indicating success or failure.
-    ///
-    /// # Errors: Returns an error if the URL cannot be accessed or the file cannot be read.
-    #[cfg(feature = "remote_model")]
-    async fn load_model_from_url(&mut self, url: &str) -> std::io::Result<()> {
-        use reqwest::Client;
-
-        // Create HTTP client with a custom user agent
-        let client = Client::builder()
-            .user_agent(format!("Litsea/{}", env!("CARGO_PKG_VERSION")))
-            .build()
-            .map_err(|e| std::io::Error::other(format!("Failed to create HTTP client: {}", e)))?;
-
-        // Send GET request to the URL
-        let resp = client
-            .get(url)
-            .send()
-            .await
-            .map_err(|e| std::io::Error::other(format!("Failed to download model: {}", e)))?;
-
-        // Check if the response status is successful
-        if !resp.status().is_success() {
-            return Err(std::io::Error::other(format!(
-                "Failed to download model: HTTP {}",
-                resp.status()
-            )));
-        }
-
-        // Read the response body
-        let content = resp
-            .bytes()
-            .await
-            .map_err(|e| std::io::Error::other(format!("Failed to read model content: {}", e)))?;
-
-        let reader = BufReader::new(content.as_ref());
-        self.parse_model_content(reader)
+        let bytes = crate::model_io::read_model_bytes(uri).await?;
+        self.parse_model_content(bytes.as_slice())
     }
 
     /// Parses model content from a buffered reader.
@@ -496,31 +395,6 @@ impl AdaBoost {
         self.feature_index =
             self.features.iter().enumerate().map(|(i, f)| (f.clone(), i)).collect();
         Ok(())
-    }
-
-    /// Loads a model from a file.
-    /// The file should contain lines with a feature and its weight,
-    /// with the last line containing the bias term.
-    ///
-    /// # Arguments
-    /// * `filename`: The path to the file containing the model.
-    ///
-    /// # Returns: A result indicating success or failure.
-    ///
-    /// # Errors: Returns an error if the file cannot be read.
-    #[cfg(not(target_arch = "wasm32"))]
-    fn load_model_from_file(&mut self, filename: &Path) -> std::io::Result<()> {
-        let file = File::open(filename)?;
-        let reader = BufReader::new(file);
-        self.parse_model_content(reader)
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    fn load_model_from_file(&mut self, _filename: &Path) -> std::io::Result<()> {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Unsupported,
-            "File system access is not supported in WASM environment",
-        ))
     }
 
     /// Adds a new instance to the model.

--- a/litsea/src/lib.rs
+++ b/litsea/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod adaboost;
 pub mod extractor;
 pub mod language;
+mod model_io;
 pub mod perceptron;
 pub mod segmenter;
 pub mod trainer;

--- a/litsea/src/model_io.rs
+++ b/litsea/src/model_io.rs
@@ -1,0 +1,128 @@
+//! Shared model loading I/O.
+//!
+//! Resolves a model URI (plain filesystem path, `file://` path, or
+//! `http(s)://` URL when the `remote_model` feature is enabled) and returns
+//! the raw model bytes. Parsing the model content is left to each learner.
+
+use std::io;
+use std::str::FromStr;
+
+use crate::util::ModelScheme;
+
+/// Reads the raw bytes of a model from a URI.
+///
+/// Supported URI forms:
+/// - a plain filesystem path (not supported on wasm32)
+/// - `file://<path>` (not supported on wasm32)
+/// - `http://` / `https://` URLs (requires the `remote_model` feature)
+pub(crate) async fn read_model_bytes(uri: &str) -> io::Result<Vec<u8>> {
+    let Some((scheme_str, rest)) = uri.split_once("://") else {
+        return read_file_bytes(uri);
+    };
+
+    let scheme = ModelScheme::from_str(scheme_str)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+
+    match scheme {
+        ModelScheme::Http | ModelScheme::Https => {
+            #[cfg(not(feature = "remote_model"))]
+            {
+                Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "http:// and https:// scheme is not supported in this build. Use file:// URLs.",
+                ))
+            }
+            #[cfg(feature = "remote_model")]
+            {
+                download(uri).await
+            }
+        }
+        ModelScheme::File => read_file_bytes(rest),
+    }
+}
+
+/// Reads a model from the local filesystem.
+#[cfg(not(target_arch = "wasm32"))]
+fn read_file_bytes(path: &str) -> io::Result<Vec<u8>> {
+    std::fs::read(path)
+}
+
+/// Local filesystem access is unavailable on wasm32.
+#[cfg(target_arch = "wasm32")]
+fn read_file_bytes(_path: &str) -> io::Result<Vec<u8>> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "File system access is not supported in WASM environment. Use http:// or https:// URLs.",
+    ))
+}
+
+/// Downloads a model over HTTP(S).
+#[cfg(feature = "remote_model")]
+async fn download(url: &str) -> io::Result<Vec<u8>> {
+    let client = reqwest::Client::builder()
+        .user_agent(format!("Litsea/{}", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|e| io::Error::other(format!("Failed to create HTTP client: {}", e)))?;
+
+    let resp = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| io::Error::other(format!("Failed to download model: {}", e)))?;
+
+    if !resp.status().is_success() {
+        return Err(io::Error::other(format!("Failed to download model: HTTP {}", resp.status())));
+    }
+
+    let content = resp
+        .bytes()
+        .await
+        .map_err(|e| io::Error::other(format!("Failed to read model content: {}", e)))?;
+
+    Ok(content.to_vec())
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    use std::io::Write;
+
+    use tempfile::NamedTempFile;
+
+    #[tokio::test]
+    async fn test_read_plain_path() -> io::Result<()> {
+        let mut file = NamedTempFile::new()?;
+        write!(file, "feat1\t0.5")?;
+        file.as_file().sync_all()?;
+
+        let bytes = read_model_bytes(file.path().to_str().unwrap()).await?;
+        assert_eq!(bytes, b"feat1\t0.5");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_read_file_scheme() -> io::Result<()> {
+        let mut file = NamedTempFile::new()?;
+        write!(file, "feat1\t0.5")?;
+        file.as_file().sync_all()?;
+
+        let uri = format!("file://{}", file.path().to_str().unwrap());
+        let bytes = read_model_bytes(&uri).await?;
+        assert_eq!(bytes, b"feat1\t0.5");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_read_invalid_scheme() {
+        let result = read_model_bytes("ftp://example.com/model").await;
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[tokio::test]
+    async fn test_read_missing_file() {
+        let result = read_model_bytes("/nonexistent/path/to.model").await;
+        assert!(result.is_err());
+    }
+}

--- a/litsea/src/perceptron.rs
+++ b/litsea/src/perceptron.rs
@@ -1,12 +1,9 @@
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, Write};
 use std::path::Path;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-
-use crate::util::ModelScheme;
 
 /// 多クラスAveraged Perceptron分類器。
 ///
@@ -226,7 +223,7 @@ impl AveragedPerceptron {
         self.average_weights();
     }
 
-    /// モデルをJSON形式でファイルに保存する。
+    /// モデルをテキスト形式(クラスヘッダ + TSV)でファイルに保存する。
     ///
     /// フォーマット:
     /// ```text
@@ -267,95 +264,12 @@ impl AveragedPerceptron {
     }
 
     /// モデルをURIから読み込む。
+    ///
+    /// URIにはファイルパス、`file://`パス、`http(s)://` URL
+    /// (`remote_model`フィーチャー有効時のみ)を指定できる。
     pub async fn load_model(&mut self, uri: &str) -> std::io::Result<()> {
-        if uri.contains("://") {
-            let parts: Vec<&str> = uri.splitn(2, "://").collect();
-            if parts.len() != 2 {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    format!("Invalid URI: {}", uri),
-                ));
-            }
-            let scheme = ModelScheme::from_str(parts[0]).map_err(|e| {
-                std::io::Error::new(std::io::ErrorKind::InvalidInput, e.to_string())
-            })?;
-            match scheme {
-                ModelScheme::Http | ModelScheme::Https => {
-                    #[cfg(not(feature = "remote_model"))]
-                    {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::Unsupported,
-                            "http:// and https:// scheme is not supported in this build. Use file:// URLs.",
-                        ));
-                    }
-                    #[cfg(feature = "remote_model")]
-                    {
-                        self.load_model_from_url(uri).await.map_err(|e| {
-                            std::io::Error::other(format!("Failed to load model from URL: {}", e))
-                        })
-                    }
-                }
-                ModelScheme::File => {
-                    #[cfg(target_arch = "wasm32")]
-                    {
-                        return Err(std::io::Error::new(
-                            std::io::ErrorKind::Unsupported,
-                            "file:// scheme is not supported in WASM environment.",
-                        ));
-                    }
-                    #[cfg(not(target_arch = "wasm32"))]
-                    {
-                        let path = Path::new(parts[1]);
-                        self.load_model_from_file(path)
-                    }
-                }
-            }
-        } else {
-            #[cfg(target_arch = "wasm32")]
-            {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Unsupported,
-                    "Local file paths are not supported in WASM environment.",
-                ));
-            }
-            #[cfg(not(target_arch = "wasm32"))]
-            {
-                let path = Path::new(uri);
-                self.load_model_from_file(path)
-            }
-        }
-    }
-
-    /// URLからモデルを読み込む。
-    #[cfg(feature = "remote_model")]
-    async fn load_model_from_url(&mut self, url: &str) -> std::io::Result<()> {
-        use reqwest::Client;
-
-        let client = Client::builder()
-            .user_agent(format!("Litsea/{}", env!("CARGO_PKG_VERSION")))
-            .build()
-            .map_err(|e| std::io::Error::other(format!("Failed to create HTTP client: {}", e)))?;
-
-        let resp = client
-            .get(url)
-            .send()
-            .await
-            .map_err(|e| std::io::Error::other(format!("Failed to download model: {}", e)))?;
-
-        if !resp.status().is_success() {
-            return Err(std::io::Error::other(format!(
-                "Failed to download model: HTTP {}",
-                resp.status()
-            )));
-        }
-
-        let content = resp
-            .bytes()
-            .await
-            .map_err(|e| std::io::Error::other(format!("Failed to read model content: {}", e)))?;
-
-        let reader = BufReader::new(content.as_ref());
-        self.parse_model_content(reader)
+        let bytes = crate::model_io::read_model_bytes(uri).await?;
+        self.parse_model_content(bytes.as_slice())
     }
 
     /// モデルの内容をパースする。
@@ -432,22 +346,6 @@ impl AveragedPerceptron {
         Ok(())
     }
 
-    /// ファイルからモデルを読み込む。
-    #[cfg(not(target_arch = "wasm32"))]
-    fn load_model_from_file(&mut self, path: &Path) -> std::io::Result<()> {
-        let file = File::open(path)?;
-        let reader = BufReader::new(file);
-        self.parse_model_content(reader)
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    fn load_model_from_file(&mut self, _path: &Path) -> std::io::Result<()> {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Unsupported,
-            "File system access is not supported in WASM environment",
-        ))
-    }
-
     /// 学習データに対する評価指標を計算する。
     #[must_use]
     pub fn get_metrics(&self) -> Metrics {
@@ -506,6 +404,7 @@ impl AveragedPerceptron {
 mod tests {
     use super::*;
 
+    use std::io::BufReader;
     use std::sync::Arc;
     use std::sync::atomic::AtomicBool;
 


### PR DESCRIPTION
## Summary

Phase 1 of `REFACTORING_PLAN.md`: eliminate the largest code duplication in the codebase — the model loading I/O stack — plus a doc fix. **Behavior-preserving**: all golden snapshot tests pass unchanged.

## Changes

### Shared model I/O module (duplication D1)

`AdaBoost` and `AveragedPerceptron` each carried a near-identical copy (~170 lines × 2) of the model loading stack: URI scheme resolution, `file://` handling, HTTP(S) download behind the `remote_model` feature gate, and wasm32 cfg branches.

- New internal module `litsea/src/model_io.rs` with a single `read_model_bytes(uri)` entry point covering all of the above, with unit tests (plain path, `file://`, invalid scheme, missing file — the `file://` path previously had no test coverage).
- Both learners' `load_model` shrink to fetch-bytes + `parse_model_content`; their private `load_model_from_url` / `load_model_from_file` methods are deleted.
- Diff in existing sources: **-245 / +13 lines**, replaced by the ~130-line shared module.
- Side effect: the dead-code warnings on wasm32 `--no-default-features` builds are gone.

### Doc fix (bug B2)

`AveragedPerceptron::save_model` claimed the model is saved as JSON; it is a class-header + TSV text format. The doc comment now matches reality.

### Deviation from the plan

Moving `util::ModelScheme` into `model_io` (and deleting the public `util` module) is deferred to Phase 3, because it would break the public API and this phase is meant to be non-breaking. `REFACTORING_PLAN.md` is updated accordingly.

## Verification

- `cargo test --workspace`: 73 lib + 10 golden + 6 CLI tests, all green (golden snapshots unchanged — behavior preserved, including the on-disk model format guarded by the round-trip tests)
- `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt --check` clean
- `cargo check -p litsea --no-default-features` and wasm32 check pass with zero warnings

https://claude.ai/code/session_01V7mvuY55PG8Q7zKhMC62hJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7mvuY55PG8Q7zKhMC62hJ)_