### PR TITLE
refactor: unify Segmenter pipeline and Extractor, fix first-word POS (Phase 2)

### DIFF
--- a/REFACTORING_PLAN.md
+++ b/REFACTORING_PLAN.md
@@ -17,7 +17,8 @@
 |---|------|------|
 | B1 | ✅ **修正済み(Phase 0 PR に前倒しで含めた)** — **`--no-default-features` でビルド不能**。`perceptron.rs` が `reqwest` を feature gate なしで使用しており(`perceptron.rs:9` の `use reqwest::Client;` と `load_model_from_url`)、`remote_model` を無効にするとコンパイルエラーになる。`adaboost.rs` は正しく `#[cfg(feature = "remote_model")]` で保護されているのに対し、後から追加された perceptron 側が追従していない。 | `cargo check -p litsea --no-default-features` が E0432/E0282 で失敗することを確認済み |
 | B2 | ✅ **修正済み(Phase 1)** — `AveragedPerceptron::save_model` の doc コメントが「モデルを**JSON形式**でファイルに保存する」と記述しているが、実際はクラスヘッダ + TSV のテキスト形式(`perceptron.rs:231-242`)。 | コード読解 |
-| B3 | CI(regression.yml / periodic.yml)に feature マトリクスがなく、B1 のようなビルド破壊が検出されない。 | ワークフロー確認 |
+| B3 | ✅ **解消済み(Phase 0)** — CI(regression.yml / periodic.yml)に feature マトリクスがなく、B1 のようなビルド破壊が検出されない。 | ワークフロー確認 |
+| B4 | **増分学習時の特徴量インデックス不整合(潜在バグ、未修正)**。`Trainer::new`(`initialize_features` + `initialize_instances`)の後に `load_model` を呼ぶと(CLI の `train -m` パス)、`parse_model_content` が `features`/`feature_index` をモデルファイルの内容(非ゼロ重みの特徴のみ)で再構築するため、`instances_buf` に格納済みの特徴インデックスが古い索引を指したまま `train()` が走る。Phase 3 のエラー型・API 再設計時に修正予定。 | Phase 2 作業中のコード読解で発見 |
 
 ### 1.2 重複コード(本計画の主対象)
 
@@ -136,9 +137,19 @@
 
 ---
 
-### フェーズ 2: Segmenter / Extractor / Trainer の構造統一(挙動不変)
+### フェーズ 2: Segmenter / Extractor / Trainer の構造統一 — ✅ 実施済み
 
 **目的**: D2・D3・D5 の重複排除と、コールバック設計の歪み(RefCell ハック)の解消。
+
+**実施結果**(2026-06-12):
+- `sentence_context()`(パディング付き chars/types 構築)と `process_tokens()`(コーパス処理の共通パイプライン)を導入し、4 箇所の重複を 1 箇所に集約。`process_corpus` / `process_corpus_with_pos` は数行の薄いラッパーに縮退。
+- **意図的な挙動変更**: `segment_with_pos` の先頭単語の品詞を、先頭文字位置の予測ラベルから決定するよう修正(従来は常に X、1 単語文では E1 センチネル上で予測していた)。全テスト文で品詞が改善(これ→PRON、東京→PROPN、字→NOUN(旧 SYM)、好→ADJ(旧 PUNCT)等)。ゴールデンテストの期待値を更新済み。分割位置は不変。
+- Extractor: `extract` / `extract_with_pos` を `write_features` + `format_row` の共通実装に統合し、`RefCell<Option<io::Error>>` ハックを撤廃(行を整形してからループ外で `?` 伝播)。
+- 当初計画からの変更点:
+  - `segment` / `segment_with_pos` の走査ループの完全統合は**見送り**(境界判定の型・所有権の契約が複雑になり可読性が下がるため、共通コンテキスト上の 2 つの薄いループとして保持)。
+  - AdaBoost の特徴量ファイル 2 回読みの 1 パス化は**取り止め**。OS のページキャッシュで 2 回目の読み込みは安価であり、全体をメモリに載せる方式は巨大コーパスでメモリを浪費、逐次インターン方式は特徴順序が変わり学習結果の再現性を壊すため、コストに見合わない。
+  - Trainer / PosTrainer の統合は公開 API 変更を伴うため Phase 3 へ。
+- 副産物: 増分学習パスの潜在バグ B4 を発見(1.1 節参照)。
 
 **作業項目**:
 1. **文コンテキスト構築の一本化**(`segmenter.rs`):

