### PR TITLE
fix: validate model files on load and harden remote downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,18 @@ compatible: all pre-trained models in `models/` load unchanged.
   skipped consistently by both feature-file passes. Note: legacy
   hand-written space-separated features files are no longer accepted; the
   `extract` command has always produced tab-separated output (#99).
+- Model loading now fails loudly on corrupt data instead of silently
+  producing a broken model: both loaders reject non-finite weights
+  (`NaN`/`inf`, which poisoned every score comparison), and the AdaBoost
+  loader validates the file format — empty files, files without a bias
+  line (the typical symptom of a truncated download), duplicate bias
+  lines, and duplicate feature lines are rejected. Weight lines after the
+  bias line remain accepted for legacy models (e.g. `RWCP.model`).
+  `AveragedPerceptron::load_model_from_reader` also resets the averaging
+  accumulators so an incremental train after a load no longer mixes stale
+  state into the averaged weights. Remote downloads gained a 10 s connect /
+  60 s request timeout, a 256 MiB size cap, and Content-Length
+  verification (#101).
 - The POS training pipeline never emitted the first character position of a
   sentence, while `segment_with_pos` predicts at that position to derive
   the first word's POS (since the Phase 2 fix). Sentence-initial sentinel

--- a/docs/src/advanced/model-file-format.md
+++ b/docs/src/advanced/model-file-format.md
@@ -31,8 +31,30 @@ UC4:I	0.2345
 When loading a model, the bias is reconstructed using:
 
 ```text
-bias_bucket_weight = -bias_value * 2 - sum(all_feature_weights)
+bias_bucket_weight = -bias_value * 2 - sum(feature_weights_before_the_bias_line)
 ```
+
+Files written by `save_model` always place the bias line last, so this equals
+the sum of all feature weights. Legacy models (e.g. `RWCP.model`) place the
+bias line mid-file; their trailing weight lines are accepted and the bias
+bucket is computed from the weights preceding the bias line, matching the
+historical loader.
+
+## Validation
+
+The loader rejects malformed files with an explicit error instead of loading
+them silently:
+
+- an **empty file**
+- a file **without a bias line** (the typical symptom of a truncated
+  download or interrupted copy)
+- **more than one** bias line
+- **duplicate** feature lines
+- **non-finite** weights or bias values (`NaN`, `inf`, `-inf`), which would
+  otherwise poison every score comparison
+
+The Averaged Perceptron model loader likewise validates its class-count
+header and rejects non-finite weights.
 
 During prediction:
 

--- a/docs/src/advanced/remote-model-loading.md
+++ b/docs/src/advanced/remote-model-loading.md
@@ -36,6 +36,19 @@ learner.load_model("https://example.com/models/japanese.model").await?;
 - The `load_model` method is **async** because HTTP loading requires an async runtime
 - For the CLI, `tokio` provides the async runtime
 
+## Limits and Failure Handling
+
+- **Connect timeout**: 10 seconds; **overall request timeout**: 60 seconds --
+  a stalled server can no longer block model loading indefinitely
+- **Maximum model size**: 256 MiB. A larger advertised `Content-Length` is
+  rejected before the body is read, and an oversized body is rejected after
+- **Incomplete downloads**: when the server sends a `Content-Length`, a
+  shorter received body is reported as an incomplete download
+- Non-2xx responses are reported as download errors with the HTTP status
+- The model parser additionally rejects truncated files (a model without its
+  trailing bias line fails to load; see
+  [Model File Format](model-file-format.md))
+
 ## WASM Considerations
 
 On `wasm32` targets:

--- a/litsea/src/adaboost.rs
+++ b/litsea/src/adaboost.rs
@@ -395,10 +395,23 @@ impl AdaBoost {
     /// * `reader`: A buffered reader containing the model data.
     ///
     /// # Errors
-    /// Returns an error if the content cannot be parsed.
+    /// Returns `LitseaError::InvalidData` if the content cannot be parsed or
+    /// violates the model format: the file must consist of unique
+    /// tab-separated weight lines plus exactly one bias line (a single
+    /// number), and every value must be finite. An empty file, a file
+    /// without a bias line (e.g. a truncated download), or a file with more
+    /// than one bias line is rejected. The learner is not modified on error.
+    ///
+    /// `save_model` always writes the bias line last; weight lines after the
+    /// bias line are nevertheless accepted for compatibility with legacy
+    /// models (e.g. `RWCP.model`), with the bias-bucket weight computed from
+    /// the weights preceding the bias line exactly as the historical loader
+    /// did.
     pub fn load_model_from_reader<R: BufRead>(&mut self, reader: R) -> Result<()> {
         let mut m: HashMap<String, f64> = HashMap::new();
-        let mut bias = 0.0;
+        let mut weight_sum = 0.0;
+        let mut bias_seen = false;
+        let mut any_line = false;
 
         for (line_num, line) in reader.lines().enumerate() {
             let line = line?;
@@ -408,6 +421,7 @@ impl AdaBoost {
                     line_num + 1
                 )));
             }
+            any_line = true;
             // Model lines are tab-separated ("feature\tweight", written by
             // save_model); feature names may embed any non-tab character.
             let mut parts = line.split('\t');
@@ -424,9 +438,28 @@ impl AdaBoost {
                         e
                     ))
                 })?;
