### PR TITLE
perf: match-based char classification, transposed perceptron weights, allocation-free hot paths (Phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ compatible: all pre-trained models in `models/` load unchanged.
 
 ### Added
 
+- `Language::char_type(char) -> &'static str`: allocation-free, match-based
+  character classification (replaces the regex-based `CharTypePatterns`).
 - `litsea::error::LitseaError` and `litsea::error::Result<T>`: a proper
   error enum (`Io`, `InvalidData`, `InvalidInput`, `Unsupported`, and
   `Download` with the `remote_model` feature) replacing the previous mix of
@@ -47,6 +49,25 @@ compatible: all pre-trained models in `models/` load unchanged.
 - `Segmenter::get_attributes` is no longer public.
 - The `litsea::util` module was removed (`ModelScheme` is now internal).
 - `parse_model_content` was renamed to the public `load_model_from_reader`.
+- `CharTypePatterns` and `Language::char_type_patterns()` were removed in
+  favor of `Language::char_type(char)`; the `regex` dependency is gone.
+  `Segmenter::char_type` is unchanged.
+
+### Performance
+
+Measured on the bundled models (criterion, medians, vs v0.4.0):
+
+- `segment()`: 65–70% faster (long Japanese text: 611 ms → 215 ms).
+  The bias term is computed once per sentence instead of once per character,
+  and attribute scoring sums weights directly without building a `HashSet`.
+- `segment_with_pos()`: 88–91% faster (long Japanese text: 4.48 s → 0.40 s).
+  The perceptron weight layout is transposed to feature → per-class vector,
+  reducing hash lookups per position from features × classes to features,
+  and attribute buffers are reused across positions.
+- Character classification: 61 ns → 9 ns per call (regex scan → `match` on
+  `char` ranges).
+- `AveragedPerceptron::train`: no longer clones all instances per call and
+  no longer rebuilds a `HashSet` per instance per epoch.
 
 ### Migration notes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,7 +797,6 @@ name = "litsea"
 version = "0.5.0"
 dependencies = [
  "criterion",
- "regex",
  "reqwest",
  "tempfile",
  "thiserror 2.0.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ license = "MIT"
 [workspace.dependencies]
 clap = { version = "4.5.60", features = ["derive"] }
 ctrlc = "3.5.2"
-regex = "1.12.3"
 reqwest = { version = "0.13.2", features = [
     "rustls",
 ], default-features = false } # use rustls instead of native-tls to avoid linking openssl; disables http2, charset, and system-proxy

--- a/REFACTORING_PLAN.md
+++ b/REFACTORING_PLAN.md
@@ -230,10 +230,19 @@
 
 ---
 
-### フェーズ 4: 内部データ表現とパフォーマンス最適化(挙動不変)
+### フェーズ 4: 内部データ表現とパフォーマンス最適化(挙動不変) — ✅ 実施済み
 
 **目的**: ホットパス(文字種分類・特徴量生成・Perceptron 学習)のアロケーション削減。
-**前提**: Phase 0 の criterion ベースラインと比較し、各変更の効果を PR に記録する。
+
+**実施結果**(2026-06-12、criterion median、Phase 0 ベースライン比):
+- **文字種分類の match 化**: `CharTypePatterns`(正規表現の線形走査)を `char` 範囲 `match` の `Language::char_type()` に置換。**61ns → 9.4ns(-85%)**。3 言語で重複していた P/A/N パターンも 1 関数に集約(D6 解消)。**`regex` 依存を削除**。
+- **Perceptron 重みレイアウトの転置**: `HashMap<class, HashMap<feat, w>>` → `HashMap<feat, Vec<w; クラス数>>`。1 文字あたりのハッシュ参照が 特徴数×クラス数(~756 回)→ 特徴数(~42 回)に減少。
+- **属性生成のアロケーション削減**: 特徴テンプレートを単一の `write_attributes()`(再利用バッファ + sink)に集約。`segment()` は HashSet を作らず重みを直接合算、`segment_with_pos()` は `Vec<String>` バッファを位置間で再利用。bias の毎文字再計算(全重みの総和!)も文単位の 1 回に。
+- **学習ループ**: `train()` のインスタンス全クローンを `mem::take` に置換、エポック毎の HashSet 再構築を撤廃。
+- tags/types を `&'static str` 化。
+- **ベンチ結果**: `segment_short` adaboost **-66〜70%**(ja 56.8→17.1µs)、perceptron **-88〜90%**(ja 293→30.8µs)。`segment_long_japanese` adaboost **611ms → 215ms(-65%)**、perceptron **4.48s → 396ms(-91%)**。`add_corpus` -37%。
+- **挙動不変をゴールデンテスト 10 件の完全一致で確認**(モデルファイル形式も round-trip テストで不変)。
+- 未実施(費用対効果で見送り): `chars: Vec<String>` → `Vec<char>` 化(センチネル表現の複雑化に対し残る利得が小さい)。
 
 **作業項目**(独立した PR に分割可、効果の大きい順):
 1. **文字種分類の match 化**(`language.rs`):

--- a/litsea/Cargo.toml
+++ b/litsea/Cargo.toml
@@ -13,7 +13,6 @@ categories.workspace = true
 license.workspace = true
 
 [dependencies]
-regex.workspace = true
 thiserror.workspace = true
 reqwest = { workspace = true, optional = true }
 

--- a/litsea/benches/bench.rs
+++ b/litsea/benches/bench.rs
@@ -133,13 +133,6 @@ fn bench_add_corpus(c: &mut Criterion) {
     });
 }
 
-/// Benchmarks `char_type_patterns()` which includes regex compilation cost on every call.
-fn bench_char_type_patterns(c: &mut Criterion) {
-    c.bench_function("char_type_patterns_japanese", |b| {
-        b.iter(|| Language::Japanese.char_type_patterns());
-    });
-}
-
 fn bench_predict_adaboost(c: &mut Criterion) {
     let learner = load_adaboost_model("japanese.model");
     let segmenter = Segmenter::new(Language::Japanese, Some(learner));
@@ -164,7 +157,6 @@ criterion_group!(
     bench_segment_long,
     bench_char_type,
     bench_add_corpus,
-    bench_char_type_patterns,
     bench_predict_adaboost,
 );
 criterion_main!(benches);

--- a/litsea/src/adaboost.rs
+++ b/litsea/src/adaboost.rs
@@ -447,6 +447,13 @@ impl AdaBoost {
         if score >= 0.0 { 1 } else { -1 }
     }
 
+    /// Returns the model weight of a single attribute (0.0 if unknown).
+    /// Used by the segmenter's hot path to score positions without building
+    /// an attribute set.
+    pub(crate) fn weight(&self, attr: &str) -> f64 {
+        self.feature_index.get(attr).map_or(0.0, |&idx| self.model[idx])
+    }
+
     /// Gets the bias term of the model.
     /// The bias is calculated as the negative sum of the model weights divided by 2.
     ///

--- a/litsea/src/language.rs
+++ b/litsea/src/language.rs
@@ -1,8 +1,6 @@
 use std::fmt;
 use std::str::FromStr;
 
-use regex::Regex;
-
 /// Supported languages for word segmentation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum Language {
@@ -42,168 +40,91 @@ impl FromStr for Language {
 }
 
 impl Language {
-    /// Creates the character type patterns for this language.
+    /// Classifies a character into a language-specific type code.
     ///
-    /// Note: This method compiles Regex patterns on each call.
-    /// For performance-sensitive code, cache the returned `CharTypePatterns` instance
-    /// (as `Segmenter::new` already does).
-    pub fn char_type_patterns(&self) -> CharTypePatterns {
+    /// Returns "O" (Other) if the character does not belong to any class.
+    /// Classification is a direct `match` on character ranges, so it is
+    /// allocation-free and O(1).
+    #[must_use]
+    pub fn char_type(&self, c: char) -> &'static str {
         match self {
-            Language::Japanese => japanese_patterns(),
-            Language::Chinese => chinese_patterns(),
-            Language::Korean => korean_patterns(),
+            Language::Japanese => japanese_char_type(c),
+            Language::Chinese => chinese_char_type(c),
+            Language::Korean => korean_char_type(c),
         }
     }
 }
 
-/// A character matcher that can be either a regex or a custom closure.
-enum CharMatcher {
-    /// Pattern-based matching using a compiled regex.
-    Regex(Regex),
-    /// Custom matching logic using a closure.
-    Closure(Box<dyn Fn(&str) -> bool + Send + Sync>),
-}
-
-impl fmt::Debug for CharMatcher {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            CharMatcher::Regex(re) => f.debug_tuple("Regex").field(&re.as_str()).finish(),
-            CharMatcher::Closure(_) => f.debug_tuple("Closure").field(&"<fn>").finish(),
-        }
+/// Classes shared by all languages, checked after the language-specific ones:
+/// - "P": CJK Symbols and Punctuation + full-width punctuation
+/// - "A": ASCII and full-width Latin characters
+/// - "N": Digits (ASCII and full-width)
+fn punct_latin_digit(c: char) -> Option<&'static str> {
+    match c {
+        '\u{3000}'..='\u{303F}'
+        | '\u{FF01}'..='\u{FF0F}'
+        | '\u{FF1A}'..='\u{FF20}'
+        | '\u{FF3B}'..='\u{FF40}'
+        | '\u{FF5B}'..='\u{FF65}' => Some("P"),
+        'a'..='z' | 'A'..='Z' | 'ａ'..='ｚ' | 'Ａ'..='Ｚ' => Some("A"),
+        '0'..='9' | '０'..='９' => Some("N"),
+        _ => None,
     }
 }
 