--- a/litsea/src/extractor.rs
+++ b/litsea/src/extractor.rs
@@ -1,13 +1,12 @@
-use std::cell::RefCell;
 use std::collections::HashSet;
 use std::error::Error;
+use std::fmt;
 use std::fs::File;
 use std::io::{self, BufRead, Write};
 use std::path::Path;
 
 use crate::language::Language;
 use crate::segmenter::Segmenter;
-use crate::upos::SegmentLabel;
 
 /// Extractor struct for processing text data and extracting features.
 /// It reads sentences from a corpus file, segments them into words,
@@ -53,50 +52,12 @@ impl Extractor {
         corpus_path: &Path,
         features_path: &Path,
     ) -> Result<(), Box<dyn Error>> {
-        // Read sentences from the corpus file.
-        // Each line is treated as a separate sentence.
-        let corpus_file = File::open(corpus_path)?;
-        let corpus = io::BufReader::new(corpus_file);
-
-        // Create a file to write the features
-        let features_file = File::create(features_path)?;
-        let mut features = io::BufWriter::new(features_file);
-
-        // Capture write errors from the closure via RefCell
-        let write_error: RefCell<Option<io::Error>> = RefCell::new(None);
-
-        // Learner function to write features
-        // It takes a set of attributes and a label, and writes them to the output file
-        let mut learner = |attributes: HashSet<String>, label: i8| {
-            if write_error.borrow().is_some() {
-                return;
-            }
-            let mut attrs: Vec<String> = attributes.into_iter().collect();
-            attrs.sort();
-            let mut line = vec![label.to_string()];
-            line.extend(attrs);
-            if let Err(e) = writeln!(features, "{}", line.join("\t")) {
-                *write_error.borrow_mut() = Some(e);
-            }
-        };
-
-        for line in corpus.lines() {
-            let line = line?;
-            let line = line.trim();
-            if !line.is_empty() {
-                self.segmenter.add_corpus_with_writer(line, &mut learner);
-            }
-            // Stop processing further lines if a write error occurred.
-            if write_error.borrow().is_some() {
-                break;
-            }
-        }
-
-        if let Some(e) = write_error.into_inner() {
-            return Err(Box::new(e));
-        }
-
-        Ok(())
+        let segmenter = &self.segmenter;
+        Self::write_features(corpus_path, features_path, |line, rows| {
+            segmenter.add_corpus_with_writer(line, |attrs, label| {
+                rows.push(Self::format_row(attrs, label));
+            });
+        })
     }
 
     /// 品詞付きコーパスから特徴量を抽出してファイルに書き出す。