-                m.insert(h.to_string(), value);
-                bias += value;
+                if !value.is_finite() {
+                    return Err(LitseaError::InvalidData(format!(
+                        "Non-finite weight at line {}: {}",
+                        line_num + 1,
+                        v
+                    )));
+                }
+                if m.insert(h.to_string(), value).is_some() {
+                    return Err(LitseaError::InvalidData(format!(
+                        "Duplicate feature at line {}: '{}'",
+                        line_num + 1,
+                        h
+                    )));
+                }
+                weight_sum += value;
             } else {
+                if bias_seen {
+                    return Err(LitseaError::InvalidData(format!(
+                        "Duplicate bias line at line {}",
+                        line_num + 1
+                    )));
+                }
                 let b: f64 = h.parse().map_err(|e| {
                     LitseaError::InvalidData(format!(
                         "Invalid bias at line {}: {}",
@@ -434,8 +467,29 @@ impl AdaBoost {
                         e
                     ))
                 })?;
-                m.insert("".to_string(), -b * 2.0 - bias);
+                if !b.is_finite() {
+                    return Err(LitseaError::InvalidData(format!(
+                        "Non-finite bias at line {}: {}",
+                        line_num + 1,
+                        h
+                    )));
+                }
+                bias_seen = true;
+                // Reconstruct the bias-bucket weight from the bias value and
+                // the running sum of the weights seen so far (the inverse of
+                // save_model's computation; also matches the historical
+                // loader for legacy files whose bias line is not last).
+                m.insert("".to_string(), -b * 2.0 - weight_sum);
             }
+        }
+
+        if !any_line {
+            return Err(LitseaError::InvalidData("Empty model file".to_string()));
+        }
+        if !bias_seen {
+            return Err(LitseaError::InvalidData(
+                "Model file has no bias line; the file may be truncated".to_string(),
+            ));
         }
 
         // A learner is "fresh" when it holds no instances and no real