-impl CharMatcher {
-    /// Returns true if the given character matches this matcher.
-    fn is_match(&self, ch: &str) -> bool {
-        match self {
-            CharMatcher::Regex(re) => re.is_match(ch),
-            CharMatcher::Closure(f) => f(ch),
-        }
-    }
-}
-
-/// Character type classification patterns for a specific language.
-/// Each pattern maps a matcher to a type code string.
-#[derive(Debug)]
-pub struct CharTypePatterns {
-    patterns: Vec<(CharMatcher, &'static str)>,
-}
-
-impl CharTypePatterns {
-    /// Creates a new instance of [`CharTypePatterns`] from regex patterns.
-    pub fn new(patterns: Vec<(Regex, &'static str)>) -> Self {
-        CharTypePatterns {
-            patterns: patterns
-                .into_iter()
-                .map(|(re, label)| (CharMatcher::Regex(re), label))
-                .collect(),
-        }
-    }
-
-    /// Creates a new instance of [`CharTypePatterns`] from heterogeneous matchers.
-    fn from_matchers(patterns: Vec<(CharMatcher, &'static str)>) -> Self {
-        CharTypePatterns { patterns }
-    }
-
-    /// Gets the type of a character based on the language-specific patterns.
-    ///
-    /// # Arguments
-    /// * `ch` - A string slice representing a single character.
-    ///
-    /// # Returns
-    /// A string slice representing the type code of the character.
-    /// Returns "O" (Other) if the character does not match any pattern.
-    pub fn get_type(&self, ch: &str) -> &str {
-        for (matcher, label) in &self.patterns {
-            if matcher.is_match(ch) {
-                return label;
-            }
-        }
-        "O" // Other
-    }
-}
-
-/// Creates character type patterns for Japanese.
+/// Character type classification for Japanese.
 ///
 /// Type codes:
 /// - "M": Kanji numbers (一二三四五六七八九十百千万億兆)
-/// - "H": Kanji (CJK ideographs)
+/// - "H": Kanji (CJK ideographs, 々〆ヵヶ)
 /// - "I": Hiragana
-/// - "K": Katakana
-/// - "P": Punctuation (CJK symbols and full-width punctuation)
-/// - "A": ASCII and full-width Latin characters
-/// - "N": Digits (ASCII and full-width)
+/// - "K": Katakana (full-width and half-width)
+/// - "P" / "A" / "N": see [`punct_latin_digit`]
 /// - "O": Other (fallback)
-fn japanese_patterns() -> CharTypePatterns {
-    CharTypePatterns::new(vec![
-        (Regex::new(r"[一二三四五六七八九十百千万億兆]").expect("hardcoded regex pattern is valid"), "M"),
-        (Regex::new(r"[一-龠々〆ヵヶ]").expect("hardcoded regex pattern is valid"), "H"),
-        (Regex::new(r"[ぁ-ん]").expect("hardcoded regex pattern is valid"), "I"),
-        (Regex::new(r"[ァ-ヴーｱ-ﾝﾞﾟ]").expect("hardcoded regex pattern is valid"), "K"),
-        // CJK Symbols and Punctuation + full-width punctuation
-        (
-            Regex::new(
-                r"[\u{3000}-\u{303F}\u{FF01}-\u{FF0F}\u{FF1A}-\u{FF20}\u{FF3B}-\u{FF40}\u{FF5B}-\u{FF65}]",
-            )
-            .expect("hardcoded regex pattern is valid"),
-            "P",
-        ),
-        (Regex::new(r"[a-zA-Zａ-ｚＡ-Ｚ]").expect("hardcoded regex pattern is valid"), "A"),
-        (Regex::new(r"[0-9０-９]").expect("hardcoded regex pattern is valid"), "N"),
-    ])
+fn japanese_char_type(c: char) -> &'static str {
+    match c {
+        '一' | '二' | '三' | '四' | '五' | '六' | '七' | '八' | '九' | '十' | '百' | '千'
+        | '万' | '億' | '兆' => "M",
+        // 一-龠 plus 々〆ヵヶ
+        '\u{4E00}'..='\u{9FA0}' | '々' | '〆' | 'ヵ' | 'ヶ' => "H",
+        // ぁ-ん
+        '\u{3041}'..='\u{3093}' => "I",
+        // ァ-ヴ, ー, half-width ｱ-ﾝ and ﾞﾟ
+        '\u{30A1}'..='\u{30F4}' | 'ー' | '\u{FF71}'..='\u{FF9D}' | 'ﾞ' | 'ﾟ' => "K",
+        _ => punct_latin_digit(c).unwrap_or("O"),
+    }
 }
 
-/// Creates character type patterns for Chinese.
+/// Character type classification for Chinese.
 ///
 /// Type codes:
 /// - "F": High-frequency function words (虚词: 的了在是和不也 etc.)
 /// - "C": CJK Unified Ideographs (U+4E00..U+9FFF)
 /// - "X": CJK Extension A (U+3400..U+4DBF)
 /// - "R": CJK Radicals and Kangxi Radicals (U+2E80..U+2FDF)
-/// - "P": Chinese punctuation and CJK symbols
 /// - "B": Bopomofo (Zhuyin)
-/// - "A": ASCII and full-width Latin characters
-/// - "N": Digits (ASCII and full-width)
+/// - "P" / "A" / "N": see [`punct_latin_digit`]
 /// - "O": Other (fallback)
-fn chinese_patterns() -> CharTypePatterns {
-    CharTypePatterns::from_matchers(vec![
-        // High-frequency function words (虚词)
-        // Includes structural particles, aspect/modal particles, conjunctions,
-        // prepositions, and common grammatical verbs/adverbs
-        (
-            CharMatcher::Regex(
-                Regex::new(r"[的地得了着过吗呢吧啊嘛和与或但而且及在从到把被对向给是有不也都就要会能可]")
-                    .expect("hardcoded regex pattern is valid"),
-            ),
-            "F",
-        ),
-        // CJK Unified Ideographs (remaining)
-        (CharMatcher::Regex(Regex::new(r"[\u{4E00}-\u{9FFF}]").expect("hardcoded regex pattern is valid")), "C"),
-        // CJK Extension A
-        (CharMatcher::Regex(Regex::new(r"[\u{3400}-\u{4DBF}]").expect("hardcoded regex pattern is valid")), "X"),
-        // CJK Radicals Supplement + Kangxi Radicals
-        (CharMatcher::Regex(Regex::new(r"[\u{2E80}-\u{2FDF}]").expect("hardcoded regex pattern is valid")), "R"),
-        // Chinese punctuation: CJK Symbols and Punctuation + full-width punctuation
-        (
-            CharMatcher::Regex(
-                Regex::new(
-                    r"[\u{3000}-\u{303F}\u{FF01}-\u{FF0F}\u{FF1A}-\u{FF20}\u{FF3B}-\u{FF40}\u{FF5B}-\u{FF65}]",
-                )
-                .expect("hardcoded regex pattern is valid"),
-            ),
-            "P",
-        ),
+fn chinese_char_type(c: char) -> &'static str {
+    match c {
+        // High-frequency function words (虚词): structural particles,
+        // aspect/modal particles, conjunctions, prepositions, and common
+        // grammatical verbs/adverbs
+        '的' | '地' | '得' | '了' | '着' | '过' | '吗' | '呢' | '吧' | '啊' | '嘛' | '和'
+        | '与' | '或' | '但' | '而' | '且' | '及' | '在' | '从' | '到' | '把' | '被' | '对'
+        | '向' | '给' | '是' | '有' | '不' | '也' | '都' | '就' | '要' | '会' | '能' | '可' => {
+            "F"
+        }
+        '\u{4E00}'..='\u{9FFF}' => "C",
+        '\u{3400}'..='\u{4DBF}' => "X",
+        '\u{2E80}'..='\u{2FDF}' => "R",
         // Bopomofo + Bopomofo Extended
-        (CharMatcher::Regex(Regex::new(r"[\u{3100}-\u{312F}\u{31A0}-\u{31BF}]").expect("hardcoded regex pattern is valid")), "B"),
-        // ASCII + Full-width Latin
-        (CharMatcher::Regex(Regex::new(r"[a-zA-Zａ-ｚＡ-Ｚ]").expect("hardcoded regex pattern is valid")), "A"),
-        // Numbers
-        (CharMatcher::Regex(Regex::new(r"[0-9０-９]").expect("hardcoded regex pattern is valid")), "N"),
-    ])
+        '\u{3100}'..='\u{312F}' | '\u{31A0}'..='\u{31BF}' => "B",
+        _ => punct_latin_digit(c).unwrap_or("O"),
+    }
 }
 
-/// Creates character type patterns for Korean.
+/// Character type classification for Korean.
 ///
 /// Type codes:
 /// - "E": High-frequency particles/endings (조사/어미: 은는을를의에)
@@ -212,93 +133,27 @@ fn chinese_patterns() -> CharTypePatterns {
 /// - "J": Hangul Jamo (U+1100..U+11FF)
 /// - "G": Hangul Compatibility Jamo (U+3130..U+318F)
 /// - "H": Hanja / CJK Ideographs (U+4E00..U+9FFF)
-/// - "P": Korean punctuation and CJK symbols
-/// - "A": ASCII and full-width Latin characters
-/// - "N": Digits (ASCII and full-width)
+/// - "P" / "A" / "N": see [`punct_latin_digit`]
 /// - "O": Other (fallback)
-fn korean_patterns() -> CharTypePatterns {
-    CharTypePatterns::from_matchers(vec![
-        // High-frequency particles/endings (조사/어미)
-        // These characters are overwhelmingly used as grammatical particles:
+fn korean_char_type(c: char) -> &'static str {
+    match c {
+        // Overwhelmingly used as grammatical particles:
         // 은/는 (topic), 을/를 (object), 의 (possessive), 에 (locative)
-        (
-            CharMatcher::Regex(
-                Regex::new(r"[은는을를의에]").expect("hardcoded regex pattern is valid"),
-            ),
-            "E",
-        ),
-        // Hangul Syllable without 받침 (final consonant)
-        // (codepoint - 0xAC00) % 28 == 0
-        (
-            CharMatcher::Closure(Box::new(|ch: &str| {
-                if let Some(cp) = ch.chars().next() {
-                    let code = cp as u32;
-                    (0xAC00..=0xD7AF).contains(&code) && (code - 0xAC00).is_multiple_of(28)
-                } else {
-                    false
-                }
-            })),
-            "SN",
-        ),
-        // Hangul Syllable with 받침 (final consonant)
-        // (codepoint - 0xAC00) % 28 != 0
-        (
-            CharMatcher::Closure(Box::new(|ch: &str| {
-                if let Some(cp) = ch.chars().next() {
-                    let code = cp as u32;
-                    (0xAC00..=0xD7AF).contains(&code) && !(code - 0xAC00).is_multiple_of(28)
-                } else {
-                    false
-                }
-            })),
-            "SF",
-        ),
-        // Hangul Jamo
-        (
-            CharMatcher::Regex(
-                Regex::new(r"[\u{1100}-\u{11FF}]").expect("hardcoded regex pattern is valid"),
-            ),
-            "J",
-        ),
-        // Hangul Compatibility Jamo
-        (
-            CharMatcher::Regex(
-                Regex::new(r"[\u{3130}-\u{318F}]").expect("hardcoded regex pattern is valid"),
-            ),
-            "G",
-        ),
-        // Hanja (CJK Unified Ideographs)
-        (
-            CharMatcher::Regex(
-                Regex::new(r"[\u{4E00}-\u{9FFF}]").expect("hardcoded regex pattern is valid"),
-            ),
-            "H",
-        ),
-        // Korean punctuation: CJK Symbols and Punctuation + full-width punctuation
-        (
-            CharMatcher::Regex(
-                Regex::new(
-                    r"[\u{3000}-\u{303F}\u{FF01}-\u{FF0F}\u{FF1A}-\u{FF20}\u{FF3B}-\u{FF40}\u{FF5B}-\u{FF65}]",
-                )
-                .expect("hardcoded regex pattern is valid"),
-            ),
-            "P",
-        ),
-        // ASCII + Full-width Latin
-        (
-            CharMatcher::Regex(
-                Regex::new(r"[a-zA-Zａ-ｚＡ-Ｚ]").expect("hardcoded regex pattern is valid"),
-            ),
-            "A",
-        ),
-        // Numbers
-        (
-            CharMatcher::Regex(
-                Regex::new(r"[0-9０-９]").expect("hardcoded regex pattern is valid"),
-            ),
-            "N",
-        ),
-    ])
+        '은' | '는' | '을' | '를' | '의' | '에' => "E",
+        // Hangul Syllables: (codepoint - 0xAC00) % 28 == 0 means no 받침
+        // (final consonant)
+        '\u{AC00}'..='\u{D7AF}' => {
+            if (c as u32 - 0xAC00).is_multiple_of(28) {
+                "SN"
+            } else {
+                "SF"
+            }
+        }
+        '\u{1100}'..='\u{11FF}' => "J",
+        '\u{3130}'..='\u{318F}' => "G",
+        '\u{4E00}'..='\u{9FFF}' => "H",
+        _ => punct_latin_digit(c).unwrap_or("O"),
+    }
 }
 
 #[cfg(test)]
@@ -334,88 +189,79 @@ mod tests {
         assert_eq!(Language::default(), Language::Japanese);
     }
 
-    // --- Empty string edge case ---
-
-    #[test]
-    fn test_get_type_empty_string() {
-        // Empty string should return "O" (Other) for all languages.
-        let jp = Language::Japanese.char_type_patterns();
-        assert_eq!(jp.get_type(""), "O");
-
-        let cn = Language::Chinese.char_type_patterns();
-        assert_eq!(cn.get_type(""), "O");
-
-        let kr = Language::Korean.char_type_patterns();
-        assert_eq!(kr.get_type(""), "O");
-    }
-
     // --- Japanese pattern tests ---
 
     #[test]
-    fn test_japanese_patterns() {
-        let p = Language::Japanese.char_type_patterns();
-        assert_eq!(p.get_type("三"), "M"); // Kanji number
-        assert_eq!(p.get_type("千"), "M"); // Kanji number (boundary)
-        assert_eq!(p.get_type("万"), "M"); // Kanji number (large unit)
-        assert_eq!(p.get_type("億"), "M"); // Kanji number (large unit)
-        assert_eq!(p.get_type("漢"), "H"); // Kanji
-        assert_eq!(p.get_type("あ"), "I"); // Hiragana
-        assert_eq!(p.get_type("ア"), "K"); // Katakana
-        assert_eq!(p.get_type("。"), "P"); // CJK punctuation
-        assert_eq!(p.get_type("、"), "P"); // CJK punctuation
-        assert_eq!(p.get_type("「"), "P"); // CJK punctuation
-        assert_eq!(p.get_type("A"), "A"); // ASCII
-        assert_eq!(p.get_type("ａ"), "A"); // Full-width Latin
-        assert_eq!(p.get_type("5"), "N"); // Digit
-        assert_eq!(p.get_type("５"), "N"); // Full-width digit
-        assert_eq!(p.get_type("@"), "O"); // Other
+    fn test_japanese_char_types() {
+        let lang = Language::Japanese;
+        assert_eq!(lang.char_type('三'), "M"); // Kanji number
+        assert_eq!(lang.char_type('千'), "M"); // Kanji number (boundary)
+        assert_eq!(lang.char_type('万'), "M"); // Kanji number (large unit)
+        assert_eq!(lang.char_type('億'), "M"); // Kanji number (large unit)
+        assert_eq!(lang.char_type('漢'), "H"); // Kanji
+        assert_eq!(lang.char_type('々'), "H"); // Iteration mark
+        assert_eq!(lang.char_type('あ'), "I"); // Hiragana
+        assert_eq!(lang.char_type('ア'), "K"); // Katakana
+        assert_eq!(lang.char_type('ー'), "K"); // Prolonged sound mark
+        assert_eq!(lang.char_type('ｱ'), "K"); // Half-width Katakana
+        assert_eq!(lang.char_type('。'), "P"); // CJK punctuation
+        assert_eq!(lang.char_type('、'), "P"); // CJK punctuation
+        assert_eq!(lang.char_type('「'), "P"); // CJK punctuation
+        assert_eq!(lang.char_type('A'), "A"); // ASCII
+        assert_eq!(lang.char_type('ａ'), "A"); // Full-width Latin
+        assert_eq!(lang.char_type('5'), "N"); // Digit
+        assert_eq!(lang.char_type('５'), "N"); // Full-width digit
+        assert_eq!(lang.char_type('@'), "O"); // Other
     }
 
     // --- Chinese pattern tests ---
 
     #[test]
-    fn test_chinese_patterns() {
-        let p = Language::Chinese.char_type_patterns();
-        assert_eq!(p.get_type("的"), "F"); // Function word (structural particle)
-        assert_eq!(p.get_type("了"), "F"); // Function word (aspect particle)
-        assert_eq!(p.get_type("在"), "F"); // Function word (preposition)
-        assert_eq!(p.get_type("是"), "F"); // Function word (verb)
-        assert_eq!(p.get_type("中"), "C"); // CJK Unified (not a function word)
-        assert_eq!(p.get_type("国"), "C"); // CJK Unified
-        assert_eq!(p.get_type("人"), "C"); // CJK Unified
-        assert_eq!(p.get_type("。"), "P"); // Chinese punctuation (U+3002)
-        assert_eq!(p.get_type("，"), "P"); // Full-width comma (U+FF0C)
-        assert_eq!(p.get_type("A"), "A"); // ASCII
-        assert_eq!(p.get_type("5"), "N"); // Digit
-        assert_eq!(p.get_type("@"), "O"); // Other
+    fn test_chinese_char_types() {
+        let lang = Language::Chinese;
+        assert_eq!(lang.char_type('的'), "F"); // Function word (structural particle)
+        assert_eq!(lang.char_type('了'), "F"); // Function word (aspect particle)
+        assert_eq!(lang.char_type('在'), "F"); // Function word (preposition)
+        assert_eq!(lang.char_type('是'), "F"); // Function word (verb)
+        assert_eq!(lang.char_type('中'), "C"); // CJK Unified (not a function word)
+        assert_eq!(lang.char_type('国'), "C"); // CJK Unified
+        assert_eq!(lang.char_type('人'), "C"); // CJK Unified
+        assert_eq!(lang.char_type('㐀'), "X"); // CJK Extension A (U+3400)
+        assert_eq!(lang.char_type('⺀'), "R"); // CJK Radicals Supplement (U+2E80)
+        assert_eq!(lang.char_type('ㄅ'), "B"); // Bopomofo (U+3105)
+        assert_eq!(lang.char_type('。'), "P"); // Chinese punctuation (U+3002)
+        assert_eq!(lang.char_type('，'), "P"); // Full-width comma (U+FF0C)
+        assert_eq!(lang.char_type('A'), "A"); // ASCII
+        assert_eq!(lang.char_type('5'), "N"); // Digit
+        assert_eq!(lang.char_type('@'), "O"); // Other
     }
 
     // --- Korean pattern tests ---
 
     #[test]
-    fn test_korean_patterns() {
-        let p = Language::Korean.char_type_patterns();
-        assert_eq!(p.get_type("는"), "E"); // Particle (topic marker)
-        assert_eq!(p.get_type("은"), "E"); // Particle (topic marker)
-        assert_eq!(p.get_type("을"), "E"); // Particle (object marker)
-        assert_eq!(p.get_type("를"), "E"); // Particle (object marker)
-        assert_eq!(p.get_type("의"), "E"); // Particle (possessive)
-        assert_eq!(p.get_type("에"), "E"); // Particle (locative)
-        assert_eq!(p.get_type("가"), "SN"); // Hangul Syllable without 받침
-        assert_eq!(p.get_type("나"), "SN"); // Hangul Syllable without 받침
-        assert_eq!(p.get_type("하"), "SN"); // Hangul Syllable without 받침
-        assert_eq!(p.get_type("한"), "SF"); // Hangul Syllable with 받침
-        assert_eq!(p.get_type("글"), "SF"); // Hangul Syllable with 받침
-        assert_eq!(p.get_type("각"), "SF"); // Hangul Syllable with 받침
-        assert_eq!(p.get_type("ㄱ"), "G"); // Compatibility Jamo (consonant)
-        assert_eq!(p.get_type("ㅏ"), "G"); // Compatibility Jamo (vowel)
-        assert_eq!(p.get_type("ㅎ"), "G"); // Compatibility Jamo (last consonant)
-        assert_eq!(p.get_type("\u{1100}"), "J"); // Hangul Jamo (choseong kiyeok, U+1100)
-        assert_eq!(p.get_type("\u{1161}"), "J"); // Hangul Jamo (jungseong a, U+1161)
-        assert_eq!(p.get_type("漢"), "H"); // Hanja
-        assert_eq!(p.get_type("。"), "P"); // Punctuation (U+3002)
-        assert_eq!(p.get_type("A"), "A"); // ASCII
-        assert_eq!(p.get_type("5"), "N"); // Digit
-        assert_eq!(p.get_type("@"), "O"); // Other
+    fn test_korean_char_types() {
+        let lang = Language::Korean;
+        assert_eq!(lang.char_type('는'), "E"); // Particle (topic marker)
+        assert_eq!(lang.char_type('은'), "E"); // Particle (topic marker)
+        assert_eq!(lang.char_type('을'), "E"); // Particle (object marker)
+        assert_eq!(lang.char_type('를'), "E"); // Particle (object marker)
+        assert_eq!(lang.char_type('의'), "E"); // Particle (possessive)
+        assert_eq!(lang.char_type('에'), "E"); // Particle (locative)
+        assert_eq!(lang.char_type('가'), "SN"); // Hangul Syllable without 받침
+        assert_eq!(lang.char_type('나'), "SN"); // Hangul Syllable without 받침
+        assert_eq!(lang.char_type('하'), "SN"); // Hangul Syllable without 받침
+        assert_eq!(lang.char_type('한'), "SF"); // Hangul Syllable with 받침
+        assert_eq!(lang.char_type('글'), "SF"); // Hangul Syllable with 받침
+        assert_eq!(lang.char_type('각'), "SF"); // Hangul Syllable with 받침
+        assert_eq!(lang.char_type('ㄱ'), "G"); // Compatibility Jamo (consonant)
+        assert_eq!(lang.char_type('ㅏ'), "G"); // Compatibility Jamo (vowel)
+        assert_eq!(lang.char_type('ㅎ'), "G"); // Compatibility Jamo (last consonant)
+        assert_eq!(lang.char_type('\u{1100}'), "J"); // Hangul Jamo (choseong kiyeok)
+        assert_eq!(lang.char_type('\u{1161}'), "J"); // Hangul Jamo (jungseong a)
+        assert_eq!(lang.char_type('漢'), "H"); // Hanja
+        assert_eq!(lang.char_type('。'), "P"); // Punctuation (U+3002)
+        assert_eq!(lang.char_type('A'), "A"); // ASCII
+        assert_eq!(lang.char_type('5'), "N"); // Digit
+        assert_eq!(lang.char_type('@'), "O"); // Other
     }
 }

--- a/litsea/src/perceptron.rs
+++ b/litsea/src/perceptron.rs
@@ -12,17 +12,21 @@ use crate::metrics::MulticlassMetrics;
 ///
 /// スパースな二値特徴に対する多クラス分類を行う。
 /// 学習時に重みの累積平均を保持し、過学習を抑制する。
+///
+/// 重みは「特徴 → クラス別ベクトル」のレイアウトで保持する。
+/// 予測時の参照回数が特徴数×クラス数から特徴数に減り、
+/// 推論のホットパスが大幅に速くなる。
 #[derive(Debug)]
 pub struct AveragedPerceptron {
-    /// クラスごとの重みベクトル: weights\[class\]\[feature\] = weight
-    weights: HashMap<String, HashMap<String, f64>>,
+    /// 特徴ごとの重みベクトル: weights\[feature\]\[class_index\] = weight
+    weights: HashMap<String, Vec<f64>>,
     /// 平均化用の累積重み
-    accumulated: HashMap<String, HashMap<String, f64>>,
+    accumulated: HashMap<String, Vec<f64>>,
     /// 各重みの最終更新タイムスタンプ
-    timestamps: HashMap<String, HashMap<String, usize>>,
+    timestamps: HashMap<String, Vec<usize>>,
     /// 現在のステップ数（全インスタンスの累計）
     step: usize,
-    /// 既知のクラス一覧
+    /// 既知のクラス一覧（常にソート済み）
     classes: Vec<String>,
     /// 学習インスタンス: (特徴量セット, 正解ラベル)
     instances: Vec<(Vec<String>, String)>,
@@ -47,19 +51,66 @@ impl AveragedPerceptron {
         }
     }
 
+    /// クラスを登録し、そのインデックスを返す。
+    /// 新しいクラスはソート順を保って挿入し、既存の重みベクトルにも
+    /// 対応する列を挿入する。
+    fn ensure_class(&mut self, label: &str) -> usize {
+        match self.classes.binary_search_by(|c| c.as_str().cmp(label)) {
+            Ok(i) => i,
+            Err(i) => {
+                self.classes.insert(i, label.to_string());
+                for v in self.weights.values_mut() {
+                    v.insert(i, 0.0);
+                }
+                for v in self.accumulated.values_mut() {
+                    v.insert(i, 0.0);
+                }
+                for v in self.timestamps.values_mut() {
+                    v.insert(i, 0);
+                }
+                i
+            }
+        }
+    }
+
     /// インスタンスを追加する。
     ///
     /// # Arguments
     /// * `features` - 特徴量の集合
     /// * `label` - 正解ラベル
     pub fn add_instance(&mut self, features: HashSet<String>, label: String) {
-        // 新しいクラスを登録
-        if !self.classes.contains(&label) {
-            self.classes.push(label.clone());
-            self.classes.sort();
-        }
+        self.ensure_class(&label);
         let feats: Vec<String> = features.into_iter().collect();
         self.instances.push((feats, label));
+    }
+
+    /// 特徴量集合から最大スコアのクラスのインデックスを返す。
+    /// クラスが未登録の場合はNoneを返す。
+    fn predict_idx<I>(&self, features: I) -> Option<usize>
+    where
+        I: IntoIterator,
+        I::Item: AsRef<str>,
+    {
+        if self.classes.is_empty() {
+            return None;
+        }
+        let mut scores = vec![0.0f64; self.classes.len()];
+        for feat in features {
+            if let Some(ws) = self.weights.get(feat.as_ref()) {
+                for (s, w) in scores.iter_mut().zip(ws.iter()) {
+                    *s += *w;
+                }
+            }
+        }
+        let mut best = 0;
+        let mut best_score = f64::NEG_INFINITY;
+        for (i, s) in scores.iter().enumerate() {
+            if *s > best_score {
+                best_score = *s;
+                best = i;
+            }
+        }
+        Some(best)
     }
 
     /// 特徴量セットからラベルを予測する。
@@ -68,34 +119,34 @@ impl AveragedPerceptron {
     /// クラスが未登録の場合は空文字列を返す。
     #[must_use]
     pub fn predict(&self, features: &HashSet<String>) -> String {
-        if self.classes.is_empty() {
-            return String::new();
+        match self.predict_idx(features.iter()) {
+            Some(i) => self.classes[i].clone(),
+            None => String::new(),
         }
-        let mut best_class = &self.classes[0];
-        let mut best_score = f64::NEG_INFINITY;
-
-        for class in &self.classes {
-            let score = self.score(class, features);
-            if score > best_score {
-                best_score = score;
-                best_class = class;
-            }
-        }
-        best_class.clone()
     }
 
-    /// クラスに対するスコアを計算する。
-    fn score(&self, class: &str, features: &HashSet<String>) -> f64 {
-        let Some(class_weights) = self.weights.get(class) else {
-            return 0.0;
-        };
-        let mut score = 0.0;
-        for feat in features {
-            if let Some(&w) = class_weights.get(feat) {
-                score += w;
-            }
+    /// スライスからラベルを予測する（アロケーション回避用の内部API）。
+    pub(crate) fn predict_slice(&self, features: &[String]) -> &str {
+        match self.predict_idx(features.iter()) {
+            Some(i) => &self.classes[i],
+            None => "",
         }
-        score
+    }
+
+    /// 1つの (特徴, クラス) の重みを更新する。
+    /// 累積重みを現在のステップまで追いつかせてから `delta` を加算する。
+    fn update_single(&mut self, feat: &str, class_idx: usize, delta: f64) {
+        let n = self.classes.len();
+        let ws = self.weights.entry(feat.to_string()).or_insert_with(|| vec![0.0; n]);
+        let ts = self.timestamps.entry(feat.to_string()).or_insert_with(|| vec![0; n]);
+        let acc = self.accumulated.entry(feat.to_string()).or_insert_with(|| vec![0.0; n]);
+
+        let elapsed = self.step - ts[class_idx];
+        if elapsed > 0 {
+            acc[class_idx] += ws[class_idx] * elapsed as f64;
+        }
+        ts[class_idx] = self.step;
+        ws[class_idx] += delta;
     }
 
     /// 重みを更新する（1インスタンス分）。
@@ -103,72 +154,26 @@ impl AveragedPerceptron {
     /// 予測が正解と異なる場合:
     /// - 正解クラスの重みを +1
     /// - 予測クラスの重みを -1
-    fn update(&mut self, truth: &str, guess: &str, features: &[String]) {
-        if truth == guess {
-            return;
-        }
+    fn update(&mut self, truth_idx: usize, guess_idx: usize, features: &[String]) {
         for feat in features {
-            // 正解クラスの累積を更新してから重みを+1
-            self.update_accumulated(truth, feat);
-            *self
-                .weights
-                .entry(truth.to_string())
-                .or_default()
-                .entry(feat.clone())
-                .or_insert(0.0) += 1.0;
-
-            // 予測クラスの累積を更新してから重みを-1
-            self.update_accumulated(guess, feat);
-            *self
-                .weights
-                .entry(guess.to_string())
-                .or_default()
-                .entry(feat.clone())
-                .or_insert(0.0) -= 1.0;
+            self.update_single(feat, truth_idx, 1.0);
+            self.update_single(feat, guess_idx, -1.0);
         }
-    }
-
-    /// 累積重みを最新のステップまで追いつかせる。
-    fn update_accumulated(&mut self, class: &str, feature: &str) {
-        let last_step = self
-            .timestamps
-            .entry(class.to_string())
-            .or_default()
-            .entry(feature.to_string())
-            .or_insert(0);
-        let elapsed = self.step - *last_step;
-        if elapsed > 0 {
-            let current_weight =
-                self.weights.get(class).and_then(|cw| cw.get(feature)).copied().unwrap_or(0.0);
-            *self
-                .accumulated
-                .entry(class.to_string())
-                .or_default()
-                .entry(feature.to_string())
-                .or_insert(0.0) += current_weight * elapsed as f64;
-        }
-        *last_step = self.step;
     }
 
     /// 平均化した重みを最終モデルに反映する。
     fn average_weights(&mut self) {
-        let classes: Vec<String> = self.classes.clone();
-        for class in &classes {
-            let features: Vec<String> = self
-                .weights
-                .get(class)
-                .map(|cw| cw.keys().cloned().collect())
-                .unwrap_or_default();
-            for feat in features {
-                self.update_accumulated(class, &feat);
-                let acc = self
-                    .accumulated
-                    .get(class)
-                    .and_then(|cw| cw.get(&feat))
-                    .copied()
-                    .unwrap_or(0.0);
-                let avg = acc / self.step.max(1) as f64;
-                self.weights.entry(class.to_string()).or_default().insert(feat, avg);
+        let n = self.classes.len();
+        let step = self.step.max(1) as f64;
+        let feats: Vec<String> = self.weights.keys().cloned().collect();
+        for feat in feats {
+            for class_idx in 0..n {
+                // delta 0 の更新で累積重みを現在のステップまで追いつかせる
+                self.update_single(&feat, class_idx, 0.0);
+                let acc = self.accumulated[&feat][class_idx];
+                if let Some(ws) = self.weights.get_mut(&feat) {
+                    ws[class_idx] = acc / step;
+                }
             }
         }
     }
@@ -183,8 +188,9 @@ impl AveragedPerceptron {
             return;
         }
 
-        // インスタンスのコピーを作成（学習中にself.instancesを参照するため）
-        let instances: Vec<(Vec<String>, String)> = self.instances.clone();
+        // インスタンスを一時的に取り出して学習中の二重借用を避ける
+        // （以前はエポックを跨いで全インスタンスを複製していた）。
+        let instances = std::mem::take(&mut self.instances);
 
         for _epoch in 0..num_epochs {
             if !running.load(Ordering::SeqCst) {
@@ -196,12 +202,19 @@ impl AveragedPerceptron {
                     break;
                 }
 
-                let feature_set: HashSet<String> = features.iter().cloned().collect();
-                let guess = self.predict(&feature_set);
-                self.update(truth, &guess, features);
+                let guess_idx = self.predict_idx(features.iter()).expect("classes registered");
+                let truth_idx = self
+                    .classes
+                    .binary_search_by(|c| c.as_str().cmp(truth))
+                    .expect("truth class registered by add_instance");
+                if guess_idx != truth_idx {
+                    self.update(truth_idx, guess_idx, features);
+                }
                 self.step += 1;
             }
         }
+
+        self.instances = instances;
 
         // 平均化した重みを最終モデルに反映
         self.average_weights();
@@ -233,10 +246,10 @@ impl AveragedPerceptron {
         }
 
         // 重み: 非ゼロの重みのみ保存
-        for (class, class_weights) in &self.weights {
-            for (feat, &w) in class_weights {
+        for (feat, ws) in &self.weights {
+            for (class_idx, &w) in ws.iter().enumerate() {
                 if w != 0.0 {
-                    writeln!(file, "{}\t{}\t{}", feat, class, w)?;
+                    writeln!(file, "{}\t{}\t{}", feat, self.classes[class_idx], w)?;
                 }
             }
         }
@@ -289,15 +302,12 @@ impl AveragedPerceptron {
                     )
                 })?
                 .map_err(|e| LitseaError::InvalidData(format!("Read error: {}", e)))?;
-            let class = class.trim().to_string();
-            if !self.classes.contains(&class) {
-                self.classes.push(class);
-            }
+            self.ensure_class(class.trim());
         }
-        self.classes.sort();
 
         // 重みを読む
         self.weights.clear();
+        let n = self.classes.len();
         for line in lines {
             let line = line?;
             let line = line.trim();
@@ -309,14 +319,15 @@ impl AveragedPerceptron {
                 return Err(LitseaError::InvalidData(format!("Invalid weight line: '{}'", line)));
             }
             let feat = parts[0];
-            let class = parts[1];
+            let class_idx =
+                self.classes.binary_search_by(|c| c.as_str().cmp(parts[1])).map_err(|_| {
+                    LitseaError::InvalidData(format!("Unknown class in weight line: '{}'", line))
+                })?;
             let weight: f64 = parts[2]
                 .parse()
                 .map_err(|e| LitseaError::InvalidData(format!("Invalid weight value: {}", e)))?;
-            self.weights
-                .entry(class.to_string())
-                .or_default()
-                .insert(feat.to_string(), weight);
+            self.weights.entry(feat.to_string()).or_insert_with(|| vec![0.0; n])[class_idx] =
+                weight;
         }
 
         Ok(())
@@ -331,13 +342,15 @@ impl AveragedPerceptron {
         let mut total_correct = 0usize;
 
         for (features, truth) in &self.instances {
-            let feature_set: HashSet<String> = features.iter().cloned().collect();
-            let guess = self.predict(&feature_set);
+            let guess = match self.predict_idx(features.iter()) {
+                Some(i) => self.classes[i].as_str(),
+                None => "",
+            };
 
             *gold_per_class.entry(truth.clone()).or_insert(0) += 1;
-            *predicted_per_class.entry(guess.clone()).or_insert(0) += 1;
+            *predicted_per_class.entry(guess.to_string()).or_insert(0) += 1;
 
-            if guess == *truth {
+            if guess == truth {
                 total_correct += 1;
                 *correct_per_class.entry(truth.clone()).or_insert(0) += 1;
             }
@@ -404,6 +417,17 @@ mod tests {
     }
 
     #[test]
+    fn test_classes_stay_sorted() {
+        let mut p = AveragedPerceptron::new();
+        for label in ["C", "A", "B", "A"] {
+            let mut feats = HashSet::new();
+            feats.insert(format!("f_{}", label));
+            p.add_instance(feats, label.to_string());
+        }
+        assert_eq!(p.classes, vec!["A", "B", "C"]);
+    }
+
+    #[test]
     fn test_predict_empty() {
         let p = AveragedPerceptron::new();
         let feats = HashSet::new();
@@ -446,6 +470,8 @@ mod tests {
 
         // 学習が即座に停止しても panic しない
         assert_eq!(p.step, 0);
+        // インスタンスは失われない
+        assert_eq!(p.instances.len(), 1);
     }
 
     #[test]
@@ -483,6 +509,25 @@ mod tests {
         test_b.insert("feat_b".to_string());
         test_b.insert("shared".to_string());
         assert_eq!(p.predict(&test_b), "CLASS_B");
+    }
+
+    #[test]
+    fn test_predict_slice_matches_predict() {
+        let mut p = AveragedPerceptron::new();
+        let mut feats_a = HashSet::new();
+        feats_a.insert("f1".to_string());
+        p.add_instance(feats_a.clone(), "A".to_string());
+        let mut feats_b = HashSet::new();
+        feats_b.insert("f2".to_string());
+        p.add_instance(feats_b.clone(), "B".to_string());
+
+        let running = Arc::new(AtomicBool::new(true));
+        p.train(10, running);
+
+        let slice_a: Vec<String> = feats_a.iter().cloned().collect();
+        assert_eq!(p.predict_slice(&slice_a), p.predict(&feats_a));
+        let slice_b: Vec<String> = feats_b.iter().cloned().collect();
+        assert_eq!(p.predict_slice(&slice_b), p.predict(&feats_b));
     }
 
     #[test]

--- a/litsea/src/segmenter.rs
+++ b/litsea/src/segmenter.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
+use std::fmt::Write as _;
 
 use crate::adaboost::AdaBoost;
-use crate::language::{CharTypePatterns, Language};
+use crate::language::Language;
 use crate::perceptron::AveragedPerceptron;
 use crate::upos::{SegmentLabel, Upos};
 
@@ -9,7 +10,6 @@ use crate::upos::{SegmentLabel, Upos};
 /// It uses predefined patterns to classify characters and segment sentences into words.
 pub struct Segmenter {
     language: Language,
-    char_types: CharTypePatterns,
     learner: AdaBoost,
     /// 品詞推定用のAveraged Perceptron（オプション）
     pos_learner: Option<AveragedPerceptron>,
@@ -34,7 +34,6 @@ impl Segmenter {
     /// ```
     pub fn new(language: Language, learner: Option<AdaBoost>) -> Self {
         Segmenter {
-            char_types: language.char_type_patterns(),
             language,
             learner: learner.unwrap_or_else(|| AdaBoost::new(0.01, 100)),
             pos_learner: None,
@@ -51,7 +50,6 @@ impl Segmenter {
     /// A new Segmenter instance configured for joint segmentation + POS tagging.
     pub fn with_pos_learner(language: Language, pos_learner: AveragedPerceptron) -> Self {
         Segmenter {
-            char_types: language.char_type_patterns(),
             language,
             learner: AdaBoost::new(0.01, 100),
             pos_learner: Some(pos_learner),
@@ -106,7 +104,10 @@ impl Segmenter {
     /// ```
     #[must_use]
     pub fn char_type(&self, ch: &str) -> &str {
-        self.char_types.get_type(ch)
+        match ch.chars().next() {
+            Some(c) => self.language.char_type(c),
+            None => "O",
+        }
     }
 
     /// Builds the padded character and character-type arrays for a text.
@@ -114,16 +115,15 @@ impl Segmenter {
     /// Returns `(chars, types)` where the first three entries are the B3/B2/B1
     /// head sentinels and the last three are the E1/E2/E3 tail sentinels, so
     /// real characters occupy indices `3..chars.len() - 3`.
-    fn sentence_context(&self, text: &str) -> (Vec<String>, Vec<String>) {
+    fn sentence_context(&self, text: &str) -> (Vec<String>, Vec<&'static str>) {
         let mut chars = vec!["B3".to_string(), "B2".to_string(), "B1".to_string()];
-        let mut types = vec!["O".to_string(); 3];
+        let mut types: Vec<&'static str> = vec!["O"; 3];
         for ch in text.chars() {
-            let s = ch.to_string();
-            types.push(self.char_type(&s).to_string());
-            chars.push(s);
+            types.push(self.language.char_type(ch));
+            chars.push(ch.to_string());
         }
         chars.extend_from_slice(&["E1".into(), "E2".into(), "E3".into()]);
-        types.extend_from_slice(&["O".into(), "O".into(), "O".into()]);
+        types.extend_from_slice(&["O", "O", "O"]);
         (chars, types)
     }
 
@@ -142,8 +142,8 @@ impl Segmenter {
         F: FnMut(HashSet<String>, L),
     {
         // Padding for lookback: tags[i-3], tags[i-2], tags[i-1] are referenced by
-        // get_attributes(). The real characters' tags follow the padding.
-        let mut tags = vec!["U".to_string(); 3];
+        // the attribute builder. The real characters' tags follow the padding.
+        let mut tags: Vec<&'static str> = vec!["U"; 3];
         let mut labels: Vec<L> = Vec::new();
         let mut text = String::new();
 
@@ -152,10 +152,10 @@ impl Segmenter {
             if char_count == 0 {
                 continue;
             }
-            tags.push("B".to_string());
+            tags.push("B");
             labels.push(label);
             for _ in 1..char_count {
-                tags.push("O".to_string());
+                tags.push("O");
                 labels.push(cont_label.clone());
             }
             text.push_str(word);
@@ -166,7 +166,7 @@ impl Segmenter {
         }
         // Override the first real character's tag to "U" (Unknown) instead of "B",
         // because there is no preceding word boundary decision to reference at position 0.
-        tags[3] = "U".to_string();
+        tags[3] = "U";
 
         let (chars, types) = self.sentence_context(&text);
 
@@ -334,21 +334,30 @@ impl Segmenter {
         }
         let learner = &self.learner;
         let (chars, types) = self.sentence_context(sentence);
-        // Padding for lookback: tags[0..3] are fixed "U" (Unknown) for get_attributes(),
-        // and tags[3] is also "U" since there is no boundary decision before the first character.
-        let mut tags = vec!["U".to_string(); 4];
+        // Padding for lookback: tags[0..3] are fixed "U" (Unknown), and tags[3]
+        // is also "U" since there is no boundary decision before the first character.
+        let mut tags: Vec<&'static str> = vec!["U"; 4];
+
+        // The bias is a sum over all model weights; compute it once per
+        // sentence instead of once per character.
+        let bias = learner.bias();
 
         let mut result = Vec::new();
         let mut word = chars[3].clone();
-        for i in 4..(chars.len() - 3) {
-            let label = learner.predict(&self.get_attributes(i, &tags, &chars, &types));
-            if label >= 0 {
+        for (i, ch) in chars.iter().enumerate().take(chars.len() - 3).skip(4) {
+            // Sum the weights of the attributes directly instead of building
+            // a HashSet per position.
+            let mut score = bias;
+            self.write_attributes(i, &tags, &chars, &types, &mut |attr| {
+                score += learner.weight(attr);
+            });
+            if score >= 0.0 {
                 result.push(std::mem::take(&mut word));
-                tags.push("B".to_string());
+                tags.push("B");
             } else {
-                tags.push("O".to_string());
+                tags.push("O");
             }
-            word += &chars[i];
+            word += ch;
         }
         result.push(word);
         result
@@ -380,29 +389,31 @@ impl Segmenter {
             .expect("pos_learner is not set. Use with_pos_learner() or add_corpus_with_pos().");
 
         let (chars, types) = self.sentence_context(sentence);
-        let mut tags = vec!["U".to_string(); 4];
-
-        let predict = |i: usize, tags: &[String]| -> SegmentLabel {
-            let attrs = self.get_attributes(i, tags, &chars, &types);
-            pos_learner.predict(&attrs).parse().unwrap_or(SegmentLabel::O)
-        };
+        let mut tags: Vec<&'static str> = vec!["U"; 4];
+        // Attribute buffer reused across positions to amortize allocations.
+        let mut attrs_buf: Vec<String> = Vec::new();
 
         // The first character always starts the first word; its predicted
         // label is used only to determine the first word's POS.
-        let mut current_pos = predict(3, &tags).pos().unwrap_or(Upos::X);
+        self.collect_attributes(3, &tags, &chars, &types, &mut attrs_buf);
+        let first_label: SegmentLabel =
+            pos_learner.predict_slice(&attrs_buf).parse().unwrap_or(SegmentLabel::O);
+        let mut current_pos = first_label.pos().unwrap_or(Upos::X);
 
         let mut result: Vec<(String, Upos)> = Vec::new();
         let mut word = chars[3].clone();
 
         for (i, ch) in chars.iter().enumerate().take(chars.len() - 3).skip(4) {
-            let label = predict(i, &tags);
+            self.collect_attributes(i, &tags, &chars, &types, &mut attrs_buf);
+            let label: SegmentLabel =
+                pos_learner.predict_slice(&attrs_buf).parse().unwrap_or(SegmentLabel::O);
             if label.is_boundary() {
                 // 現在の単語を確定して結果に追加
                 result.push((std::mem::take(&mut word), current_pos));
                 current_pos = label.pos().unwrap_or(Upos::X);
-                tags.push("B".to_string());
+                tags.push("B");
             } else {
-                tags.push("O".to_string());
+                tags.push("O");
             }
             word += ch;
         }
@@ -411,104 +422,136 @@ impl Segmenter {
         result
     }
 
-    /// Gets the attributes for a specific index in the character and type arrays.
-    ///
-    /// # Arguments
-    /// * `i` - The index for which to get the attributes.
-    /// * `tags` - A slice of strings representing the tags for each character.
-    /// * `chars` - A slice of strings representing the characters in the sentence.
-    /// * `types` - A slice of strings representing the types of each character.
-    ///
-    /// # Returns
-    /// A HashSet of strings representing the attributes for the specified index.
-    ///
-    /// # Panics
-    /// Panics if `i` is less than 3 or if `i + 2` exceeds the length of `chars` or `types`.
-    /// Callers must ensure that `i` is within the valid range `[3, chars.len() - 3)`.
-    ///
-    /// # Note
-    /// The attributes are constructed based on the surrounding characters and their types, allowing for rich feature extraction.
-    /// This method is used internally by the segmenter to create features for each character in the sentence.
-    #[must_use]
+    /// Builds the attribute set for a specific index (used by the corpus
+    /// processing pipeline, where the public callbacks expect a `HashSet`).
     fn get_attributes(
         &self,
         i: usize,
-        tags: &[String],
+        tags: &[&'static str],
         chars: &[String],
-        types: &[String],
+        types: &[&'static str],
     ) -> HashSet<String> {
+        let mut attrs = HashSet::with_capacity(48);
+        self.write_attributes(i, tags, chars, types, &mut |attr| {
+            attrs.insert(attr.to_string());
+        });
+        attrs
+    }
+
+    /// Collects the attributes for a position into a reusable `Vec<String>`,
+    /// reusing the existing string allocations where possible.
+    fn collect_attributes(
+        &self,
+        i: usize,
+        tags: &[&'static str],
+        chars: &[String],
+        types: &[&'static str],
+        out: &mut Vec<String>,
+    ) {
+        let mut idx = 0;
+        self.write_attributes(i, tags, chars, types, &mut |attr| {
+            if idx < out.len() {
+                out[idx].clear();
+                out[idx].push_str(attr);
+            } else {
+                out.push(attr.to_string());
+            }
+            idx += 1;
+        });
+        out.truncate(idx);
+    }
+
+    /// Writes each attribute for position `i` into a reusable buffer and
+    /// passes it to `sink`. This is the single source of truth for the
+    /// feature template.
+    ///
+    /// # Panics
+    /// Panics if `i` is less than 3 or if `i + 2` exceeds the length of
+    /// `chars` or `types`. Callers must ensure that `i` is within the valid
+    /// range `[3, chars.len() - 3)`.
+    fn write_attributes(
+        &self,
+        i: usize,
+        tags: &[&'static str],
+        chars: &[String],
+        types: &[&'static str],
+        sink: &mut dyn FnMut(&str),
+    ) {
         let w1 = &chars[i - 3];
         let w2 = &chars[i - 2];
         let w3 = &chars[i - 1];
         let w4 = &chars[i];
         let w5 = &chars[i + 1];
         let w6 = &chars[i + 2];
-        let c1 = &types[i - 3];
-        let c2 = &types[i - 2];
-        let c3 = &types[i - 1];
-        let c4 = &types[i];
-        let c5 = &types[i + 1];
-        let c6 = &types[i + 2];
-        let p1 = &tags[i - 3];
-        let p2 = &tags[i - 2];
-        let p3 = &tags[i - 1];
+        let c1 = types[i - 3];
+        let c2 = types[i - 2];
+        let c3 = types[i - 1];
+        let c4 = types[i];
+        let c5 = types[i + 1];
+        let c6 = types[i + 2];
+        let p1 = tags[i - 3];
+        let p2 = tags[i - 2];
+        let p3 = tags[i - 1];
 
-        let mut attrs: HashSet<String> = [
-            format!("UP1:{}", p1),
-            format!("UP2:{}", p2),
-            format!("UP3:{}", p3),
-            format!("BP1:{}{}", p1, p2),
-            format!("BP2:{}{}", p2, p3),
-            format!("UW1:{}", w1),
-            format!("UW2:{}", w2),
-            format!("UW3:{}", w3),
-            format!("UW4:{}", w4),
-            format!("UW5:{}", w5),
-            format!("UW6:{}", w6),
-            format!("BW1:{}{}", w2, w3),
-            format!("BW2:{}{}", w3, w4),
-            format!("BW3:{}{}", w4, w5),
-            format!("UC1:{}", c1),
-            format!("UC2:{}", c2),
-            format!("UC3:{}", c3),
-            format!("UC4:{}", c4),
-            format!("UC5:{}", c5),
-            format!("UC6:{}", c6),
-            format!("BC1:{}{}", c2, c3),
-            format!("BC2:{}{}", c3, c4),
-            format!("BC3:{}{}", c4, c5),
-            format!("TC1:{}{}{}", c1, c2, c3),
-            format!("TC2:{}{}{}", c2, c3, c4),
-            format!("TC3:{}{}{}", c3, c4, c5),
-            format!("TC4:{}{}{}", c4, c5, c6),
-            format!("UQ1:{}{}", p1, c1),
-            format!("UQ2:{}{}", p2, c2),
-            format!("UQ3:{}{}", p3, c3),
-            format!("BQ1:{}{}{}", p2, c2, c3),
-            format!("BQ2:{}{}{}", p2, c3, c4),
-            format!("BQ3:{}{}{}", p3, c2, c3),
-            format!("BQ4:{}{}{}", p3, c3, c4),
-            format!("TQ1:{}{}{}{}", p2, c1, c2, c3),
-            format!("TQ2:{}{}{}{}", p2, c2, c3, c4),
-            format!("TQ3:{}{}{}{}", p3, c1, c2, c3),
-            format!("TQ4:{}{}{}{}", p3, c2, c3, c4),
-        ]
-        .into_iter()
-        .collect();
+        let mut buf = String::with_capacity(32);
+        macro_rules! attr {
+            ($($arg:tt)*) => {{
+                buf.clear();
+                let _ = write!(buf, $($arg)*);
+                sink(&buf);
+            }};
+        }
+
+        attr!("UP1:{}", p1);
+        attr!("UP2:{}", p2);
+        attr!("UP3:{}", p3);
+        attr!("BP1:{}{}", p1, p2);
+        attr!("BP2:{}{}", p2, p3);
+        attr!("UW1:{}", w1);
+        attr!("UW2:{}", w2);
+        attr!("UW3:{}", w3);
+        attr!("UW4:{}", w4);
+        attr!("UW5:{}", w5);
+        attr!("UW6:{}", w6);
+        attr!("BW1:{}{}", w2, w3);
+        attr!("BW2:{}{}", w3, w4);
+        attr!("BW3:{}{}", w4, w5);
+        attr!("UC1:{}", c1);
+        attr!("UC2:{}", c2);
+        attr!("UC3:{}", c3);
+        attr!("UC4:{}", c4);
+        attr!("UC5:{}", c5);
+        attr!("UC6:{}", c6);
+        attr!("BC1:{}{}", c2, c3);
+        attr!("BC2:{}{}", c3, c4);
+        attr!("BC3:{}{}", c4, c5);
+        attr!("TC1:{}{}{}", c1, c2, c3);
+        attr!("TC2:{}{}{}", c2, c3, c4);
+        attr!("TC3:{}{}{}", c3, c4, c5);
+        attr!("TC4:{}{}{}", c4, c5, c6);
+        attr!("UQ1:{}{}", p1, c1);
+        attr!("UQ2:{}{}", p2, c2);
+        attr!("UQ3:{}{}", p3, c3);
+        attr!("BQ1:{}{}{}", p2, c2, c3);
+        attr!("BQ2:{}{}{}", p2, c3, c4);
+        attr!("BQ3:{}{}{}", p3, c2, c3);
+        attr!("BQ4:{}{}{}", p3, c3, c4);
+        attr!("TQ1:{}{}{}{}", p2, c1, c2, c3);
+        attr!("TQ2:{}{}{}{}", p2, c2, c3, c4);
+        attr!("TQ3:{}{}{}{}", p3, c1, c2, c3);
+        attr!("TQ4:{}{}{}{}", p3, c2, c3, c4);
 
         // Language-specific features: char + char-type mixed features for Japanese and Chinese.
         // Korean is excluded because its uniform character types (SN/SF only) make these features noise.
         match self.language {
             Language::Japanese | Language::Chinese => {
-                attrs.insert(format!("WC1:{}{}", w3, c4));
-                attrs.insert(format!("WC2:{}{}", c3, w4));
-                attrs.insert(format!("WC3:{}{}", w3, c3));
-                attrs.insert(format!("WC4:{}{}", w4, c4));
+                attr!("WC1:{}{}", w3, c4);
+                attr!("WC2:{}{}", c3, w4);
+                attr!("WC3:{}{}", w3, c3);
+                attr!("WC4:{}{}", w4, c4);
             }
             _ => {}
         }
-
-        attrs
     }
 }
 
@@ -530,6 +573,7 @@ mod tests {
         assert_eq!(segmenter.char_type("A"), "A"); // Latin
         assert_eq!(segmenter.char_type("1"), "N"); // Digit
         assert_eq!(segmenter.char_type("@"), "O"); // Not matching any pattern
+        assert_eq!(segmenter.char_type(""), "O"); // Empty string
     }
 
     #[test]
@@ -593,14 +637,14 @@ mod tests {
         // Should not panic or add anything, just a smoke test
     }
 
-    #[tokio::test]
-    async fn test_segment() {
+    #[test]
+    fn test_segment() {
         let sentence = "これはテストです。";
 
         let model_file =
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../models").join("RWCP.model");
         let mut learner = AdaBoost::new(0.01, 100);
-        learner.load_model(model_file.to_str().unwrap()).await.unwrap();
+        learner.load_model_from_path(&model_file).unwrap();
 
         let segmenter = Segmenter::new(Language::Japanese, Some(learner));
 
@@ -635,7 +679,7 @@ mod tests {
     fn test_get_attributes() {
         let segmenter = Segmenter::new(Language::Japanese, None);
 
-        let tags = vec!["U".to_string(); 7];
+        let tags: Vec<&'static str> = vec!["U"; 7];
 
         let chars = vec![
             "B3".to_string(), // index 0
@@ -647,15 +691,7 @@ mod tests {
             "E1".to_string(), // index 6
         ];
 
-        let types = vec![
-            "O".to_string(), // index 0
-            "O".to_string(), // index 1
-            "O".to_string(), // index 2
-            "O".to_string(), // index 3
-            "I".to_string(), // index 4
-            "I".to_string(), // index 5
-            "O".to_string(), // index 6
-        ];
+        let types: Vec<&'static str> = vec!["O", "O", "O", "O", "I", "I", "O"];
 
         let attrs = segmenter.get_attributes(4, &tags, &chars, &types);
         assert!(attrs.contains("UW4:い"));
@@ -671,10 +707,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn test_get_attributes_panics_index_too_low() {
+    fn test_collect_attributes_reuses_buffer() {
         let segmenter = Segmenter::new(Language::Japanese, None);
-        let tags = vec!["U".to_string(); 7];
+        let tags: Vec<&'static str> = vec!["U"; 7];
         let chars = vec![
             "B3".to_string(),
             "B2".to_string(),
@@ -684,7 +719,36 @@ mod tests {
             "う".to_string(),
             "E1".to_string(),
         ];
-        let types = vec!["O".to_string(); 7];
+        let types: Vec<&'static str> = vec!["O", "O", "O", "O", "I", "I", "O"];
+
+        let mut buf: Vec<String> = Vec::new();
+        segmenter.collect_attributes(4, &tags, &chars, &types, &mut buf);
+        assert_eq!(buf.len(), 42);
+        // The slice contents must match the HashSet variant.
+        let set = segmenter.get_attributes(4, &tags, &chars, &types);
+        for attr in &buf {
+            assert!(set.contains(attr), "missing from set: {}", attr);
+        }
+        // A second collection reuses the buffer and yields the same result.
+        segmenter.collect_attributes(4, &tags, &chars, &types, &mut buf);
+        assert_eq!(buf.len(), 42);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_get_attributes_panics_index_too_low() {
+        let segmenter = Segmenter::new(Language::Japanese, None);
+        let tags: Vec<&'static str> = vec!["U"; 7];
+        let chars = vec![
+            "B3".to_string(),
+            "B2".to_string(),
+            "B1".to_string(),
+            "あ".to_string(),
+            "い".to_string(),
+            "う".to_string(),
+            "E1".to_string(),
+        ];
+        let types: Vec<&'static str> = vec!["O"; 7];
         // i=2 is out of valid range [3, chars.len()-3); should panic on chars[i-3]
         let _ = segmenter.get_attributes(2, &tags, &chars, &types);
     }
@@ -693,7 +757,7 @@ mod tests {
     #[should_panic]
     fn test_get_attributes_panics_index_too_high() {
         let segmenter = Segmenter::new(Language::Japanese, None);
-        let tags = vec!["U".to_string(); 7];
+        let tags: Vec<&'static str> = vec!["U"; 7];
         let chars = vec![
             "B3".to_string(),
             "B2".to_string(),
@@ -703,7 +767,7 @@ mod tests {
             "う".to_string(),
             "E1".to_string(),
         ];
-        let types = vec!["O".to_string(); 7];
+        let types: Vec<&'static str> = vec!["O"; 7];
         // i=5 means i+2=7 which exceeds chars.len()=7; should panic on chars[i+2]
         let _ = segmenter.get_attributes(5, &tags, &chars, &types);
     }
@@ -712,7 +776,7 @@ mod tests {
     fn test_get_attributes_korean() {
         let segmenter = Segmenter::new(Language::Korean, None);
 
-        let tags = vec!["U".to_string(); 7];
+        let tags: Vec<&'static str> = vec!["U"; 7];
 
         let chars = vec![
             "B3".to_string(), // index 0
@@ -724,15 +788,7 @@ mod tests {
             "E1".to_string(), // index 6
         ];
 
-        let types = vec![
-            "O".to_string(),  // index 0
-            "O".to_string(),  // index 1
-            "O".to_string(),  // index 2
-            "SF".to_string(), // index 3
-            "SF".to_string(), // index 4
-            "SN".to_string(), // index 5
-            "O".to_string(),  // index 6
-        ];
+        let types: Vec<&'static str> = vec!["O", "O", "O", "SF", "SF", "SN", "O"];
 
         let attrs = segmenter.get_attributes(4, &tags, &chars, &types);
         assert!(attrs.contains("UW4:국"));


### PR DESCRIPTION
## Summary

Phase 4 of `REFACTORING_PLAN.md`: hot-path performance optimization. **Behavior-preserving** — all 10 golden snapshots pass unchanged and the on-disk model format is untouched (round-trip tests green).

## Benchmark results (criterion median, vs the Phase 0 / v0.4.0 baseline)

| Benchmark | Before | After | Change |
|---|---|---|---|
| `segment_long_japanese` (averaged_perceptron) | **4.48 s** | **396 ms** | **-91%** |
| `segment_long_japanese` (adaboost) | 611 ms | 215 ms | -65% |
| `segment_short` averaged_perceptron (ja/zh/ko) | 293 / 211 / 286 µs | 30.8 / 25.8 / 33.3 µs | -88…90% |
| `segment_short` adaboost (ja/zh/ko) | 56.8 / 37.1 / 51.3 µs | 17.1 / 12.9 / 17.1 µs | -66…70% |
| Character classification | 61 ns | 9.4 ns | -85% |
| `add_corpus` | 161 µs | 104 µs | -37% |

## Changes

### Character classification → `match` (drops the `regex` dependency)
`CharTypePatterns` ran each character through a linear scan of up to 9 regexes (and the caller converted `char` → `String` first). It is replaced by `Language::char_type(char) -> &'static str`, a direct `match` on char ranges. The P/A/N patterns that were copy-pasted across the three languages (duplication D6) now live in one helper. **`regex` is no longer a dependency.**

### Perceptron weight layout transposed
`HashMap<class, HashMap<feature, weight>>` → `HashMap<feature, Vec<weight; num_classes>>`. Per-position hash lookups drop from features × classes (~756) to features (~42). The class list stays sorted, so argmax tie-breaking is identical.

### Allocation-free attribute scoring
The 42-entry feature template now lives in a single `write_attributes()` that streams each attribute through one reused buffer:
- `segment()` sums AdaBoost weights directly — no `HashSet` per position — and computes the bias **once per sentence** instead of once per character (the bias is a sum over *all* model weights, so this alone removed an O(model size) cost per character).
- `segment_with_pos()` reuses a `Vec<String>` attribute buffer across positions.
- `tags`/`types` are `&'static str` instead of heap `String`s.
- The public corpus/writer APIs still receive `HashSet<String>` as before.

### Training loop
`AveragedPerceptron::train` no longer clones all instances (`mem::take` + restore) and no longer rebuilds a `HashSet` per instance per epoch.

### API note (folded into the unreleased v0.5.0 breaking set)
`CharTypePatterns` and `Language::char_type_patterns()` are removed in favor of `Language::char_type(char)`. `Segmenter::char_type(&str)` is unchanged. CHANGELOG updated.

Deliberately skipped (documented in the plan): converting `chars: Vec<String>` to `Vec<char>` — the sentinel representation complexity outweighs the remaining gains.

## Verification

- `cargo test --workspace`: 78 lib + 10 golden + 6 CLI + 6 doc tests, all green — golden snapshots byte-identical
- `cargo clippy --workspace --all-targets -- -D warnings` / `cargo fmt --check` clean
- `cargo check -p litsea --no-default-features` and wasm32 check pass

https://claude.ai/code/session_01V7mvuY55PG8Q7zKhMC62hJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7mvuY55PG8Q7zKhMC62hJ)_