### PR TITLE
fix: treat broken pipe on stdout as normal termination in litsea segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,11 @@ compatible: all pre-trained models in `models/` load unchanged.
   skipped consistently by both feature-file passes. Note: legacy
   hand-written space-separated features files are no longer accepted; the
   `extract` command has always produced tab-separated output (#99).
+- `litsea segment` now treats a downstream consumer closing stdout early
+  (e.g. `litsea segment model | head -1`) as normal termination instead of
+  reporting `Error: Broken pipe` and exiting 1, and explicitly flushes its
+  output buffer so real I/O errors are surfaced instead of being lost in
+  the writer's drop (#102).
 - Model loading now fails loudly on corrupt data instead of silently
   producing a broken model: both loaders reject non-finite weights
   (`NaN`/`inf`, which poisoned every score comparison), and the AdaBoost

--- a/docs/src/litsea-cli/segment.md
+++ b/docs/src/litsea-cli/segment.md
@@ -25,6 +25,9 @@ echo "text" | litsea segment [OPTIONS] <MODEL_URI>
 
 - **Input**: Reads from stdin, one sentence per line. Empty lines are skipped.
 - **Output**: Writes to stdout, space-separated tokens, one line per input line.
+- **Pipelines**: A downstream consumer closing the pipe early (e.g.
+  `litsea segment model | head -1`) terminates the command successfully
+  (exit code 0), so `segment` composes cleanly in shell pipelines.
 
 ## Examples
 

--- a/litsea-cli/src/main.rs
+++ b/litsea-cli/src/main.rs
@@ -194,10 +194,49 @@ async fn train(args: TrainArgs) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+/// Writes one output line, treating a closed downstream pipe as normal
+/// termination.
+///
+/// # Arguments
+/// * `writer` - The output writer.
+/// * `line` - The line to write (a newline is appended).
+///
+/// # Returns
+/// `Ok(true)` to continue writing, `Ok(false)` when the downstream consumer
+/// closed the pipe (e.g. `litsea segment model | head -1`), or the original
+/// error for any other I/O failure.
+fn write_output_line<W: Write>(writer: &mut W, line: &str) -> io::Result<bool> {
+    match writeln!(writer, "{}", line) {
+        Ok(()) => Ok(true),
+        Err(e) if e.kind() == io::ErrorKind::BrokenPipe => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
+/// Flushes the output writer, treating a closed downstream pipe as normal
+/// termination.
+///
+/// # Arguments
+/// * `writer` - The output writer to flush.
+///
+/// # Returns
+/// `Ok(())` on success or broken pipe; any other I/O error is returned so it
+/// is surfaced instead of being lost in the writer's drop.
+fn flush_output<W: Write>(writer: &mut W) -> io::Result<()> {
+    match writer.flush() {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::BrokenPipe => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
 /// Segment a sentence using the trained model.
 /// This function loads the AdaBoost model from the specified file,
 /// reads sentences from standard input, segments them into words,
 /// and writes the segmented sentences to standard output.
+///
+/// A downstream consumer closing stdout early (broken pipe) terminates the
+/// command successfully instead of reporting an error.
 ///
 /// # Arguments
 /// * `args` - The arguments for the segment command [`SegmentArgs`].
@@ -227,7 +266,9 @@ async fn segment(args: SegmentArgs) -> Result<(), Box<dyn Error>> {
             let tokens = segmenter.segment_with_pos(line);
             let formatted: Vec<String> =
                 tokens.iter().map(|(word, pos)| format!("{}/{}", word, pos)).collect();
-            writeln!(writer, "{}", formatted.join(" "))?;
+            if !write_output_line(&mut writer, &formatted.join(" "))? {
+                return Ok(());
+            }
         }
     } else {
         // 既存のAdaBoostモデルで単語分割のみ
@@ -243,10 +284,13 @@ async fn segment(args: SegmentArgs) -> Result<(), Box<dyn Error>> {
                 continue;
             }
             let tokens = segmenter.segment(line);
-            writeln!(writer, "{}", tokens.join(" "))?;
+            if !write_output_line(&mut writer, &tokens.join(" "))? {
+                return Ok(());
+            }
         }
     }
 
+    flush_output(&mut writer)?;
     Ok(())
 }
 

--- a/litsea-cli/tests/cli.rs
+++ b/litsea-cli/tests/cli.rs
@@ -1,0 +1,57 @@
+//! Integration tests for the litsea CLI binary.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+fn model_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../models").join(name)
+}
+
+/// Regression test for #102: a downstream consumer closing stdout early
+/// (e.g. `litsea segment model | head -1`) is normal termination for a
+/// line-oriented CLI, not an error. The child's stdout is dropped
+/// immediately and enough input is written to overflow the child's output
+/// buffer, forcing a write into the closed pipe.
+#[test]
+fn test_broken_pipe_exits_zero() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_litsea"))
+        .arg("segment")
+        .arg("-l")
+        .arg("japanese")
+        .arg(model_path("RWCP.model"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn litsea");
+
+    // Simulate the downstream consumer exiting immediately.
+    drop(child.stdout.take());
+
+    // Feed well over the 8 KiB BufWriter capacity so the child is forced to
+    // write into the closed pipe. The child may exit mid-write, so stdin
+    // write errors are expected and ignored.
+    {
+        let mut stdin = child.stdin.take().expect("stdin");
+        for _ in 0..2000 {
+            if writeln!(stdin, "これはテストです。").is_err() {
+                break;
+            }
+        }
+    }
+
+    let output = child.wait_with_output().expect("wait");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "expected exit 0 on broken pipe, got {:?} (stderr: {})",
+        output.status,
+        stderr
+    );
+    assert!(
+        !stderr.contains("Broken pipe"),
+        "broken pipe must not be reported as an error: {}",
+        stderr
+    );
+}


### PR DESCRIPTION
Closes #102 (part of #97)

## Summary

Rust ignores SIGPIPE by default, so in a pipeline like `litsea segment model | head -1`, the `writeln!` in the segment loop fails with `ErrorKind::BrokenPipe` once the downstream consumer exits; the error propagated to `main()`, which printed `Error: Broken pipe (os error 32)` and exited 1. For a line-oriented CLI meant to compose in shell pipelines, downstream-closes-early is normal termination. Additionally, the `BufWriter` was never explicitly flushed, so flush errors were silently swallowed in drop.

## Changes

- `write_output_line()` helper: `BrokenPipe` → `Ok(false)` (terminate successfully), other I/O errors propagate; applied to both the `--pos` and plain loops.
- `flush_output()` helper: explicit flush after the loop with the same broken-pipe tolerance, surfacing real output errors instead of losing them in drop.
- New integration test `litsea-cli/tests/cli.rs::test_broken_pipe_exits_zero` — the first test in the CLI crate, std-only (no new dependencies): drops the child's stdout to simulate `| head -1`, feeds >8 KiB of input, asserts exit 0 and a clean stderr. Confirmed RED (exit 1, `Error: Broken pipe`) before the fix. Seeds the #107 CLI test suite.
- CHANGELOG entry; `docs/src/litsea-cli/segment.md` documents the pipeline behavior.

## Verification

- Manual pipeline check: `yes ... | head -2000 | litsea segment -l japanese models/RWCP.model | head -1` → litsea's `PIPESTATUS` entry is 0 with empty stderr.
- `cargo test --workspace`: 98 lib + 10 golden + 1 CLI + 6 doc tests pass; clippy `-D warnings`, fmt, markdownlint clean.