### PR TITLE
perf: optimize inference hot path with FxHashMap, cached bias, and borrowed buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,17 @@ compatible: all pre-trained models in `models/` load unchanged.
 
 ### Performance
 
+Inference hot path, second pass (#103): internal feature maps switched from
+the default SipHash to `rustc_hash::FxHashMap` (keys are internally
+generated, so HashDoS resistance is unnecessary); the AdaBoost bias is
+cached instead of recomputed as an O(model-size) sum per sentence;
+`sentence_context` borrows characters from the input instead of allocating
+a `String` per character; and the perceptron's per-prediction scores vector
+is reused across positions. Short-sentence segmentation improved a further
+21-39% and long-text segmentation ~16% across all three languages on the
+bundled criterion suite, with golden-test outputs unchanged. Adds the
+`rustc-hash` dependency (MIT OR Apache-2.0, no transitive dependencies).
+
 Measured on the bundled models (criterion, medians, vs v0.4.0):
 
 - `segment()`: 65–70% faster (long Japanese text: 611 ms → 215 ms).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,7 @@ version = "0.5.0"
 dependencies = [
  "criterion",
  "reqwest",
+ "rustc-hash",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ ctrlc = "3.5.2"
 reqwest = { version = "0.13.4", features = [
     "rustls",
 ], default-features = false } # use rustls instead of native-tls to avoid linking openssl; disables http2, charset, and system-proxy
+rustc-hash = "2.1.1"
 tempfile = "3.27.0"
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros"] }

--- a/litsea/Cargo.toml
+++ b/litsea/Cargo.toml
@@ -13,6 +13,7 @@ categories.workspace = true
 license.workspace = true
 
 [dependencies]
+rustc-hash.workspace = true
 thiserror.workspace = true
 reqwest = { workspace = true, optional = true }
 

--- a/litsea/src/adaboost.rs
+++ b/litsea/src/adaboost.rs
@@ -1,9 +1,15 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+
+// Internal maps use FxHashMap: the keys are internally generated feature
+// strings (no HashDoS exposure) and the hot path performs dozens of
+// short-string lookups per character, where FxHash is significantly faster
+// than the default SipHash.
+use rustc_hash::FxHashMap;
 
 use crate::error::{LitseaError, Result};
 use crate::metrics::BinaryMetrics;
@@ -23,11 +29,14 @@ pub struct AdaBoost {
     instance_weights: Vec<f64>,
     model: Vec<f64>,
     features: Vec<String>,
-    feature_index: HashMap<String, usize>,
+    feature_index: FxHashMap<String, usize>,
     labels: Vec<Label>,
     instances_buf: Vec<usize>,
     instances: Vec<(usize, usize)>, // (start, end) index in instances_buf
     num_instances: usize,
+    /// Cached value of `-sum(model) / 2.0`, kept in sync by every
+    /// weight-mutating path so `bias()` is O(1) on the inference hot path.
+    cached_bias: f64,
 }
 
 impl AdaBoost {
@@ -47,19 +56,30 @@ impl AdaBoost {
     /// # Returns
     /// A new instance of [`AdaBoost`].
     pub fn new(threshold: f64, num_iterations: usize) -> Self {
+        // The bias bucket "" always occupies feature index 0.
+        let mut feature_index = FxHashMap::default();
+        feature_index.insert(String::new(), 0);
         AdaBoost {
             threshold,
             num_iterations,
             instance_weights: vec![],
-            // The bias bucket "" always occupies feature index 0.
             model: vec![0.0],
             features: vec![String::new()],
-            feature_index: HashMap::from([(String::new(), 0)]),
+            feature_index,
             labels: vec![],
             instances_buf: vec![],
             instances: vec![],
             num_instances: 0,
+            cached_bias: 0.0,
         }
+    }
+
+    /// Recomputes the cached bias from the current model weights. Must be
+    /// called by every path that changes weight values (summing in model
+    /// order keeps the float result identical to the previous on-demand
+    /// computation).
+    fn recompute_bias(&mut self) {
+        self.cached_bias = -self.model.iter().sum::<f64>() / 2.0;
     }
 
     /// Initializes the features from a file.
@@ -132,6 +152,7 @@ impl AdaBoost {
         self.instances.reserve(self.num_instances);
         self.instances_buf.reserve(buf_size);
 
+        self.recompute_bias();
         Ok(())
     }
 
@@ -309,6 +330,10 @@ impl AdaBoost {
                 }
             }
         }
+
+        // The training loop mutates model weights directly; refresh the
+        // cached bias once at the end.
+        self.recompute_bias();
     }
 
     /// Saves the trained model to a file.
@@ -408,7 +433,7 @@ impl AdaBoost {
     /// the weights preceding the bias line exactly as the historical loader
     /// did.
     pub fn load_model_from_reader<R: BufRead>(&mut self, reader: R) -> Result<()> {
-        let mut m: HashMap<String, f64> = HashMap::new();
+        let mut m: FxHashMap<String, f64> = FxHashMap::default();
         let mut weight_sum = 0.0;
         let mut bias_seen = false;
         let mut any_line = false;
@@ -521,6 +546,7 @@ impl AdaBoost {
                 }
             }
         }
+        self.recompute_bias();
         Ok(())
     }
 