@@ -852,11 +906,64 @@ mod tests {
 
     #[test]
     fn test_load_model_from_reader_empty_input() {
+        // #101: an empty model file is rejected (consistent with the
+        // perceptron loader), and the learner state stays untouched.
         let mut learner = AdaBoost::new(0.01, 10);
-        // Empty input should succeed, leaving only the bias bucket registered.
         let result = learner.load_model_from_reader("".as_bytes());
-        assert!(result.is_ok());
+        assert!(matches!(result, Err(LitseaError::InvalidData(_))));
         assert_eq!(learner.features, vec![String::new()]);
+    }
+
+    #[test]
+    fn test_load_model_rejects_nonfinite_weight() {
+        // #101: NaN/inf parse successfully as f64 but poison bias() and every
+        // score comparison; they must be rejected at load time.
+        for content in ["feat1\tNaN\n0.0\n", "feat1\tinf\n0.0\n"] {
+            let mut learner = AdaBoost::new(0.01, 10);
+            let result = learner.load_model_from_reader(content.as_bytes());
+            assert!(
+                matches!(result, Err(LitseaError::InvalidData(_))),
+                "expected InvalidData for {:?}",
+                content
+            );
+        }
+    }
+
+    #[test]
+    fn test_load_model_rejects_nonfinite_bias() {
+        let mut learner = AdaBoost::new(0.01, 10);
+        let result = learner.load_model_from_reader("feat1\t0.5\n-inf\n".as_bytes());
+        assert!(matches!(result, Err(LitseaError::InvalidData(_))));
+    }
+
+    #[test]
+    fn test_load_model_allows_weight_lines_after_bias() {
+        // #101: save_model always writes the bias line last, but legacy
+        // models (e.g. the shipped RWCP.model) place it mid-file. Such files
+        // must keep loading, with the bias bucket computed from the weights
+        // preceding the bias line (the historical loader's semantics).
+        let mut learner = AdaBoost::new(0.01, 10);
+        learner.load_model_from_reader("0.5\nfeat1\t0.5\n".as_bytes()).unwrap();
+        // Bias bucket from the bias line only: -0.5 * 2 - 0 = -1.0.
+        let bias_idx = learner.feature_index[""];
+        assert!((learner.model[bias_idx] + 1.0).abs() < 1e-9);
+        assert!(learner.feature_index.contains_key("feat1"));
+    }
+
+    #[test]
+    fn test_load_model_rejects_double_bias() {
+        let mut learner = AdaBoost::new(0.01, 10);
+        let result = learner.load_model_from_reader("feat1\t0.5\n0.1\n0.2\n".as_bytes());
+        assert!(matches!(result, Err(LitseaError::InvalidData(_))));
+    }
+
+    #[test]
+    fn test_load_model_rejects_duplicate_feature() {
+        // save_model never emits the same feature twice; a duplicate would
+        // make the reconstructed bias-bucket weight inconsistent.
+        let mut learner = AdaBoost::new(0.01, 10);
+        let result = learner.load_model_from_reader("feat1\t0.5\nfeat1\t0.25\n0.0\n".as_bytes());
+        assert!(matches!(result, Err(LitseaError::InvalidData(_))));
     }
 
     #[test]
@@ -915,15 +1022,15 @@ mod tests {
 
     #[test]
     fn test_load_model_without_bias_line() {
-        // Regression test for #98: a model file consisting only of weight
-        // lines (no trailing bias line) must still leave the bias feature ""
-        // registered at index 0.
+        // #101 (supersedes the lenient #98 expectation): save_model always
+        // writes a trailing bias line, so a file without one indicates
+        // truncation (e.g. a partial download) and must be rejected instead
+        // of loading silently with a wrong bias.
         let mut learner = AdaBoost::new(0.01, 10);
-        learner.load_model_from_reader("feat1\t0.5\nfeat2\t-0.25\n".as_bytes()).unwrap();
-        assert_eq!(learner.features.first().map(String::as_str), Some(""));
-        assert_eq!(learner.feature_index.get(""), Some(&0));
-        assert!(learner.feature_index.contains_key("feat1"));
-        assert!(learner.feature_index.contains_key("feat2"));
+        let result = learner.load_model_from_reader("feat1\t0.5\nfeat2\t-0.25\n".as_bytes());
+        assert!(matches!(result, Err(LitseaError::InvalidData(_))));
+        // The learner state stays untouched on error.
+        assert_eq!(learner.features, vec![String::new()]);
     }
 
     #[test]

--- a/litsea/src/model_io.rs
+++ b/litsea/src/model_io.rs
@@ -76,11 +76,28 @@ fn read_file_bytes(_path: &str) -> Result<Vec<u8>> {
     ))
 }
 
+/// Maximum accepted size of a remotely downloaded model (256 MiB).
+///
+/// The largest shipped model is ~19 MB; the cap is a generous safety bound
+/// that prevents a misconfigured or malicious URL from buffering an
+/// unbounded body in memory.
+#[cfg(feature = "remote_model")]
+const MAX_MODEL_BYTES: u64 = 256 * 1024 * 1024;
+
 /// Downloads a model over HTTP(S).
+///
+/// The request uses a 10-second connect timeout and a 60-second overall
+/// timeout. Responses larger than [`MAX_MODEL_BYTES`] are rejected, and a
+/// body shorter than the advertised `Content-Length` is reported as an
+/// incomplete download.
 #[cfg(feature = "remote_model")]
 async fn download(url: &str) -> Result<Vec<u8>> {
+    use std::time::Duration;
+
     let client = reqwest::Client::builder()
         .user_agent(format!("Litsea/{}", env!("CARGO_PKG_VERSION")))
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(60))
         .build()
         .map_err(|e| LitseaError::Download(format!("failed to create HTTP client: {}", e)))?;
 
@@ -90,7 +107,34 @@ async fn download(url: &str) -> Result<Vec<u8>> {
         return Err(LitseaError::Download(format!("HTTP {}", resp.status())));
     }
 
+    let expected_len = resp.content_length();
+    if let Some(len) = expected_len {
+        if len > MAX_MODEL_BYTES {
+            return Err(LitseaError::Download(format!(
+                "model size {} bytes exceeds the maximum of {} bytes",
+                len, MAX_MODEL_BYTES
+            )));
+        }
+    }
+
     let content = resp.bytes().await.map_err(|e| LitseaError::Download(e.to_string()))?;
