### PR TITLE
refactor!: redesign Segmenter construction and make segment_with_pos fallible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
-## 0.5.0 (unreleased)
+## 0.6.0 (unreleased)
 
-This release contains the breaking API changes from Phase 3 of the
-refactoring plan (`REFACTORING_PLAN.md`). Model files remain fully
-compatible: all pre-trained models in `models/` load unchanged.
+Note: crates.io already has 0.5.0 published, so the accumulated unreleased
+changes below (originally drafted under a "0.5.0 (unreleased)" heading)
+will ship as 0.6.0. This release contains the breaking API changes from
+Phase 3 of the refactoring plan (`REFACTORING_PLAN.md`) plus the #97
+quality campaign. Model files remain fully compatible: all pre-trained
+models in `models/` load unchanged.
 
 ### Added
 
@@ -82,6 +85,16 @@ compatible: all pre-trained models in `models/` load unchanged.
 
 ### Changed (breaking)
 
+- `Segmenter::new(language, Option<AdaBoost>)` is now
+  `Segmenter::new(language)` (default learner) plus
+  `Segmenter::with_learner(language, learner)`; the 0.01/100 default lives
+  in `impl Default for AdaBoost`. Migration:
+  `Segmenter::new(lang, None)` → `Segmenter::new(lang)`;
+  `Segmenter::new(lang, Some(l))` → `Segmenter::with_learner(lang, l)` (#127).
+- `Segmenter::segment_with_pos` returns
+  `litsea::Result<Vec<(String, Upos)>>` instead of panicking when no POS
+  learner is set (`LitseaError::PosLearnerNotSet`). Migration: append `?`
+  or `unwrap()` at call sites that previously relied on the panic (#127).
 - All fallible APIs now return `litsea::Result<T>` instead of
   `std::io::Result<T>` / `Result<T, Box<dyn Error>>`.
 - `AdaBoost::predict` takes `&HashSet<String>` instead of consuming the set.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "litsea"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion",
  "reqwest",
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "litsea-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "clap",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ lto = "thin"
 codegen-units = 1
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.87"
 description = "Litsea is an extremely compact word segmentation and model training tool implemented in Rust."
@@ -39,4 +39,4 @@ criterion = { version = "0.8.2", default-features = false, features = [
     "html_reports",
 ] }
 
-litsea = { version = "0.5.0", path = "./litsea" }
+litsea = { version = "0.6.0", path = "./litsea" }

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -48,7 +48,7 @@ There is a small plant called *Litsea cubeba* (Aomoji) in the same Lauraceae fam
 
 ## Current Version
 
-Litsea v0.5.0 -- Rust Edition 2024, minimum Rust version 1.87.
+Litsea v0.6.0 (unreleased) -- Rust Edition 2024, minimum Rust version 1.87.
 
 ## Links
 

--- a/docs/src/architecture/module-design.md
+++ b/docs/src/architecture/module-design.md
@@ -50,7 +50,7 @@ The main user-facing module.
   - `new(language, learner)` -- Create a segmenter with an optional pre-trained model
   - `with_pos_learner(language, pos_learner)` -- Create a segmenter for joint segmentation + POS tagging
   - `segment(sentence)` -- Segment text into words, returns `Vec<String>`
-  - `segment_with_pos(sentence)` -- Segment and tag, returns `Vec<(String, Upos)>`
+  - `segment_with_pos(sentence)` -- Segment and tag, returns `Result<Vec<(String, Upos)>>` (`PosLearnerNotSet` without a POS learner)
   - `char_type(ch)` -- Classify a single character into its type code
   - `add_corpus(corpus)` / `add_corpus_with_pos(corpus)` -- Add training data
   - `add_corpus_with_writer(corpus, callback)` / `add_corpus_with_pos_writer(corpus, callback)` -- Process a corpus with a custom callback

--- a/docs/src/architecture/workspace-structure.md
+++ b/docs/src/architecture/workspace-structure.md
@@ -103,7 +103,7 @@ resolver = "3"
 members = ["litsea", "litsea-cli"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.87"
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -35,7 +35,7 @@ Add Litsea to your project's `Cargo.toml`:
 
 ```toml
 [dependencies]
-litsea = "0.5.0"
+litsea = "0.6.0"
 ```
 
 > **Note:** Loading models from local files (`load_model_from_path`) is synchronous, so no async runtime is needed. An async runtime such as `tokio` is only required if you load models over HTTP/HTTPS with the async `load_model` method (enabled by the `remote_model` feature, which is on by default).

--- a/docs/src/getting-started/quick-start.md
+++ b/docs/src/getting-started/quick-start.md
@@ -65,7 +65,7 @@ fn main() -> litsea::Result<()> {
     learner.load_model_from_path(Path::new("./models/RWCP.model"))?;
 
     // Create a segmenter
-    let segmenter = Segmenter::new(Language::Japanese, Some(learner));
+    let segmenter = Segmenter::with_learner(Language::Japanese, learner);
 
     // Segment text
     let tokens = segmenter.segment("これはテストです。");
@@ -96,7 +96,7 @@ fn main() -> litsea::Result<()> {
     let segmenter = Segmenter::with_pos_learner(Language::Japanese, pos_learner);
 
     // Segment text with POS tags
-    let tokens = segmenter.segment_with_pos("今日はいい天気ですね。");
+    let tokens = segmenter.segment_with_pos("今日はいい天気ですね。")?;
     for (word, pos) in &tokens {
         print!("{}/{} ", word, pos);
     }

--- a/docs/src/language-support/adding-a-new-language.md
+++ b/docs/src/language-support/adding-a-new-language.md
@@ -136,7 +136,7 @@ fn test_thai_char_types() {
 // In segmenter.rs tests
 #[test]
 fn test_char_type_thai() {
-    let segmenter = Segmenter::new(Language::Thai, None);
+    let segmenter = Segmenter::new(Language::Thai);
     assert_eq!(segmenter.char_type("ก"), "T");
 }
 ```

--- a/docs/src/litsea.md
+++ b/docs/src/litsea.md
@@ -6,7 +6,7 @@ The `litsea` crate provides a Rust API for word segmentation, model training, an
 
 ```toml
 [dependencies]
-litsea = "0.5.0"
+litsea = "0.6.0"
 ```
 
 Loading models from local files is synchronous and needs no async runtime. An async runtime such as `tokio` is only required when loading models over HTTP/HTTPS with the async `load_model` method.
@@ -53,7 +53,7 @@ fn main() -> litsea::Result<()> {
     let mut learner = AdaBoost::new(0.01, 100);
     learner.load_model_from_path(Path::new("./models/RWCP.model"))?;
 
-    let segmenter = Segmenter::new(Language::Japanese, Some(learner));
+    let segmenter = Segmenter::with_learner(Language::Japanese, learner);
     let tokens = segmenter.segment("これはテストです。");
 
     assert_eq!(tokens, vec!["これ", "は", "テスト", "です", "。"]);
@@ -75,7 +75,7 @@ fn main() -> litsea::Result<()> {
     pos_learner.load_model_from_path(Path::new("./models/japanese_pos.model"))?;
 
     let segmenter = Segmenter::with_pos_learner(Language::Japanese, pos_learner);
-    let tokens = segmenter.segment_with_pos("これはテストです。");
+    let tokens = segmenter.segment_with_pos("これはテストです。")?;
 
     for (word, pos) in &tokens {
         print!("{}/{} ", word, pos);

--- a/docs/src/litsea/segmenter.md
+++ b/docs/src/litsea/segmenter.md
@@ -14,32 +14,38 @@ pub struct Segmenter {
 
 The fields are private; use the accessor methods `language()`, `learner()`, `learner_mut()`, `pos_learner()`, and `pos_learner_mut()` to reach them.
 
-## Constructor
+## Constructors
 
 ### `Segmenter::new`
 
 ```rust
-pub fn new(language: Language, learner: Option<AdaBoost>) -> Self
+pub fn new(language: Language) -> Self
 ```
 
-The POS learner is left unset; calling `segment_with_pos` on a segmenter
-built with `new()` panics. Use [`with_pos_learner`](#pos-mode-api) for joint
-segmentation + POS tagging.
+Creates a segmenter with a default (untrained) `AdaBoost` learner — suitable
+for training or feature extraction. Until a model is loaded or training data
+is added, `segment` returns one word per character. The POS learner is left
+unset; `segment_with_pos` returns `Err(LitseaError::PosLearnerNotSet)` — use
+[`with_pos_learner`](#pos-mode-api) for joint segmentation + POS tagging.
 
-Creates a new segmenter.
+### `Segmenter::with_learner`
 
-- `language` -- The language for character type classification
-- `learner` -- An optional pre-trained `AdaBoost` model. If `None`, a default (untrained) instance is created.
+```rust
+pub fn with_learner(language: Language, learner: AdaBoost) -> Self
+```
+
+Creates a segmenter with the given learner, typically one that has loaded a
+pre-trained model.
 
 ```rust
 use litsea::language::Language;
 use litsea::segmenter::Segmenter;
 
 // With a pre-trained model
-let segmenter = Segmenter::new(Language::Japanese, Some(learner));
+let segmenter = Segmenter::with_learner(Language::Japanese, learner);
 
 // Without a model (for training or feature extraction)
-let segmenter = Segmenter::new(Language::Japanese, None);
+let segmenter = Segmenter::new(Language::Japanese);
 ```
 
 ## Methods
@@ -66,7 +72,7 @@ pub fn char_type(&self, ch: &str) -> &str
 Classifies a single character into its type code using language-specific rules. The first character of the `&str` is classified; an empty string returns `"O"`.
 
 ```rust
-let segmenter = Segmenter::new(Language::Japanese, None);
+let segmenter = Segmenter::new(Language::Japanese);
 assert_eq!(segmenter.char_type("あ"), "I");  // Hiragana
 assert_eq!(segmenter.char_type("漢"), "H");  // Kanji
 assert_eq!(segmenter.char_type("A"), "A");   // ASCII
@@ -81,7 +87,7 @@ pub fn add_corpus(&mut self, corpus: &str)
 Processes a space-separated corpus and adds instances to the internal AdaBoost learner.
 
 ```rust
-let mut segmenter = Segmenter::new(Language::Japanese, None);
+let mut segmenter = Segmenter::new(Language::Japanese);
 segmenter.add_corpus("テスト です");
 ```
 
@@ -131,15 +137,16 @@ Creates a segmenter configured for joint segmentation + POS tagging.
 ### `segment_with_pos`
 
 ```rust
-pub fn segment_with_pos(&self, sentence: &str) -> Vec<(String, Upos)>
+pub fn segment_with_pos(&self, sentence: &str) -> Result<Vec<(String, Upos)>>
 ```
 
 Segments a sentence and jointly predicts each word's UPOS tag. The
 prediction at the first character position determines the first word's POS.
+An empty sentence yields `Ok` with an empty vector.
 
-**Panics** if no POS learner is set — build the segmenter with
-`with_pos_learner()` or register training data with `add_corpus_with_pos()`
-first.
+**Errors** with `LitseaError::PosLearnerNotSet` if no POS learner is set —
+build the segmenter with `with_pos_learner()` or register training data with
+`add_corpus_with_pos()` first.
 
 ```rust
 use std::path::Path;
@@ -152,7 +159,7 @@ let mut pos_learner = AveragedPerceptron::new();
 pos_learner.load_model_from_path(Path::new("./models/japanese_pos.model"))?;
 
 let segmenter = Segmenter::with_pos_learner(Language::Japanese, pos_learner);
-let tokens = segmenter.segment_with_pos("これはテストです。");
+let tokens = segmenter.segment_with_pos("これはテストです。")?;
 // [("これ", Upos::PRON), ("は", Upos::ADP), ("テスト", Upos::NOUN),
 //  ("です", Upos::AUX), ("。", Upos::PUNCT)]
 ```

--- a/litsea-cli/src/main.rs
+++ b/litsea-cli/src/main.rs
@@ -263,7 +263,7 @@ async fn segment(args: SegmentArgs) -> Result<(), Box<dyn Error>> {
             if line.is_empty() {
                 continue;
             }
-            let tokens = segmenter.segment_with_pos(line);
+            let tokens = segmenter.segment_with_pos(line)?;
             let formatted: Vec<String> =
                 tokens.iter().map(|(word, pos)| format!("{}/{}", word, pos)).collect();
             if !write_output_line(&mut writer, &formatted.join(" "))? {
@@ -275,7 +275,7 @@ async fn segment(args: SegmentArgs) -> Result<(), Box<dyn Error>> {
         let mut learner = AdaBoost::new(0.01, 100);
         learner.load_model(args.model_uri.as_str()).await?;
 
-        let segmenter = Segmenter::new(language, Some(learner));
+        let segmenter = Segmenter::with_learner(language, learner);
 
         for line in stdin.lock().lines() {
             let line = line?;

--- a/litsea/benches/bench.rs
+++ b/litsea/benches/bench.rs
@@ -55,7 +55,7 @@ fn bench_segment_short(c: &mut Criterion) {
 
         // AdaBoost (word segmentation only)
         let ada_learner = load_adaboost_model(ada_model);
-        let ada_segmenter = Segmenter::new(*language, Some(ada_learner));
+        let ada_segmenter = Segmenter::with_learner(*language, ada_learner);
         group.bench_with_input(BenchmarkId::new("adaboost", lang), &input, |b, &text| {
             b.iter(|| black_box(ada_segmenter.segment(black_box(text))));
         });
@@ -67,7 +67,7 @@ fn bench_segment_short(c: &mut Criterion) {
             BenchmarkId::new("averaged_perceptron", lang),
             &input,
             |b, &text| {
-                b.iter(|| black_box(pos_segmenter.segment_with_pos(black_box(text))));
+                b.iter(|| black_box(pos_segmenter.segment_with_pos(black_box(text)).unwrap()));
             },
         );
     }
@@ -89,7 +89,7 @@ fn bench_segment_long(c: &mut Criterion) {
 
     // AdaBoost
     let ada_learner = load_adaboost_model("japanese.model");
-    let ada_segmenter = Segmenter::new(Language::Japanese, Some(ada_learner));
+    let ada_segmenter = Segmenter::with_learner(Language::Japanese, ada_learner);
     group.bench_function("adaboost", |b| {
         b.iter(|| {
             for line in &lines {
@@ -104,7 +104,7 @@ fn bench_segment_long(c: &mut Criterion) {
     group.bench_function("averaged_perceptron", |b| {
         b.iter(|| {
             for line in &lines {
-                black_box(pos_segmenter.segment_with_pos(black_box(line)));
+                black_box(pos_segmenter.segment_with_pos(black_box(line)).unwrap());
             }
         });
     });
@@ -117,7 +117,7 @@ fn bench_segment_long(c: &mut Criterion) {
 // ---------------------------------------------------------------------------
 
 fn bench_char_type(c: &mut Criterion) {
-    let segmenter = Segmenter::new(Language::Japanese, None);
+    let segmenter = Segmenter::new(Language::Japanese);
     c.bench_function("get_type_hiragana", |b| {
         b.iter(|| black_box(segmenter.char_type(black_box("あ"))));
     });
@@ -126,7 +126,7 @@ fn bench_char_type(c: &mut Criterion) {
 fn bench_add_corpus(c: &mut Criterion) {
     c.bench_function("add_corpus", |b| {
         b.iter_batched(
-            || Segmenter::new(Language::Japanese, None),
+            || Segmenter::new(Language::Japanese),
             |mut segmenter| segmenter.add_corpus(black_box("これ は テスト です 。")),
             criterion::BatchSize::SmallInput,
         );
@@ -135,7 +135,7 @@ fn bench_add_corpus(c: &mut Criterion) {
 
 fn bench_predict_adaboost(c: &mut Criterion) {
     let learner = load_adaboost_model("japanese.model");
-    let segmenter = Segmenter::new(Language::Japanese, Some(learner));
+    let segmenter = Segmenter::with_learner(Language::Japanese, learner);
 
     // Capture a realistic attribute set from the corpus pipeline.
     let mut attrs = None;

--- a/litsea/src/adaboost.rs
+++ b/litsea/src/adaboost.rs
@@ -41,6 +41,14 @@ pub struct AdaBoost {
     cached_bias: f64,
 }
 
+impl Default for AdaBoost {
+    /// Creates a learner with the default hyperparameters used across the
+    /// library and CLI: `threshold = 0.01`, `num_iterations = 100`.
+    fn default() -> Self {
+        AdaBoost::new(0.01, 100)
+    }
+}
+
 impl AdaBoost {
     /// Creates a new instance of [`AdaBoost`].
     /// This method initializes the AdaBoost parameters such as threshold
@@ -853,6 +861,14 @@ mod tests {
         // When the same attribute is passed to predict, score returns 1 based on the initial model value (0.0) (because score>=0).
         let prediction = learner.predict(&attrs);
         assert_eq!(prediction, 1);
+    }
+
+    #[test]
+    fn test_adaboost_default_params() {
+        // #127: Default must match the documented library/CLI defaults.
+        let learner = AdaBoost::default();
+        assert!((learner.threshold - 0.01).abs() < f64::EPSILON);
+        assert_eq!(learner.num_iterations, 100);
     }
 
     #[test]

--- a/litsea/src/error.rs
+++ b/litsea/src/error.rs
@@ -22,6 +22,13 @@ pub enum LitseaError {
     #[error("unsupported: {0}")]
     Unsupported(&'static str),
 
+    /// `segment_with_pos` was called on a segmenter without a POS learner.
+    #[error(
+        "POS learner is not set; build the segmenter with with_pos_learner() \
+         or add training data with add_corpus_with_pos()"
+    )]
+    PosLearnerNotSet,
+
     /// Downloading a remote model failed.
     #[cfg(feature = "remote_model")]
     #[error("failed to download model: {0}")]

--- a/litsea/src/extractor.rs
+++ b/litsea/src/extractor.rs
@@ -35,7 +35,7 @@ impl Extractor {
     /// Returns a new instance of `Extractor` with a new `Segmenter` for the specified language.
     pub fn new(language: Language) -> Self {
         Extractor {
-            segmenter: Segmenter::new(language, None),
+            segmenter: Segmenter::new(language),
         }
     }
 

--- a/litsea/src/segmenter.rs
+++ b/litsea/src/segmenter.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::fmt::Write as _;
 
 use crate::adaboost::AdaBoost;
+use crate::error::{LitseaError, Result};
 use crate::language::Language;
 use crate::perceptron::AveragedPerceptron;
 use crate::upos::{SegmentLabel, Upos};
@@ -19,31 +20,54 @@ pub struct Segmenter {
 }
 
 impl Segmenter {
-    /// Creates a new instance of [`Segmenter`].
+    /// Creates a new instance of [`Segmenter`] with a default (untrained)
+    /// AdaBoost learner.
+    ///
+    /// The default learner has no trained weights, so [`segment`](Self::segment)
+    /// returns one word per character until a model is loaded (via
+    /// [`learner_mut`](Self::learner_mut)) or training data is added with
+    /// [`add_corpus`](Self::add_corpus). To start from a trained learner, use
+    /// [`with_learner`](Self::with_learner).
     ///
     /// # Arguments
     /// * `language` - The language to use for character type classification.
-    /// * `learner` - An optional AdaBoost instance. If None, a default AdaBoost instance is created.
     ///
     /// # Returns
-    /// A new Segmenter instance with the specified language and AdaBoost learner.
+    /// A new Segmenter instance with the specified language.
     ///
     /// # Example
     /// ```
     /// use litsea::language::Language;
     /// use litsea::segmenter::Segmenter;
     ///
-    /// let segmenter = Segmenter::new(Language::Japanese, None);
+    /// let segmenter = Segmenter::new(Language::Japanese);
     /// ```
-    pub fn new(language: Language, learner: Option<AdaBoost>) -> Self {
+    pub fn new(language: Language) -> Self {
+        Self::with_learner(language, AdaBoost::default())
+    }
+
+    /// Creates a new instance of [`Segmenter`] with the given AdaBoost
+    /// learner (typically one that has loaded a trained model).
+    ///
+    /// # Arguments
+    /// * `language` - The language to use for character type classification.
+    /// * `learner` - The AdaBoost learner to segment with.
+    ///
+    /// # Returns
+    /// A new Segmenter instance with the specified language and learner.
+    pub fn with_learner(language: Language, learner: AdaBoost) -> Self {
         Segmenter {
             language,
-            learner: learner.unwrap_or_else(|| AdaBoost::new(0.01, 100)),
+            learner,
             pos_learner: None,
         }
     }
 
     /// Creates a new instance of [`Segmenter`] with a POS learner.
+    ///
+    /// The AdaBoost learner is the untrained default: use
+    /// [`segment_with_pos`](Self::segment_with_pos) with this constructor;
+    /// [`segment`](Self::segment) would return one word per character.
     ///
     /// # Arguments
     /// * `language` - The language to use for character type classification.
@@ -54,7 +78,7 @@ impl Segmenter {
     pub fn with_pos_learner(language: Language, pos_learner: AveragedPerceptron) -> Self {
         Segmenter {
             language,
-            learner: AdaBoost::new(0.01, 100),
+            learner: AdaBoost::default(),
             pos_learner: Some(pos_learner),
         }
     }
@@ -101,7 +125,7 @@ impl Segmenter {
     /// use litsea::language::Language;
     /// use litsea::segmenter::Segmenter;
     ///
-    /// let segmenter = Segmenter::new(Language::Japanese, None);
+    /// let segmenter = Segmenter::new(Language::Japanese);
     /// let char_type = segmenter.char_type("あ");
     /// assert_eq!(char_type, "I"); // Hiragana
     /// ```
@@ -241,7 +265,7 @@ impl Segmenter {
     /// use litsea::language::Language;
     /// use litsea::segmenter::Segmenter;
     ///
-    /// let segmenter = Segmenter::new(Language::Japanese, None);
+    /// let segmenter = Segmenter::new(Language::Japanese);
     /// segmenter.add_corpus_with_writer("テスト です", |attrs, label| {
     ///    println!("Attributes: {:?}, Label: {}", attrs, label);
     /// });
@@ -268,7 +292,7 @@ impl Segmenter {
     /// use litsea::language::Language;
     /// use litsea::segmenter::Segmenter;
     ///
-    /// let mut segmenter = Segmenter::new(Language::Japanese, None);
+    /// let mut segmenter = Segmenter::new(Language::Japanese);
     /// segmenter.add_corpus("テスト です");
     /// ```
     /// This will process the corpus and add instances to the segmenter.
@@ -292,7 +316,7 @@ impl Segmenter {
     /// use litsea::language::Language;
     /// use litsea::segmenter::Segmenter;
     ///
-    /// let mut segmenter = Segmenter::new(Language::Japanese, None);
+    /// let mut segmenter = Segmenter::new(Language::Japanese);
     /// segmenter.add_corpus_with_pos("これ/PRON は/ADP テスト/NOUN です/AUX 。/PUNCT");
     /// ```
     pub fn add_corpus_with_pos(&mut self, corpus: &str) {
@@ -344,7 +368,7 @@ impl Segmenter {
     /// let mut learner = AdaBoost::new(0.01, 100);
     /// learner.load_model_from_path(&model_file).unwrap();
     ///
-    /// let segmenter = Segmenter::new(Language::Japanese, Some(learner));
+    /// let segmenter = Segmenter::with_learner(Language::Japanese, learner);
     /// let result = segmenter.segment("これはテストです。");
     /// assert_eq!(result, vec!["これ", "は", "テスト", "です", "。"]);
     /// ```
@@ -397,20 +421,18 @@ impl Segmenter {
     /// * `sentence` - The sentence to segment
     ///
     /// # Returns
-    /// `Vec<(String, Upos)>` - Pairs of words and their POS tags
+    /// `Result<Vec<(String, Upos)>>` - Pairs of words and their POS tags.
+    /// An empty sentence yields `Ok` with an empty vector.
     ///
-    /// # Panics
-    /// Panics if `pos_learner` is not set. Set it beforehand with
-    /// `with_pos_learner()` or `add_corpus_with_pos()`.
-    #[must_use]
-    pub fn segment_with_pos(&self, sentence: &str) -> Vec<(String, Upos)> {
+    /// # Errors
+    /// Returns [`LitseaError::PosLearnerNotSet`] if no POS learner is set.
+    /// Set one beforehand with [`with_pos_learner`](Self::with_pos_learner)
+    /// or [`add_corpus_with_pos`](Self::add_corpus_with_pos).
+    pub fn segment_with_pos(&self, sentence: &str) -> Result<Vec<(String, Upos)>> {
         if sentence.is_empty() {
-            return Vec::new();
+            return Ok(Vec::new());
         }
-        let pos_learner = self
-            .pos_learner
-            .as_ref()
-            .expect("pos_learner is not set. Use with_pos_learner() or add_corpus_with_pos().");
+        let pos_learner = self.pos_learner.as_ref().ok_or(LitseaError::PosLearnerNotSet)?;
 
         let (chars, types) = self.sentence_context(sentence);
         let mut tags: Vec<&'static str> = Vec::with_capacity(chars.len());
@@ -450,7 +472,7 @@ impl Segmenter {
         }
 
         result.push((word, current_pos));
-        result
+        Ok(result)
     }
 
     /// Builds the attribute set for a specific index (used by the corpus
@@ -596,7 +618,7 @@ mod tests {
 
     #[test]
     fn test_char_type_japanese() {
-        let segmenter = Segmenter::new(Language::Japanese, None);
+        let segmenter = Segmenter::new(Language::Japanese);
 
         assert_eq!(segmenter.char_type("あ"), "I"); // Hiragana
         assert_eq!(segmenter.char_type("漢"), "H"); // Kanji
@@ -609,7 +631,7 @@ mod tests {
 
     #[test]
     fn test_char_type_chinese() {
-        let segmenter = Segmenter::new(Language::Chinese, None);
+        let segmenter = Segmenter::new(Language::Chinese);
 
         assert_eq!(segmenter.char_type("的"), "F"); // Function word
         assert_eq!(segmenter.char_type("中"), "C"); // CJK Unified
@@ -622,7 +644,7 @@ mod tests {
 
     #[test]
     fn test_char_type_korean() {
-        let segmenter = Segmenter::new(Language::Korean, None);
+        let segmenter = Segmenter::new(Language::Korean);
 
         assert_eq!(segmenter.char_type("는"), "E"); // Particle (topic marker)
         assert_eq!(segmenter.char_type("가"), "SN"); // Hangul Syllable without 받침
@@ -636,7 +658,7 @@ mod tests {
 
     #[test]
     fn test_add_corpus_with_writer() {
-        let segmenter = Segmenter::new(Language::Japanese, None);
+        let segmenter = Segmenter::new(Language::Japanese);
         let sentence = "テスト です";
         let mut collected = Vec::new();
 
@@ -662,7 +684,7 @@ mod tests {
 
     #[test]
     fn test_add_corpus() {
-        let mut segmenter = Segmenter::new(Language::Japanese, None);
+        let mut segmenter = Segmenter::new(Language::Japanese);
         let sentence = "テスト です";
         segmenter.add_corpus(sentence);
         // Should not panic or add anything, just a smoke test
@@ -677,7 +699,7 @@ mod tests {
         let mut learner = AdaBoost::new(0.01, 100);
         learner.load_model_from_path(&model_file).unwrap();
 
-        let segmenter = Segmenter::new(Language::Japanese, Some(learner));
+        let segmenter = Segmenter::with_learner(Language::Japanese, learner);
 
         let result = segmenter.segment(sentence);
 
@@ -694,21 +716,21 @@ mod tests {
 
     #[test]
     fn test_add_sentence_empty() {
-        let mut segmenter = Segmenter::new(Language::Japanese, None);
+        let mut segmenter = Segmenter::new(Language::Japanese);
         segmenter.add_corpus("");
         // Should not panic or add anything
     }
 
     #[test]
     fn test_segment_empty_sentence() {
-        let segmenter = Segmenter::new(Language::Japanese, None);
+        let segmenter = Segmenter::new(Language::Japanese);
         let result = segmenter.segment("");
         assert!(result.is_empty());
     }
 
     #[test]
     fn test_get_attributes() {
-        let segmenter = Segmenter::new(Language::Japanese, None);
+        let segmenter = Segmenter::new(Language::Japanese);
 
         let tags: Vec<&'static str> = vec!["U"; 7];
 
@@ -739,7 +761,7 @@ mod tests {
 
     #[test]
     fn test_collect_attributes_reuses_buffer() {
-        let segmenter = Segmenter::new(Language::Japanese, None);
+        let segmenter = Segmenter::new(Language::Japanese);
         let tags: Vec<&'static str> = vec!["U"; 7];
         let chars = vec!["B3", "B2", "B1", "あ", "い", "う", "E1"];
         let types: Vec<&'static str> = vec!["O", "O", "O", "O", "I", "I", "O"];
@@ -760,7 +782,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_get_attributes_panics_index_too_low() {
-        let segmenter = Segmenter::new(Language::Japanese, None);
+        let segmenter = Segmenter::new(Language::Japanese);
         let tags: Vec<&'static str> = vec!["U"; 7];
         let chars = vec!["B3", "B2", "B1", "あ", "い", "う", "E1"];
         let types: Vec<&'static str> = vec!["O"; 7];
@@ -771,7 +793,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_get_attributes_panics_index_too_high() {
-        let segmenter = Segmenter::new(Language::Japanese, None);
+        let segmenter = Segmenter::new(Language::Japanese);
         let tags: Vec<&'static str> = vec!["U"; 7];
         let chars = vec!["B3", "B2", "B1", "あ", "い", "う", "E1"];
         let types: Vec<&'static str> = vec!["O"; 7];
@@ -781,7 +803,7 @@ mod tests {
 
     #[test]
     fn test_get_attributes_korean() {
-        let segmenter = Segmenter::new(Language::Korean, None);
+        let segmenter = Segmenter::new(Language::Korean);
 
         let tags: Vec<&'static str> = vec!["U"; 7];
 
@@ -811,7 +833,7 @@ mod tests {
 
     #[test]
     fn test_add_corpus_with_pos() {
-        let mut segmenter = Segmenter::new(Language::Japanese, None);
+        let mut segmenter = Segmenter::new(Language::Japanese);
         segmenter.add_corpus_with_pos("これ/PRON は/PART テスト/NOUN です/AUX 。/PUNCT");
         // pos_learner is initialized
         assert!(segmenter.pos_learner.is_some());
@@ -819,7 +841,7 @@ mod tests {
 
     #[test]
     fn test_add_corpus_with_pos_writer() {
-        let segmenter = Segmenter::new(Language::Japanese, None);
+        let segmenter = Segmenter::new(Language::Japanese);
         let corpus = "テスト/NOUN です/AUX";
         let mut collected = Vec::new();
 
@@ -848,7 +870,7 @@ mod tests {
         // segment_with_pos predicts at inference), while the AdaBoost
         // boundary pipeline keeps skipping it (the boundary label at the
         // first position is degenerate — always a word start).
-        let segmenter = Segmenter::new(Language::Japanese, None);
+        let segmenter = Segmenter::new(Language::Japanese);
 
         let mut pos_labels = Vec::new();
         segmenter.add_corpus_with_pos_writer("テスト/NOUN です/AUX", |_, label| {
@@ -866,7 +888,7 @@ mod tests {
 
     #[test]
     fn test_segment_with_pos() {
-        let mut segmenter = Segmenter::new(Language::Japanese, None);
+        let mut segmenter = Segmenter::new(Language::Japanese);
 
         // Add the training data multiple times and train
         for _ in 0..20 {
@@ -879,7 +901,7 @@ mod tests {
         segmenter.pos_learner.as_mut().unwrap().train(10, running);
 
         // Segmentation + POS tagging
-        let result = segmenter.segment_with_pos("これはテストです。");
+        let result = segmenter.segment_with_pos("これはテストです。").unwrap();
         assert!(!result.is_empty());
 
         // Verify the result is (word, POS) pairs
@@ -891,15 +913,26 @@ mod tests {
     }
 
     #[test]
+    fn test_segment_with_pos_without_learner_errors() {
+        // #127: calling segment_with_pos without a POS learner returns a
+        // recoverable error instead of panicking.
+        let segmenter = Segmenter::new(Language::Japanese);
+        let result = segmenter.segment_with_pos("これはテストです。");
+        assert!(matches!(result, Err(LitseaError::PosLearnerNotSet)));
+        // The empty sentence stays Ok regardless of learner state.
+        assert!(segmenter.segment_with_pos("").unwrap().is_empty());
+    }
+
+    #[test]
     fn test_segment_with_pos_empty() {
         let segmenter = Segmenter::with_pos_learner(Language::Japanese, AveragedPerceptron::new());
-        let result = segmenter.segment_with_pos("");
+        let result = segmenter.segment_with_pos("").unwrap();
         assert!(result.is_empty());
     }
 
     #[test]
     fn test_process_corpus_with_pos_empty() {
-        let segmenter = Segmenter::new(Language::Japanese, None);
+        let segmenter = Segmenter::new(Language::Japanese);
         let mut called = false;
         segmenter.add_corpus_with_pos_writer("", |_, _| {
             called = true;

--- a/litsea/tests/golden.rs
+++ b/litsea/tests/golden.rs
@@ -23,7 +23,7 @@ fn adaboost_segmenter(language: Language, model: &str) -> Segmenter {
     learner
         .load_model_from_path(&model_path(model))
         .unwrap_or_else(|e| panic!("failed to load {}: {}", model, e));
-    Segmenter::new(language, Some(learner))
+    Segmenter::with_learner(language, learner)
 }
 
 fn pos_segmenter(language: Language, model: &str) -> Segmenter {
@@ -43,7 +43,8 @@ fn assert_segment(segmenter: &Segmenter, cases: &[(&str, &[&str])]) {
 
 fn assert_segment_with_pos(segmenter: &Segmenter, cases: &[(&str, &[(&str, &str)])]) {
     for (input, expected) in cases {
-        let actual: Vec<(String, Upos)> = segmenter.segment_with_pos(input);
+        let actual: Vec<(String, Upos)> =
+            segmenter.segment_with_pos(input).expect("POS learner is set");
         let actual_str: Vec<(String, String)> =
             actual.into_iter().map(|(w, p)| (w, p.to_string())).collect();
         let expected_owned: Vec<(String, String)> =
@@ -234,7 +235,7 @@ fn golden_segment_with_pos_japanese() {
             ),
         ],
     );
-    assert!(segmenter.segment_with_pos("").is_empty());
+    assert!(segmenter.segment_with_pos("").expect("POS learner is set").is_empty());
 }
 
 #[test]
@@ -287,7 +288,7 @@ fn golden_segment_with_pos_chinese() {
             ),
         ],
     );
-    assert!(segmenter.segment_with_pos("").is_empty());
+    assert!(segmenter.segment_with_pos("").expect("POS learner is set").is_empty());
 }
 
 #[test]
@@ -335,7 +336,7 @@ fn golden_segment_with_pos_korean() {
             ),
         ],
     );
-    assert!(segmenter.segment_with_pos("").is_empty());
+    assert!(segmenter.segment_with_pos("").expect("POS learner is set").is_empty());
 }
 
 // ---------------------------------------------------------------------------
@@ -356,8 +357,8 @@ fn roundtrip_adaboost_model() {
     let mut reloaded = AdaBoost::new(0.01, 100);
     reloaded.load_model_from_path(temp.path()).unwrap();
 
-    let seg_original = Segmenter::new(Language::Japanese, Some(original));
-    let seg_reloaded = Segmenter::new(Language::Japanese, Some(reloaded));
+    let seg_original = Segmenter::with_learner(Language::Japanese, original);
+    let seg_reloaded = Segmenter::with_learner(Language::Japanese, reloaded);
     for s in sentences {
         assert_eq!(
             seg_original.segment(s),
@@ -385,8 +386,8 @@ fn roundtrip_perceptron_model() {
     let seg_reloaded = Segmenter::with_pos_learner(Language::Japanese, reloaded);
     for s in sentences {
         assert_eq!(
-            seg_original.segment_with_pos(s),
-            seg_reloaded.segment_with_pos(s),
+            seg_original.segment_with_pos(s).expect("POS learner is set"),
+            seg_reloaded.segment_with_pos(s).expect("POS learner is set"),
             "round-tripped Perceptron model diverged on {:?}",
             s
         );


### PR DESCRIPTION
Closes #127 (part of #109 → #97)

## Summary

Removes the library's last production-path panic and the `Option`-parameter constructor, per the design decided on #109 (Result approach).

## Breaking changes & migration

| Before | After |
|---|---|
| `Segmenter::new(lang, None)` | `Segmenter::new(lang)` |
| `Segmenter::new(lang, Some(learner))` | `Segmenter::with_learner(lang, learner)` |
| `segment_with_pos(s) -> Vec<(String, Upos)>` (panics without a POS learner) | `segment_with_pos(s) -> Result<Vec<(String, Upos)>>` (`Err(LitseaError::PosLearnerNotSet)`) |

- `impl Default for AdaBoost` now defines the 0.01/100 defaults exactly once (previously duplicated in three places).
- Docs on `new` / `with_pos_learner` / `segment` state that the default learner is untrained (one word per character until a model is loaded) — previously a silent trap.

## Version housekeeping

crates.io already has **0.5.0 published** while the CHANGELOG still said "0.5.0 (unreleased)" — the campaign's breaking changes have been accumulating unreleased on top of a published version. This PR bumps the workspace to **0.6.0**, retitles the CHANGELOG section (with an explanatory note), adds migration notes for both breaking changes above, and syncs doc version references.

## Tests

- New `test_segment_with_pos_without_learner_errors` (Err on non-empty, Ok on empty) — RED round-trip verified (error return temporarily bypassed → FAILED → restored).
- New `test_adaboost_default_params`.
- ~35 call sites migrated mechanically; **golden suite passes unchanged** (segmentation/POS behavior identical).

## Verification

`cargo test --workspace`: 104 lib + 10 golden + 8 CLI + 6 doc tests pass; clippy `-D warnings`, fmt, markdownlint, `mdbook build docs` clean.