### PR TITLE
test: pin AdaBoost convergence break and file-based trainer learning

### DIFF
--- a/litsea/src/adaboost.rs
+++ b/litsea/src/adaboost.rs
@@ -1251,6 +1251,38 @@ mod tests {
     }
 
     #[test]
+    fn test_train_stops_at_convergence_threshold() {
+        // Regression test for #106: training must stop via the
+        // `(0.5 - best_error_rate).abs() < threshold` break, not by
+        // exhausting num_iterations.
+        //
+        // Construction (threshold = 0.1): every instance carries the same
+        // feature "f", 11 positive and 9 negative. Baseline error = 0.55 and
+        // feature-f error = 0.45, both |0.5 - e| = 0.05, so h_best stays at
+        // the bias bucket with best_error_rate = 0.55, and 0.05 < 0.1 fires
+        // the break in round 1 BEFORE any model update. Without the break,
+        // alpha = 0.5 * ln(0.45/0.55) ~ -0.10 accumulates on model[0] every
+        // one of the 1000 iterations (~ -100), so the all-zero assertions
+        // below fail loudly.
+        let mut learner = AdaBoost::new(0.1, 1000);
+        for _ in 0..11 {
+            learner.add_instance(attrs_of("f"), 1);
+        }
+        for _ in 0..9 {
+            learner.add_instance(attrs_of("f"), -1);
+        }
+
+        learner.train(Arc::new(AtomicBool::new(true)));
+
+        assert!(
+            learner.model.iter().all(|w| *w == 0.0),
+            "model must stay untouched when the convergence break fires: {:?}",
+            learner.model
+        );
+        assert_eq!(learner.bias(), 0.0);
+    }
+
+    #[test]
     fn test_train_empty_learner_does_not_panic() {
         // Regression test for #98: train() on a learner with no instances
         // must be a no-op instead of panicking via NaN error rates.

--- a/litsea/src/trainer.rs
+++ b/litsea/src/trainer.rs
@@ -281,6 +281,39 @@ mod tests {
     }
 
     #[test]
+    fn test_trainer_trains_to_completion() -> Result<()> {
+        // Regression test for #106: the file-based pipeline
+        // (initialize_features -> initialize_instances -> train -> save)
+        // must actually learn when running stays true. The existing trainer
+        // tests only stop training before the first iteration.
+        let mut file = NamedTempFile::new().expect("Failed to create temp file");
+        for _ in 0..3 {
+            writeln!(file, "1\tfa").expect("write");
+            writeln!(file, "-1\tfb").expect("write");
+        }
+
+        let mut trainer = Trainer::new(0.01, 100, file.path())?;
+        let model_out = NamedTempFile::new()?;
+        let running = Arc::new(AtomicBool::new(true));
+
+        let metrics = trainer.train(running, model_out.path())?;
+
+        assert!(
+            (metrics.accuracy - 100.0).abs() < 1e-9,
+            "separable data must train to 100%, got {}",
+            metrics.accuracy
+        );
+        assert_eq!(metrics.true_positives, 3);
+        assert_eq!(metrics.true_negatives, 3);
+
+        // The trained model was saved with real content (weight lines plus
+        // the trailing bias line).
+        let saved = std::fs::read_to_string(model_out.path())?;
+        assert!(saved.lines().count() >= 2, "saved model looks empty: {saved:?}");
+        Ok(())
+    }
+
+    #[test]
     fn test_pos_trainer_preserves_trailing_unicode_whitespace() -> Result<()> {
         // Regression test for #99: a feature that ends its line with an
         // ideographic space (U+3000) must not be trimmed away while reading


### PR DESCRIPTION
Closes #106 (part of #97)

## Summary

At review time the AdaBoost training loop's learning behavior was completely untested — every test invoking `train()` stopped it before the first iteration. #98 closed most of that gap (`test_train_via_add_instance_learns`: separable data through `add_instance` in two registration orders → 100% accuracy). This PR pins the two remaining untested behaviors. Tests only; no implementation changes.

## New tests

1. **`test_train_stops_at_convergence_threshold`** — proves training stops via the `(0.5 − best_error_rate).abs() < threshold` break rather than exhausting `num_iterations`. The break runs *before* the model update, so with threshold = 0.1 and `{f}→+1 ×11 / {f}→−1 ×9` (baseline error 0.55, feature error 0.45, both within the threshold band) it fires in round 1 leaving the model all-zero; a broken break would accumulate α ≈ −0.10 per iteration on the bias bucket (≈ −100 over 1000 iterations), failing the assertions loudly.
2. **`test_trainer_trains_to_completion`** — the file-based pipeline (`Trainer::new` → `initialize_features`/`initialize_instances` → `train(running = true)` → `save_model`) actually learns: 100% accuracy on tab-separated separable data, TP = TN = 3, non-empty saved model.

## RED round-trip evidence

| Test | Temporarily disabled | Result |
|---|---|---|
| convergence | the threshold break in `train()` | FAILED (model diverges) → restored → ok |
| trainer | `self.learner.train(running)` in `Trainer::train` | FAILED (50% accuracy) → restored → ok |

## Verification

`cargo test --workspace`: 102 lib + 10 golden + 1 CLI + 6 doc tests pass; clippy `-D warnings`, fmt clean.