### PR TITLE
perf: enable thin LTO and single codegen unit for release builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,18 @@ compatible: all pre-trained models in `models/` load unchanged.
 
 ### Performance
 
+Release profile tuning (#105): the workspace now sets `lto = "thin"` and
+`codegen-units = 1` for release builds, enabling cross-codegen-unit
+inlining of the per-character feature-scoring call chain. Long-text
+segmentation improved a further 10-13% and short-sentence segmentation up
+to 14% on the bundled criterion suite; a leaf release rebuild grows from
+~2.5 s to ~49 s as the compile-time cost. One nanobenchmark off the
+segmentation hot path (`AdaBoost::predict` on a `HashSet`, ~190 ns →
+~230 ns) regressed from changed inlining decisions and is accepted as a
+trade-off. `panic = "abort"` was considered and rejected: it cannot be
+scoped to the CLI binary alone and would complicate release-profile tests
+and benches that rely on unwinding.
+
 Training and model I/O (#104): the perceptron's three parallel training
 maps (`weights`/`accumulated`/`timestamps`) are merged into one slot map,
 so a weight update costs a single hashed lookup with no allocation on the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,15 @@
 resolver = "3"
 members = ["litsea", "litsea-cli"]
 
+# CPU-bound hot loops (feature-template scoring per character) benefit from
+# cross-codegen-unit inlining; thin LTO + a single codegen unit trades
+# release compile time for runtime performance (#105). `panic = "abort"` was
+# considered and rejected: it cannot be scoped to the CLI binary alone and
+# would complicate release-profile tests/benches that require unwinding.
+[profile.release]
+lto = "thin"
+codegen-units = 1
+
 [workspace.package]
 version = "0.5.0"
 edition = "2024"


### PR DESCRIPTION
Closes #105 (part of #97)

## Summary

The workspace had no `[profile.release]`, so release (and criterion) builds used the defaults (`codegen-units = 16`, no LTO). The per-character feature-scoring call chain crosses module boundaries (`write_attributes` → sink closure → `weight()` / slot lookups), which benefits directly from cross-codegen-unit inlining.

## Change

```toml
[profile.release]
lto = "thin"
codegen-units = 1
```

`panic = "abort"` was considered and **rejected**: the setting is top-level-only (cannot be scoped to the CLI binary), it complicates release-profile tests/benches that need unwinding, and its benefit here would be binary size rather than throughput. Documented in the Cargo.toml comment and CHANGELOG.

## Benchmarks (criterion vs saved baseline)

| Benchmark | Change |
|---|---|
| segment_long_japanese/adaboost | **−12.8%** |
| segment_long_japanese/perceptron | **−10.2%** |
| segment_short/adaboost/korean | −14.2% |
| segment_short/perceptron/korean | −12.4% |
| segment_short/adaboost/chinese | −10.5% |
| segment_short/adaboost/japanese | −1.4% |
| segment_short/perceptron/japanese, chinese | ~0% (noise) |
| add_corpus | −32.4% |
| predict_adaboost (off the segmentation hot path) | **+24% regression** * |

\* Confirmed by a standalone re-run (~190 → ~230 ns): an LLVM inlining artifact on `AdaBoost::predict(&HashSet)`, which `segment()` does not use (it sums via `weight()` directly). Accepted as a trade-off since every end-to-end benchmark improved or stayed flat; documented in the CHANGELOG.

## Compile-time cost

Leaf release rebuild: 2.53 s → 48.70 s (release-only; dev profile untouched).

## Verification

`cargo test --workspace` all green (100 lib + 10 golden + 1 CLI + 6 doc); clippy `-D warnings`, fmt, markdownlint clean.