+
+    if content.len() as u64 > MAX_MODEL_BYTES {
+        return Err(LitseaError::Download(format!(
+            "model size {} bytes exceeds the maximum of {} bytes",
+            content.len(),
+            MAX_MODEL_BYTES
+        )));
+    }
+    if let Some(len) = expected_len {
+        if content.len() as u64 != len {
+            return Err(LitseaError::Download(format!(
+                "incomplete download: received {} of {} bytes",
+                content.len(),
+                len
+            )));
+        }
+    }
 
     Ok(content.to_vec())
 }
@@ -145,5 +189,68 @@ mod tests {
     async fn test_read_missing_file() {
         let result = read_model_bytes("/nonexistent/path/to.model").await;
         assert!(matches!(result, Err(LitseaError::Io(_))));
+    }
+
+    #[cfg(feature = "remote_model")]
+    mod download_tests {
+        use super::*;
+
+        use std::io::Read as _;
+        use std::net::TcpListener;
+
+        /// Serves one raw HTTP response on a random local port and returns
+        /// the port. The server thread exits after the first connection.
+        fn serve_once(response: &'static [u8]) -> u16 {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+            let port = listener.local_addr().expect("local_addr").port();
+            std::thread::spawn(move || {
+                if let Ok((mut stream, _)) = listener.accept() {
+                    // Read the request headers (best effort) before replying.
+                    let mut buf = [0u8; 4096];
+                    let _ = stream.read(&mut buf);
+                    let _ = stream.write_all(response);
+                }
+            });
+            port
+        }
+
+        #[tokio::test]
+        async fn test_download_success() {
+            let port = serve_once(
+                b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello",
+            );
+            let bytes = read_model_bytes(&format!("http://127.0.0.1:{}/model", port))
+                .await
+                .expect("download should succeed");
+            assert_eq!(bytes, b"hello");
+        }
+
+        #[tokio::test]
+        async fn test_download_non_success_status() {
+            let port = serve_once(
+                b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            );
+            let result = read_model_bytes(&format!("http://127.0.0.1:{}/model", port)).await;
+            assert!(
+                matches!(result, Err(LitseaError::Download(ref msg)) if msg.contains("404")),
+                "expected an HTTP 404 download error, got {:?}",
+                result
+            );
+        }
+
+        #[tokio::test]
+        async fn test_download_rejects_oversized_content_length() {
+            // #101: an advertised size beyond the cap must be rejected before
+            // the body is read (the stub closes without sending a body).
+            let port = serve_once(
+                b"HTTP/1.1 200 OK\r\nContent-Length: 999999999999\r\nConnection: close\r\n\r\n",
+            );
+            let result = read_model_bytes(&format!("http://127.0.0.1:{}/model", port)).await;
+            assert!(
+                matches!(result, Err(LitseaError::Download(ref msg)) if msg.contains("exceeds")),
+                "expected a size-cap download error, got {:?}",
+                result
+            );
+        }
     }
 }

--- a/litsea/src/perceptron.rs
+++ b/litsea/src/perceptron.rs
@@ -308,8 +308,14 @@ impl AveragedPerceptron {
             self.ensure_class(class.trim());
         }
 
-        // Read the weights
+        // Read the weights. Reset all learned state: the weights are replaced
+        // by the file's, and the averaging accumulators must not survive into
+        // a later train() call (they would combine stale timestamps with the
+        // loaded weights and corrupt the averaged model).
         self.weights.clear();