@@ -552,6 +578,8 @@ impl AdaBoost {
         self.labels.push(label);
         self.instance_weights.push(1.0);
         self.num_instances += 1;
+        // New features enter with weight 0.0, so the cached bias (the model
+        // weight sum) is unchanged; no recompute needed on this hot-ish path.
     }
 
     /// Predicts the label for a given set of attributes.
@@ -580,13 +608,15 @@ impl AdaBoost {
     }
 
     /// Gets the bias term of the model.
-    /// The bias is calculated as the negative sum of the model weights divided by 2.
+    /// The bias is calculated as the negative sum of the model weights
+    /// divided by 2. The value is cached and kept in sync by every
+    /// weight-mutating path, so this is O(1).
     ///
     /// # Returns
     /// The bias term as a `f64`.
     #[must_use]
     pub fn bias(&self) -> f64 {
-        -self.model.iter().sum::<f64>() / 2.0
+        self.cached_bias
     }
 
     /// Calculates and returns the performance metrics of the model on the training data.
@@ -820,11 +850,39 @@ mod tests {
     fn test_bias() {
         let mut learner = AdaBoost::new(0.01, 10);
 
-        // Set model weights as an example.
+        // Set model weights as an example (direct field assignment bypasses
+        // the mutating APIs, so refresh the cache explicitly).
         learner.model = vec![0.2, 0.3, -0.1];
+        learner.recompute_bias();
 
         // bias = -sum(model)/2 = -(0.2+0.3-0.1)/2 = -0.4/2 = -0.2
         assert!((learner.bias() + 0.2).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_bias_cache_stays_consistent() {
+        // Regression test for #103: bias() is cached; every mutating path
+        // must leave it equal to -sum(model)/2.
+        let expected = |l: &AdaBoost| -l.model.iter().sum::<f64>() / 2.0;
+
+        // After add_instance + train.
+        let mut learner = AdaBoost::new(0.01, 20);
+        learner.add_instance(attrs_of("a"), 1);
+        learner.add_instance(attrs_of("c"), -1);
+        learner.train(Arc::new(AtomicBool::new(true)));
+        assert!((learner.bias() - expected(&learner)).abs() < 1e-12);
+
+        // After a fresh model load.
+        let mut learner = AdaBoost::new(0.01, 10);
+        learner
+            .load_model_from_reader("feat1\t0.5\nfeat2\t-0.25\n0.1\n".as_bytes())
+            .unwrap();
+        assert!((learner.bias() - expected(&learner)).abs() < 1e-12);
+
+        // After an incremental (merge) load on top of training data.
+        learner.add_instance(attrs_of("feat9"), 1);
+        learner.load_model_from_reader("feat9\t0.75\n0.0\n".as_bytes()).unwrap();
+        assert!((learner.bias() - expected(&learner)).abs() < 1e-12);
     }
 
     #[test]
@@ -836,6 +894,7 @@ mod tests {
         learner.model = vec![0.5, -1.0];
         learner.feature_index =
             learner.features.iter().enumerate().map(|(i, f)| (f.clone(), i)).collect();
+        learner.recompute_bias();
 
         // Instance 1: Attribute "A" → score = 0.25 + 0.5 = 0.75 (positive example)
         let mut attrs1 = HashSet::new();
@@ -887,6 +946,7 @@ mod tests {
         // bias = -(0.0 + 1.0) / 2.0 = -0.5
         // score for instance with "A": -0.5 + 1.0 = 0.5 >= 0 → positive prediction
         learner.model = vec![0.0, 1.0];
+        learner.recompute_bias();
 
         let mut attrs = HashSet::new();
         attrs.insert("A".to_string());

--- a/litsea/src/perceptron.rs
+++ b/litsea/src/perceptron.rs
@@ -5,6 +5,11 @@ use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+// Internal weight maps use FxHashMap: keys are internally generated feature
+// strings (no HashDoS exposure) and prediction probes dozens of short keys
+// per character, where FxHash beats the default SipHash.
+use rustc_hash::FxHashMap;
+
 use crate::error::{LitseaError, Result};
 use crate::metrics::MulticlassMetrics;
 
@@ -20,11 +25,11 @@ use crate::metrics::MulticlassMetrics;
 #[derive(Debug)]
 pub struct AveragedPerceptron {
     /// Per-feature weight vectors: weights\[feature\]\[class_index\] = weight
-    weights: HashMap<String, Vec<f64>>,
+    weights: FxHashMap<String, Vec<f64>>,
     /// Accumulated weights used for averaging
-    accumulated: HashMap<String, Vec<f64>>,
+    accumulated: FxHashMap<String, Vec<f64>>,
     /// Last-updated timestamp of each weight
-    timestamps: HashMap<String, Vec<usize>>,
+    timestamps: FxHashMap<String, Vec<usize>>,
     /// Current step count (total across all instances)
     step: usize,
     /// Known classes (always kept sorted)
@@ -43,9 +48,9 @@ impl AveragedPerceptron {
     /// Creates a new Averaged Perceptron instance.
     pub fn new() -> Self {
         AveragedPerceptron {
-            weights: HashMap::new(),
-            accumulated: HashMap::new(),
-            timestamps: HashMap::new(),
+            weights: FxHashMap::default(),
+            accumulated: FxHashMap::default(),
+            timestamps: FxHashMap::default(),
             step: 0,
             classes: Vec::new(),
             instances: Vec::new(),
@@ -85,9 +90,11 @@ impl AveragedPerceptron {
         self.instances.push((feats, label));
     }
 
-    /// Returns the index of the highest-scoring class for the features.
+    /// Returns the index of the highest-scoring class for the features,
+    /// reusing `scores` as a scratch buffer (cleared and resized here) to
+    /// avoid one heap allocation per prediction on the inference hot path.
     /// Returns None if no classes are registered.
-    fn predict_idx<I>(&self, features: I) -> Option<usize>
+    fn predict_idx_into<I>(&self, features: I, scores: &mut Vec<f64>) -> Option<usize>
     where
         I: IntoIterator,
         I::Item: AsRef<str>,
@@ -95,7 +102,8 @@ impl AveragedPerceptron {
         if self.classes.is_empty() {
             return None;
         }
-        let mut scores = vec![0.0f64; self.classes.len()];
+        scores.clear();
+        scores.resize(self.classes.len(), 0.0);
         for feat in features {
             if let Some(ws) = self.weights.get(feat.as_ref()) {
                 for (s, w) in scores.iter_mut().zip(ws.iter()) {
@@ -120,15 +128,17 @@ impl AveragedPerceptron {
     /// score. Returns an empty string if no classes are registered.
     #[must_use]
     pub fn predict(&self, features: &HashSet<String>) -> String {
-        match self.predict_idx(features.iter()) {
+        let mut scores = Vec::new();
+        match self.predict_idx_into(features.iter(), &mut scores) {
             Some(i) => self.classes[i].clone(),
             None => String::new(),
         }
     }
 
-    /// Predicts the label from a slice (internal allocation-avoiding API).
-    pub(crate) fn predict_slice(&self, features: &[String]) -> &str {
-        match self.predict_idx(features.iter()) {
+    /// Predicts the label from a slice, reusing the caller's scratch buffer
+    /// (internal allocation-avoiding API).
+    pub(crate) fn predict_slice(&self, features: &[String], scores: &mut Vec<f64>) -> &str {
+        match self.predict_idx_into(features.iter(), scores) {
             Some(i) => &self.classes[i],
             None => "",
         }
@@ -194,6 +204,8 @@ impl AveragedPerceptron {
         // Temporarily move the instances out to avoid double borrows during
         // training (previously every instance was cloned).
         let instances = std::mem::take(&mut self.instances);
+        // Scratch buffer reused across every prediction in the epoch loop.
+        let mut scores: Vec<f64> = Vec::new();
 
         for _epoch in 0..num_epochs {
             if !running.load(Ordering::SeqCst) {
@@ -205,7 +217,9 @@ impl AveragedPerceptron {
                     break;
                 }
 
-                let guess_idx = self.predict_idx(features.iter()).expect("classes registered");
+                let guess_idx = self
+                    .predict_idx_into(features.iter(), &mut scores)
+                    .expect("classes registered");
                 let truth_idx = self
                     .classes
                     .binary_search_by(|c| c.as_str().cmp(truth))
@@ -355,9 +369,10 @@ impl AveragedPerceptron {
         let mut predicted_per_class: HashMap<String, usize> = HashMap::new();
         let mut gold_per_class: HashMap<String, usize> = HashMap::new();
         let mut total_correct = 0usize;
+        let mut scores: Vec<f64> = Vec::new();
 
         for (features, truth) in &self.instances {
-            let guess = match self.predict_idx(features.iter()) {
+            let guess = match self.predict_idx_into(features.iter(), &mut scores) {
                 Some(i) => self.classes[i].as_str(),
                 None => "",
             };
@@ -539,10 +554,11 @@ mod tests {
         let running = Arc::new(AtomicBool::new(true));
         p.train(10, running);
 
+        let mut scores: Vec<f64> = Vec::new();
         let slice_a: Vec<String> = feats_a.iter().cloned().collect();
-        assert_eq!(p.predict_slice(&slice_a), p.predict(&feats_a));
+        assert_eq!(p.predict_slice(&slice_a, &mut scores), p.predict(&feats_a));
         let slice_b: Vec<String> = feats_b.iter().cloned().collect();
-        assert_eq!(p.predict_slice(&slice_b), p.predict(&feats_b));
+        assert_eq!(p.predict_slice(&slice_b, &mut scores), p.predict(&feats_b));
     }
 
     #[test]

--- a/litsea/src/segmenter.rs
+++ b/litsea/src/segmenter.rs
@@ -114,15 +114,19 @@ impl Segmenter {
     ///
     /// Returns `(chars, types)` where the first three entries are the B3/B2/B1
     /// head sentinels and the last three are the E1/E2/E3 tail sentinels, so
-    /// real characters occupy indices `3..chars.len() - 3`.
-    fn sentence_context(&self, text: &str) -> (Vec<String>, Vec<&'static str>) {
-        let mut chars = vec!["B3".to_string(), "B2".to_string(), "B1".to_string()];
-        let mut types: Vec<&'static str> = vec!["O"; 3];
-        for ch in text.chars() {
+    /// real characters occupy indices `3..chars.len() - 3`. Characters borrow
+    /// directly from `text` (no per-character allocation); the byte length is
+    /// used as a capacity upper bound.
+    fn sentence_context<'a>(&self, text: &'a str) -> (Vec<&'a str>, Vec<&'static str>) {
+        let mut chars: Vec<&str> = Vec::with_capacity(text.len() + 6);
+        let mut types: Vec<&'static str> = Vec::with_capacity(text.len() + 6);
+        chars.extend_from_slice(&["B3", "B2", "B1"]);
+        types.extend_from_slice(&["O"; 3]);
+        for (i, ch) in text.char_indices() {
             types.push(self.language.char_type(ch));
-            chars.push(ch.to_string());
+            chars.push(&text[i..i + ch.len_utf8()]);
         }
-        chars.extend_from_slice(&["E1".into(), "E2".into(), "E3".into()]);
+        chars.extend_from_slice(&["E1", "E2", "E3"]);
         types.extend_from_slice(&["O", "O", "O"]);
         (chars, types)
     }
@@ -351,14 +355,15 @@ impl Segmenter {
         let (chars, types) = self.sentence_context(sentence);
         // Padding for lookback: tags[0..3] are fixed "U" (Unknown), and tags[3]
         // is also "U" since there is no boundary decision before the first character.
-        let mut tags: Vec<&'static str> = vec!["U"; 4];
+        let mut tags: Vec<&'static str> = Vec::with_capacity(chars.len());
+        tags.extend_from_slice(&["U"; 4]);
 
         // The bias is a sum over all model weights; compute it once per
         // sentence instead of once per character.
         let bias = learner.bias();
 
         let mut result = Vec::new();
-        let mut word = chars[3].clone();
+        let mut word = chars[3].to_string();
         for (i, ch) in chars.iter().enumerate().take(chars.len() - 3).skip(4) {
             // Sum the weights of the attributes directly instead of building
             // a HashSet per position.
@@ -372,7 +377,7 @@ impl Segmenter {
             } else {
                 tags.push("O");
             }
-            word += ch;
+            word.push_str(ch);
         }
         result.push(word);
         result
@@ -405,24 +410,31 @@ impl Segmenter {
             .expect("pos_learner is not set. Use with_pos_learner() or add_corpus_with_pos().");
 
         let (chars, types) = self.sentence_context(sentence);
-        let mut tags: Vec<&'static str> = vec!["U"; 4];
-        // Attribute buffer reused across positions to amortize allocations.
+        let mut tags: Vec<&'static str> = Vec::with_capacity(chars.len());
+        tags.extend_from_slice(&["U"; 4]);
+        // Attribute and score buffers reused across positions to amortize
+        // allocations.
         let mut attrs_buf: Vec<String> = Vec::new();
+        let mut scores_buf: Vec<f64> = Vec::new();
 
         // The first character always starts the first word; its predicted
         // label is used only to determine the first word's POS.
         self.collect_attributes(3, &tags, &chars, &types, &mut attrs_buf);
-        let first_label: SegmentLabel =
-            pos_learner.predict_slice(&attrs_buf).parse().unwrap_or(SegmentLabel::O);
+        let first_label: SegmentLabel = pos_learner
+            .predict_slice(&attrs_buf, &mut scores_buf)
+            .parse()
+            .unwrap_or(SegmentLabel::O);
         let mut current_pos = first_label.pos().unwrap_or(Upos::X);
 
         let mut result: Vec<(String, Upos)> = Vec::new();
-        let mut word = chars[3].clone();
+        let mut word = chars[3].to_string();
 
         for (i, ch) in chars.iter().enumerate().take(chars.len() - 3).skip(4) {
             self.collect_attributes(i, &tags, &chars, &types, &mut attrs_buf);
-            let label: SegmentLabel =
-                pos_learner.predict_slice(&attrs_buf).parse().unwrap_or(SegmentLabel::O);
+            let label: SegmentLabel = pos_learner
+                .predict_slice(&attrs_buf, &mut scores_buf)
+                .parse()
+                .unwrap_or(SegmentLabel::O);
             if label.is_boundary() {
                 // Finalize the current word and push it to the result
                 result.push((std::mem::take(&mut word), current_pos));
@@ -431,7 +443,7 @@ impl Segmenter {
             } else {
                 tags.push("O");
             }
-            word += ch;
+            word.push_str(ch);
         }
 
         result.push((word, current_pos));
@@ -444,7 +456,7 @@ impl Segmenter {
         &self,
         i: usize,
         tags: &[&'static str],
-        chars: &[String],
+        chars: &[&str],
         types: &[&'static str],
     ) -> HashSet<String> {
         let mut attrs = HashSet::with_capacity(48);
@@ -460,7 +472,7 @@ impl Segmenter {
         &self,
         i: usize,
         tags: &[&'static str],
-        chars: &[String],
+        chars: &[&str],
         types: &[&'static str],
         out: &mut Vec<String>,
     ) {
@@ -489,7 +501,7 @@ impl Segmenter {
         &self,
         i: usize,
         tags: &[&'static str],
-        chars: &[String],
+        chars: &[&str],
         types: &[&'static str],
         sink: &mut dyn FnMut(&str),
     ) {
@@ -698,13 +710,13 @@ mod tests {
         let tags: Vec<&'static str> = vec!["U"; 7];
 
         let chars = vec![
-            "B3".to_string(), // index 0
-            "B2".to_string(), // index 1
-            "B1".to_string(), // index 2
-            "あ".to_string(), // index 3
-            "い".to_string(), // index 4
-            "う".to_string(), // index 5
-            "E1".to_string(), // index 6
+            "B3", // index 0
+            "B2", // index 1
+            "B1", // index 2
+            "あ", // index 3
+            "い", // index 4
+            "う", // index 5
+            "E1", // index 6
         ];
 
         let types: Vec<&'static str> = vec!["O", "O", "O", "O", "I", "I", "O"];
@@ -726,15 +738,7 @@ mod tests {
     fn test_collect_attributes_reuses_buffer() {
         let segmenter = Segmenter::new(Language::Japanese, None);
         let tags: Vec<&'static str> = vec!["U"; 7];
-        let chars = vec![
-            "B3".to_string(),
-            "B2".to_string(),
-            "B1".to_string(),
-            "あ".to_string(),
-            "い".to_string(),
-            "う".to_string(),
-            "E1".to_string(),
-        ];
+        let chars = vec!["B3", "B2", "B1", "あ", "い", "う", "E1"];
         let types: Vec<&'static str> = vec!["O", "O", "O", "O", "I", "I", "O"];
 
         let mut buf: Vec<String> = Vec::new();
@@ -755,15 +759,7 @@ mod tests {
     fn test_get_attributes_panics_index_too_low() {
         let segmenter = Segmenter::new(Language::Japanese, None);
         let tags: Vec<&'static str> = vec!["U"; 7];
-        let chars = vec![
-            "B3".to_string(),
-            "B2".to_string(),
-            "B1".to_string(),
-            "あ".to_string(),
-            "い".to_string(),
-            "う".to_string(),
-            "E1".to_string(),
-        ];
+        let chars = vec!["B3", "B2", "B1", "あ", "い", "う", "E1"];
         let types: Vec<&'static str> = vec!["O"; 7];
         // i=2 is out of valid range [3, chars.len()-3); should panic on chars[i-3]
         let _ = segmenter.get_attributes(2, &tags, &chars, &types);
@@ -774,15 +770,7 @@ mod tests {
     fn test_get_attributes_panics_index_too_high() {
         let segmenter = Segmenter::new(Language::Japanese, None);
         let tags: Vec<&'static str> = vec!["U"; 7];
-        let chars = vec![
-            "B3".to_string(),
-            "B2".to_string(),
-            "B1".to_string(),
-            "あ".to_string(),
-            "い".to_string(),
-            "う".to_string(),
-            "E1".to_string(),
-        ];
+        let chars = vec!["B3", "B2", "B1", "あ", "い", "う", "E1"];
         let types: Vec<&'static str> = vec!["O"; 7];
         // i=5 means i+2=7 which exceeds chars.len()=7; should panic on chars[i+2]
         let _ = segmenter.get_attributes(5, &tags, &chars, &types);
@@ -795,13 +783,13 @@ mod tests {
         let tags: Vec<&'static str> = vec!["U"; 7];
 
         let chars = vec![
-            "B3".to_string(), // index 0
-            "B2".to_string(), // index 1
-            "B1".to_string(), // index 2
-            "한".to_string(), // index 3
-            "국".to_string(), // index 4
-            "어".to_string(), // index 5
-            "E1".to_string(), // index 6
+            "B3", // index 0
+            "B2", // index 1
+            "B1", // index 2
+            "한", // index 3
+            "국", // index 4
+            "어", // index 5
+            "E1", // index 6
         ];
 
         let types: Vec<&'static str> = vec!["O", "O", "O", "SF", "SF", "SN", "O"];


### PR DESCRIPTION
Closes #103 (part of #97)

## Summary

`segment()` / `segment_with_pos()` perform ~42 feature lookups per character. Four costs remained on that path after the Phase 4 refactor: SipHash on every short-string lookup, one `String` allocation per input character in `sentence_context`, an O(model-size) `bias()` recomputation per sentence, and a per-prediction scores `Vec` allocation.

## Changes (no public API change, no output change)

- Internal maps (`AdaBoost::feature_index`, perceptron `weights`/`accumulated`/`timestamps`, loader temp map) switched to `rustc_hash::FxHashMap` — keys are internally generated, so HashDoS resistance buys nothing. New dependency rustc-hash 2.1.1 (MIT OR Apache-2.0, zero transitive deps per `cargo tree`).
- AdaBoost bias cached in a field, refreshed by every weight-mutating path; sums in the same order as before → bit-identical value. New regression test `test_bias_cache_stays_consistent`.
- `predict_idx`/`predict_slice` reuse a caller-provided scores buffer across the `segment_with_pos`/`train`/`metrics` loops.
- `sentence_context` returns `(Vec<&str>, Vec<&'static str>)` borrowing from the input via `char_indices()` with capacity pre-sizing; sentinel literals used directly.

## Benchmarks (criterion medians vs saved baseline)

| Benchmark | Before | After | Change |
|---|---|---|---|
| segment_short/adaboost/japanese | 16.55 µs | 9.74 µs | **−38.7%** |
| segment_short/perceptron/japanese | 25.39 µs | 19.65 µs | −21.0% |
| segment_short/adaboost/chinese | 10.62 µs | 8.52 µs | −22.4% |
| segment_short/perceptron/chinese | 17.19 µs | 13.23 µs | −21.8% |
| segment_short/adaboost/korean | 13.32 µs | 11.17 µs | −21.1% |
| segment_short/perceptron/korean | — | 19.70 µs | −33.1% |
| segment_long_japanese/adaboost | ~185 ms | 154.6 ms | −16.1% * |
| segment_long_japanese/perceptron | ~298 ms | 249.5 ms | −16.2% |
| add_corpus | ~83.5 µs | 68.97 µs | −17.4% |
| predict_adaboost | ~759 ns | 229 ns | **−69.8%** (bias cache) |

\* First comparison pass was statistically insignificant noise (p = 0.25); a standalone re-run confirmed −16.1% (p < 0.05). The only "regression" is +3.4% on an untouched 6.8 ns nanobench (`get_type_hiragana`), i.e. noise.

## Correctness

- `cargo test --workspace`: 99 lib + 10 golden + 1 CLI + 6 doc tests pass — **golden outputs unchanged**, proving behavioral identity.
- clippy `-D warnings`, fmt, markdownlint clean.