@@ -113,43 +74,61 @@ impl Extractor {
         corpus_path: &Path,
         features_path: &Path,
     ) -> Result<(), Box<dyn Error>> {
+        let segmenter = &self.segmenter;
+        Self::write_features(corpus_path, features_path, |line, rows| {
+            segmenter.add_corpus_with_pos_writer(line, |attrs, label| {
+                rows.push(Self::format_row(attrs, label));
+            });
+        })
+    }
+
+    /// Shared extraction pipeline: reads the corpus line by line, lets
+    /// `process_line` convert each non-empty line into formatted feature rows,
+    /// and writes the rows to the features file.
+    fn write_features<P>(
+        corpus_path: &Path,
+        features_path: &Path,
+        mut process_line: P,
+    ) -> Result<(), Box<dyn Error>>
+    where
+        P: FnMut(&str, &mut Vec<String>),
+    {
+        // Read sentences from the corpus file.
+        // Each line is treated as a separate sentence.
         let corpus_file = File::open(corpus_path)?;
         let corpus = io::BufReader::new(corpus_file);
 
+        // Create a file to write the features
         let features_file = File::create(features_path)?;
         let mut features = io::BufWriter::new(features_file);
 
-        let write_error: RefCell<Option<io::Error>> = RefCell::new(None);
-
-        let mut writer = |attributes: HashSet<String>, label: SegmentLabel| {
-            if write_error.borrow().is_some() {
-                return;
-            }
-            let mut attrs: Vec<String> = attributes.into_iter().collect();
-            attrs.sort();
-            let mut line = vec![label.to_string()];
-            line.extend(attrs);
-            if let Err(e) = writeln!(features, "{}", line.join("\t")) {
-                *write_error.borrow_mut() = Some(e);
-            }
-        };
-
+        let mut rows: Vec<String> = Vec::new();
         for line in corpus.lines() {
             let line = line?;
             let line = line.trim();
-            if !line.is_empty() {
-                self.segmenter.add_corpus_with_pos_writer(line, &mut writer);
+            if line.is_empty() {
+                continue;
             }
-            if write_error.borrow().is_some() {
-                break;
+            process_line(line, &mut rows);
+            for row in rows.drain(..) {
+                writeln!(features, "{}", row)?;
             }
-        }
-
-        if let Some(e) = write_error.into_inner() {
-            return Err(Box::new(e));
         }
 
         Ok(())
+    }
+
+    /// Formats one feature row: the label followed by the sorted attributes,
+    /// tab-separated.
+    fn format_row(attributes: HashSet<String>, label: impl fmt::Display) -> String {
+        let mut attrs: Vec<String> = attributes.into_iter().collect();
+        attrs.sort();
+        let mut row = label.to_string();
+        for attr in attrs {
+            row.push('\t');
+            row.push_str(&attr);
+        }
+        row
     }
 }
 

--- a/litsea/src/segmenter.rs
+++ b/litsea/src/segmenter.rs
@@ -81,35 +81,58 @@ impl Segmenter {
         self.char_types.get_type(ch)
     }
 
-    /// Processes a corpus string by building tags, characters, and types arrays,
-    /// then calls the callback for each character position with its attributes and label.
-    fn process_corpus<F>(&self, corpus: &str, mut callback: F)
-    where
-        F: FnMut(HashSet<String>, i8),
-    {
-        if corpus.is_empty() {
-            return;
-        }
-        // Padding for lookback: tags[i-3], tags[i-2], tags[i-1] are referenced by
-        // get_attributes(). The first real character's tag is pushed inside the word loop.
-        let mut tags = vec!["U".to_string(); 3];
+    /// Builds the padded character and character-type arrays for a text.
+    ///
+    /// Returns `(chars, types)` where the first three entries are the B3/B2/B1
+    /// head sentinels and the last three are the E1/E2/E3 tail sentinels, so
+    /// real characters occupy indices `3..chars.len() - 3`.
+    fn sentence_context(&self, text: &str) -> (Vec<String>, Vec<String>) {
         let mut chars = vec!["B3".to_string(), "B2".to_string(), "B1".to_string()];
         let mut types = vec!["O".to_string(); 3];
+        for ch in text.chars() {
+            let s = ch.to_string();
+            types.push(self.get_type(&s).to_string());
+            chars.push(s);
+        }
+        chars.extend_from_slice(&["E1".into(), "E2".into(), "E3".into()]);
+        types.extend_from_slice(&["O".into(), "O".into(), "O".into()]);
+        (chars, types)
+    }
 
-        for word in corpus.split(' ') {
-            if word.is_empty() {
+    /// Shared corpus-processing pipeline behind `process_corpus` and
+    /// `process_corpus_with_pos`.
+    ///
+    /// `tokens` yields `(word, label)` pairs where `label` is assigned to the
+    /// first character of the word; continuation characters receive
+    /// `cont_label`. Builds the padded context arrays and invokes `callback`
+    /// with the feature set and label for each character position except the
+    /// first one, which has no preceding boundary decision to learn from.
+    fn process_tokens<'a, L, I, F>(&self, tokens: I, cont_label: L, mut callback: F)
+    where
+        L: Clone,
+        I: Iterator<Item = (&'a str, L)>,
+        F: FnMut(HashSet<String>, L),
+    {
+        // Padding for lookback: tags[i-3], tags[i-2], tags[i-1] are referenced by
+        // get_attributes(). The real characters' tags follow the padding.
+        let mut tags = vec!["U".to_string(); 3];
+        let mut labels: Vec<L> = Vec::new();
+        let mut text = String::new();
+
+        for (word, label) in tokens {
+            let char_count = word.chars().count();
+            if char_count == 0 {
                 continue;
             }
             tags.push("B".to_string());
-            for _ in 1..word.chars().count() {
+            labels.push(label);
+            for _ in 1..char_count {
                 tags.push("O".to_string());
+                labels.push(cont_label.clone());
             }
-            for ch in word.chars() {
-                let s = ch.to_string();
-                types.push(self.get_type(&s).to_string());
-                chars.push(s);
-            }
+            text.push_str(word);
         }
+
         if tags.len() < 4 {
             return;
         }
@@ -117,87 +140,41 @@ impl Segmenter {
         // because there is no preceding word boundary decision to reference at position 0.
         tags[3] = "U".to_string();
 
-        chars.extend_from_slice(&["E1".into(), "E2".into(), "E3".into()]);
-        types.extend_from_slice(&["O".into(), "O".into(), "O".into()]);
+        let (chars, types) = self.sentence_context(&text);
 
         for i in 4..(chars.len() - 3) {
-            let label = if tags[i] == "B" { 1 } else { -1 };
             let attrs = self.get_attributes(i, &tags, &chars, &types);
-            callback(attrs, label);
+            callback(attrs, labels[i - 3].clone());
         }
+    }
+
+    /// Processes a corpus string ("word word ..."), calling the callback for
+    /// each character position with its attributes and boundary label
+    /// (1 = word start, -1 = continuation).
+    fn process_corpus<F>(&self, corpus: &str, callback: F)
+    where
+        F: FnMut(HashSet<String>, i8),
+    {
+        self.process_tokens(corpus.split(' ').map(|word| (word, 1i8)), -1i8, callback);
     }
 
     /// 品詞付きコーパスを処理し、各文字位置の特徴量とSegmentLabelを返す。
     ///
     /// コーパスフォーマット: "単語/品詞 単語/品詞 ..."
     /// 例: "これ/PRON は/PART テスト/NOUN です/AUX 。/PUNCT"
-    fn process_corpus_with_pos<F>(&self, corpus: &str, mut callback: F)
+    fn process_corpus_with_pos<F>(&self, corpus: &str, callback: F)
     where
         F: FnMut(HashSet<String>, SegmentLabel),
     {
-        if corpus.is_empty() {
-            return;
-        }
-
-        let mut tags = vec!["U".to_string(); 3];
-        let mut chars = vec!["B3".to_string(), "B2".to_string(), "B1".to_string()];
-        let mut types = vec!["O".to_string(); 3];
-        let mut labels: Vec<SegmentLabel> = Vec::new();
-
-        for token in corpus.split(' ') {
-            if token.is_empty() {
-                continue;
-            }
-            // "単語/品詞" をパース
-            let (word, pos) = if let Some(slash_pos) = token.rfind('/') {
-                let word_part = &token[..slash_pos];
-                let pos_str = &token[slash_pos + 1..];
-                let pos: Upos = pos_str.parse().unwrap_or(Upos::X);
-                (word_part, pos)
-            } else {
-                // スラッシュが無い場合はXとして扱う
-                (token, Upos::X)
+        let tokens = corpus.split(' ').map(|token| {
+            // "単語/品詞" をパース（スラッシュが無い場合はXとして扱う）
+            let (word, pos) = match token.rfind('/') {
+                Some(idx) => (&token[..idx], token[idx + 1..].parse().unwrap_or(Upos::X)),
+                None => (token, Upos::X),
             };
-
-            let char_count = word.chars().count();
-            if char_count == 0 {
-                continue;
-            }
-
-            // 先頭文字: B-品詞
-            tags.push("B".to_string());
-            labels.push(SegmentLabel::B(pos));
-            // 継続文字: O
-            for _ in 1..char_count {
-                tags.push("O".to_string());
-                labels.push(SegmentLabel::O);
-            }
-            for ch in word.chars() {
-                let s = ch.to_string();
-                types.push(self.get_type(&s).to_string());
-                chars.push(s);
-            }
-        }
-
-        if tags.len() < 4 {
-            return;
-        }
-        tags[3] = "U".to_string();
-
-        chars.extend_from_slice(&["E1".into(), "E2".into(), "E3".into()]);
-        types.extend_from_slice(&["O".into(), "O".into(), "O".into()]);
-
-        // labels[0]はtags[3]に対応（先頭文字のラベルはB-品詞だがタグはU）
-        for i in 4..(chars.len() - 3) {
-            let label_idx = i - 3; // labels配列のインデックス
-            if label_idx >= labels.len() {
-                break;
-            }
-            // 先頭文字（tags[3]="U"の位置）のラベルはB-品詞のまま維持
-            let label = labels[label_idx].clone();
-            let attrs = self.get_attributes(i, &tags, &chars, &types);
-            callback(attrs, label);
-        }
+            (word, SegmentLabel::B(pos))
+        });
+        self.process_tokens(tokens, SegmentLabel::O, callback);
     }
 
     /// Adds a corpus to the segmenter with a custom writer function.
@@ -330,19 +307,10 @@ impl Segmenter {
             return Vec::new();
         }
         let learner = &self.learner;
+        let (chars, types) = self.sentence_context(sentence);
         // Padding for lookback: tags[0..3] are fixed "U" (Unknown) for get_attributes(),
         // and tags[3] is also "U" since there is no boundary decision before the first character.
         let mut tags = vec!["U".to_string(); 4];
-        let mut chars = vec!["B3".to_string(), "B2".to_string(), "B1".to_string()];
-        let mut types = vec!["O".to_string(); 3];
-
-        for ch in sentence.chars() {
-            let s = ch.to_string();
-            types.push(self.get_type(&s).to_string());
-            chars.push(s);
-        }
-        chars.extend_from_slice(&["E1".into(), "E2".into(), "E3".into()]);
-        types.extend_from_slice(&["O".into(), "O".into(), "O".into()]);
 
         let mut result = Vec::new();
         let mut word = chars[3].clone();
@@ -364,6 +332,7 @@ impl Segmenter {
     ///
     /// Averaged Perceptron（`pos_learner`）を使って各文字位置のラベル
     /// （`B-品詞`/`O`）を予測し、単語と品詞のペアを返す。
+    /// 先頭単語の品詞は先頭文字位置の予測ラベルから決定する。
     ///
     /// # Arguments
     /// * `sentence` - 分割対象の文
@@ -384,28 +353,23 @@ impl Segmenter {
             .as_ref()
             .expect("pos_learner is not set. Use with_pos_learner() or add_corpus_with_pos().");
 
+        let (chars, types) = self.sentence_context(sentence);
         let mut tags = vec!["U".to_string(); 4];
-        let mut chars = vec!["B3".to_string(), "B2".to_string(), "B1".to_string()];
-        let mut types = vec!["O".to_string(); 3];
 
-        for ch in sentence.chars() {
-            let s = ch.to_string();
-            types.push(self.get_type(&s).to_string());
-            chars.push(s);
-        }
-        chars.extend_from_slice(&["E1".into(), "E2".into(), "E3".into()]);
-        types.extend_from_slice(&["O".into(), "O".into(), "O".into()]);
+        let predict = |i: usize, tags: &[String]| -> SegmentLabel {
+            let attrs = self.get_attributes(i, tags, &chars, &types);
+            pos_learner.predict(&attrs).parse().unwrap_or(SegmentLabel::O)
+        };
+
+        // The first character always starts the first word; its predicted
+        // label is used only to determine the first word's POS.
+        let mut current_pos = predict(3, &tags).pos().unwrap_or(Upos::X);
 
         let mut result: Vec<(String, Upos)> = Vec::new();
         let mut word = chars[3].clone();
-        // 先頭文字の品詞（最初のpredict結果から取得）
-        let mut current_pos = Upos::X;
 
-        for i in 4..(chars.len() - 3) {
-            let attrs = self.get_attributes(i, &tags, &chars, &types);
-            let label_str = pos_learner.predict(&attrs);
-            let label: SegmentLabel = label_str.parse().unwrap_or(SegmentLabel::O);
-
+        for (i, ch) in chars.iter().enumerate().take(chars.len() - 3).skip(4) {
+            let label = predict(i, &tags);
             if label.is_boundary() {
                 // 現在の単語を確定して結果に追加
                 result.push((std::mem::take(&mut word), current_pos));
@@ -414,17 +378,7 @@ impl Segmenter {
             } else {
                 tags.push("O".to_string());
             }
-            word += &chars[i];
-        }
-
-        // 先頭単語の品詞を決定: 最初の文字位置で予測
-        if result.is_empty() {
-            // 文全体が1単語の場合
-            let first_attrs =
-                self.get_attributes(4.min(chars.len().saturating_sub(3)), &tags, &chars, &types);
-            let first_label_str = pos_learner.predict(&first_attrs);
-            let first_label: SegmentLabel = first_label_str.parse().unwrap_or(SegmentLabel::O);
-            current_pos = first_label.pos().unwrap_or(Upos::X);
+            word += ch;
         }
 
         result.push((word, current_pos));

--- a/litsea/tests/golden.rs
+++ b/litsea/tests/golden.rs
@@ -164,11 +164,10 @@ async fn golden_segment_korean() {
 // ---------------------------------------------------------------------------
 // Joint segmentation + POS tagging (Averaged Perceptron models)
 //
-// Note: the first word of every sentence is currently tagged "X" because
-// segment_with_pos() determines the first word's POS from a prediction made
-// before any boundary context exists (see segmenter.rs). This is a known
-// quirk snapshotted as-is; Phase 2 of the refactoring plan may change it
-// intentionally.
+// Note: until refactoring Phase 2, the first word of every sentence was
+// tagged "X" because segment_with_pos() never used the prediction at the
+// first character position. It now derives the first word's POS from that
+// prediction; these expectations reflect the fixed behavior.
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
@@ -180,7 +179,7 @@ async fn golden_segment_with_pos_japanese() {
             (
                 "これはテストです。",
                 &[
-                    ("これ", "X"),
+                    ("これ", "PRON"),
                     ("は", "ADP"),
                     ("テスト", "NOUN"),
                     ("です", "AUX"),
@@ -190,7 +189,7 @@ async fn golden_segment_with_pos_japanese() {
             (
                 "私の猫は可愛い。",
                 &[
-                    ("私", "X"),
+                    ("私", "PRON"),
                     ("の", "ADP"),
                     ("猫", "NOUN"),
                     ("は", "ADP"),
@@ -201,7 +200,7 @@ async fn golden_segment_with_pos_japanese() {
             (
                 "東京都に住んでいます。",
                 &[
-                    ("東京", "X"),
+                    ("東京", "PROPN"),
                     ("都", "NOUN"),
                     ("に", "ADP"),
                     ("住ん", "VERB"),
@@ -211,12 +210,12 @@ async fn golden_segment_with_pos_japanese() {
                     ("。", "PUNCT"),
                 ],
             ),
-            ("字", &[("字", "SYM")]),
-            ("こんにちは", &[("こん", "X"), ("にち", "ADP"), ("は", "ADP")]),
+            ("字", &[("字", "NOUN")]),
+            ("こんにちは", &[("こん", "PRON"), ("にち", "ADP"), ("は", "ADP")]),
             (
                 "価格は1000円です。",
                 &[
-                    ("価格", "X"),
+                    ("価格", "NOUN"),
                     ("は", "ADP"),
                     ("1000", "NUM"),
                     ("円", "NOUN"),
@@ -227,7 +226,7 @@ async fn golden_segment_with_pos_japanese() {
             (
                 "RustでNLPを実装する。",
                 &[
-                    ("Rust", "X"),
+                    ("Rust", "NOUN"),
                     ("で", "ADP"),
                     ("NLP", "PROPN"),
                     ("を", "ADP"),
@@ -261,7 +260,7 @@ async fn golden_segment_with_pos_chinese() {
             (
                 "我喜欢吃中国菜。",
                 &[
-                    ("我", "X"),
+                    ("我", "PRON"),
                     ("喜欢", "VERB"),
                     ("吃中", "VERB"),
                     ("国菜", "VERB"),
@@ -270,12 +269,24 @@ async fn golden_segment_with_pos_chinese() {
             ),
             (
                 "他在北京工作。",
-                &[("他", "X"), ("在", "ADP"), ("北京", "PROPN"), ("工作", "NOUN"), ("。", "PUNCT")],
+                &[
+                    ("他", "PRON"),
+                    ("在", "ADP"),
+                    ("北京", "PROPN"),
+                    ("工作", "NOUN"),
+                    ("。", "PUNCT"),
+                ],
             ),
-            ("好", &[("好", "PUNCT")]),
+            ("好", &[("好", "ADJ")]),
             (
                 "2024年的春天。",
-                &[("2024", "X"), ("年", "NOUN"), ("的", "PART"), ("春天", "NOUN"), ("。", "PUNCT")],
+                &[
+                    ("2024", "NUM"),
+                    ("年", "NOUN"),
+                    ("的", "PART"),
+                    ("春天", "NOUN"),
+                    ("。", "PUNCT"),
+                ],
             ),
         ],
     );
@@ -290,12 +301,12 @@ async fn golden_segment_with_pos_korean() {
         &[
             (
                 "이것은 테스트입니다.",
-                &[("이것은", "X"), (" ", "PUNCT"), ("테스트입니다", "NOUN"), (".", "PUNCT")],
+                &[("이것은", "PRON"), (" ", "PUNCT"), ("테스트입니다", "NOUN"), (".", "PUNCT")],
             ),
             (
                 "나는 고양이를 좋아한다.",
                 &[
-                    ("나는", "X"),
+                    ("나는", "PRON"),
                     (" ", "PUNCT"),
                     ("고양이를", "NOUN"),
                     (" ", "PUNCT"),
@@ -306,7 +317,7 @@ async fn golden_segment_with_pos_korean() {
             (
                 "한국어 형태소 분석기.",
                 &[
-                    ("한국어", "X"),
+                    ("한국어", "NOUN"),
                     (" ", "PUNCT"),
                     ("형태소", "NOUN"),
                     (" ", "PUNCT"),
@@ -314,8 +325,11 @@ async fn golden_segment_with_pos_korean() {
                     (".", "PUNCT"),
                 ],
             ),
-            ("글", &[("글", "PUNCT")]),
-            ("2024년 봄.", &[("2024년", "X"), (" ", "PUNCT"), ("봄", "NOUN"), (".", "PUNCT")]),
+            ("글", &[("글", "NOUN")]),
+            (
+                "2024년 봄.",
+                &[("2024년", "NOUN"), (" ", "PUNCT"), ("봄", "NOUN"), (".", "PUNCT")],
+            ),
         ],
     );
     assert!(segmenter.segment_with_pos("").is_empty());


### PR DESCRIPTION
## Summary

Phase 2 of `REFACTORING_PLAN.md`: unify the Segmenter's four duplicated context-building pipelines and the Extractor's two near-identical methods, and **fix the first-word POS quirk** in `segment_with_pos` (requested change — this is the one intentional behavior change in this PR).

## Changes

### Segmenter: shared pipeline (duplication D2)

The B3/B2/B1 / E1/E2/E3 padding and chars/types array construction existed in four places (`process_corpus`, `process_corpus_with_pos`, `segment`, `segment_with_pos`). Now:

- `sentence_context()` builds the padded chars/types arrays in one place.
- `process_tokens()` is the single corpus-processing pipeline; `process_corpus` and `process_corpus_with_pos` are thin wrappers that differ only in token parsing and label type (`i8` vs `SegmentLabel`).

### Fix: first-word POS in `segment_with_pos`

Previously every sentence's first word was tagged `X` because the prediction at the first character position was never used — and for single-word sentences the after-the-fact fallback predicted on the **E1 tail sentinel** rather than a real character. `segment_with_pos` now derives the first word's POS from the prediction at the first character position.

First-word tags improve across all golden sentences (segmentation positions are unchanged):

| Input | Before | After |
|---|---|---|
| これ(はテストです。) | X | **PRON** |
| 東京(都に住んでいます。) | X | **PROPN** |
| 字 (single char) | SYM | **NOUN** |
| 好 (single char) | PUNCT | **ADJ** |
| 2024(年的春天。) | X | **NUM** |
| 이것은(...) | X | **PRON** |

Golden expectations are updated accordingly; all other snapshots (7 segmentation tests, round-trips) pass **unchanged**.

### Extractor: shared implementation (duplication D3)

`extract` / `extract_with_pos` are merged into a shared `write_features` + `format_row` implementation. The `RefCell<Option<io::Error>>` out-of-band error propagation hack is gone: the callback formats rows, and writing happens outside the callback where errors propagate with `?`. Output format is byte-identical.

### Deviations from the plan (documented in REFACTORING_PLAN.md)

- Full unification of the `segment` / `segment_with_pos` walk loops was skipped: the boundary/ownership contracts get convoluted for ~10 lines of genuinely different logic. Both now share `sentence_context()`.
- Single-pass training-file loading was dropped: the OS page cache makes the second read cheap, and the in-memory alternatives either waste memory on large corpora or change feature ordering (breaking training reproducibility).
- Trainer/PosTrainer consolidation moves to Phase 3 (requires API changes).
- Newly discovered latent bug **B4** documented for Phase 3: in the incremental-training path (`train -m <model>`), `load_model` rebuilds `feature_index` from the model file, leaving `instances_buf` indices stale.

## Verification

- `cargo test --workspace`: 73 lib + 10 golden + 6 CLI tests, all green
- `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt --check` clean
- `cargo check -p litsea --no-default-features` and wasm32 check pass

https://claude.ai/code/session_01V7mvuY55PG8Q7zKhMC62hJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7mvuY55PG8Q7zKhMC62hJ)_