+        self.accumulated.clear();
+        self.timestamps.clear();
+        self.step = 0;
         let n = self.classes.len();
         for line in lines {
             let line = line?;
@@ -329,6 +335,12 @@ impl AveragedPerceptron {
             let weight: f64 = parts[2]
                 .parse()
                 .map_err(|e| LitseaError::InvalidData(format!("Invalid weight value: {}", e)))?;
+            if !weight.is_finite() {
+                return Err(LitseaError::InvalidData(format!(
+                    "Non-finite weight in line: '{}'",
+                    line
+                )));
+            }
             self.weights.entry(feat.to_string()).or_insert_with(|| vec![0.0; n])[class_idx] =
                 weight;
         }
@@ -643,6 +655,56 @@ mod tests {
         // Invalid class count
         let result = p.load_model_from_reader("not_a_number".as_bytes());
         assert!(matches!(result, Err(LitseaError::InvalidData(_))));
+    }
+
+    #[test]
+    fn test_load_model_rejects_nonfinite_weight() {
+        // #101: NaN/inf weights must be rejected at load time.
+        for content in ["1\nA\nf1\tA\tNaN\n", "1\nA\nf1\tA\tinf\n"] {
+            let mut p = AveragedPerceptron::new();
+            let result = p.load_model_from_reader(content.as_bytes());
+            assert!(
+                matches!(result, Err(LitseaError::InvalidData(_))),
+                "expected InvalidData for {:?}",
+                content
+            );
+        }
+    }
+
+    #[test]
+    fn test_load_model_resets_averaging_state() -> Result<()> {
+        // #101: loading a model must reset the averaging accumulators so a
+        // subsequent train() does not mix stale state with loaded weights.
+        let mut feats_a = HashSet::new();
+        feats_a.insert("f1".to_string());
+        let mut feats_b = HashSet::new();
+        feats_b.insert("f2".to_string());
+
+        let mut p = AveragedPerceptron::new();
+        p.add_instance(feats_a.clone(), "A".to_string());
+        p.add_instance(feats_b.clone(), "B".to_string());
+        p.train(5, Arc::new(AtomicBool::new(true)));
+        assert!(p.step > 0);
+
+        let model_content = "2\nA\nB\nf1\tA\t0.5\nf2\tB\t0.5\n";
+        p.load_model_from_reader(model_content.as_bytes())?;
+        assert_eq!(p.step, 0);
+        assert!(p.accumulated.is_empty());
+        assert!(p.timestamps.is_empty());
+
+        // Behavioral check: train-after-load on the recycled instance matches
+        // load-then-train on a fresh perceptron with the same instances.
+        p.train(5, Arc::new(AtomicBool::new(true)));
+
+        let mut q = AveragedPerceptron::new();
+        q.add_instance(feats_a.clone(), "A".to_string());
+        q.add_instance(feats_b.clone(), "B".to_string());
+        q.load_model_from_reader(model_content.as_bytes())?;
+        q.train(5, Arc::new(AtomicBool::new(true)));
+
+        assert_eq!(p.predict(&feats_a), q.predict(&feats_a));
+        assert_eq!(p.predict(&feats_b), q.predict(&feats_b));
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
Closes #101 (part of #97)

## Summary

Model loading had four silent failure modes: non-finite weights (`feat\tNaN` parses fine and makes `bias()` NaN, so whole sentences come back unsegmented with no error), no AdaBoost model-format integrity checks (a file truncated before its bias line loaded silently with a wrong bias), unbounded remote downloads (no timeout, no size cap, no Content-Length verification), and stale perceptron averaging state surviving a model load (train → load → train mixed old accumulators into the averaged weights).

## Changes

- **AdaBoost loader**: rejects with line-numbered `InvalidData` — empty files, files without a bias line (truncation detection), duplicate bias lines, duplicate feature lines, non-finite weights/bias. The learner is untouched on error. Weight lines after the single bias line remain accepted for legacy compatibility: the shipped `RWCP.model` places its bias mid-file, and the bias bucket is computed from the running sum exactly as the historical loader did (pinned by a dedicated test and the unchanged RWCP goldens; see the plan-update comment on #101 for how the test suite caught the initially stricter rule).
- **Perceptron loader**: rejects non-finite weights; resets `accumulated`/`timestamps`/`step` alongside `weights.clear()`, with direct state assertions plus a behavioral train-after-load equivalence test.
- **Remote download** (`model_io::download`): 10 s connect / 60 s request timeouts, 256 MiB size cap (checked against `Content-Length` up front and the received size after), incomplete-download detection. Values documented in `docs/src/advanced/remote-model-loading.md`.
- Docs: model-file-format gains a Validation section and a precise bias-reconstruction description; CHANGELOG entry (Fixed + behavior notes).

## Behavior changes

- Empty model files and files without a bias line now error instead of loading silently (two #98-era tests pinning the lenient behavior were deliberately inverted). Files produced by `save_model` always carry a final bias line, so litsea-produced models are unaffected — proven by the unchanged golden suite, including RWCP.

## Tests

Ten regression tests written first and confirmed RED on the unfixed code; download coverage via a `std::net::TcpListener` HTTP stub (success / 404 / oversized-Content-Length rejection — no new dependencies). `cargo test --workspace`: 98 lib + 10 golden + 6 doc tests pass; clippy `-D warnings`, fmt, markdownlint clean.