### PR TITLE
refactor!: use typed FromStr errors and mark Language/LitseaError non_exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,16 @@ models in `models/` load unchanged.
 
 ### Changed (breaking)
 
+- `FromStr` for `Language`, `Upos`, and `SegmentLabel` now uses dedicated
+  thiserror-derived error types (`ParseLanguageError`, `ParseUposError`,
+  `ParseSegmentLabelError`, re-exported at the crate root) instead of
+  `type Err = String`. Display messages are unchanged (including the
+  clap-rendered CLI message), so only code that relied on the error being a
+  `String` needs updating (#128).
+- `Language` and `LitseaError` are now `#[non_exhaustive]`: external
+  exhaustive matches need a wildcard arm. `Upos` (fixed 17-tag UD standard)
+  and `SegmentLabel` (structurally complete) deliberately stay exhaustive
+  (#128).
 - `Segmenter::new(language, Option<AdaBoost>)` is now
   `Segmenter::new(language)` (default learner) plus
   `Segmenter::with_learner(language, learner)`; the 0.01/100 default lives

--- a/docs/src/architecture/workspace-structure.md
+++ b/docs/src/architecture/workspace-structure.md
@@ -86,7 +86,7 @@ The CLI provides a command-line interface to Litsea's functionality.
 | `clap` | 4.6 | Command-line argument parsing |
 | `ctrlc` | 3.5 | Graceful Ctrl+C handling during training |
 | `tokio` | 1.52+ | Async runtime |
-| `litsea` | 0.5 | Core library (workspace member) |
+| `litsea` | 0.6 | Core library (workspace member) |
 | `tempfile` | 3.27 | Temporary files for integration tests (dev dependency) |
 
 ## Workspace Configuration

--- a/litsea/src/error.rs
+++ b/litsea/src/error.rs
@@ -1,7 +1,12 @@
 //! Error types for the litsea library.
 
 /// Errors returned by litsea operations.
+///
+/// Marked `#[non_exhaustive]`: new variants are added as the library grows
+/// (e.g. `Download` and `PosLearnerNotSet` were later additions), so
+/// external matches must carry a wildcard arm.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum LitseaError {
     /// I/O failure while reading or writing files.
     #[error(transparent)]
@@ -19,6 +24,10 @@ pub enum LitseaError {
     /// The operation is not supported in this build or environment
     /// (e.g. remote models without the `remote_model` feature, or file
     /// system access on wasm32).
+    ///
+    /// Holds `&'static str` (unlike the owned `String` variants) on
+    /// purpose: every message is a compile-time constant, so an owned
+    /// string would allocate for no benefit.
     #[error("unsupported: {0}")]
     Unsupported(&'static str),
 

--- a/litsea/src/language.rs
+++ b/litsea/src/language.rs
@@ -1,8 +1,28 @@
 use std::fmt;
 use std::str::FromStr;
 
+/// Error returned when parsing a [`Language`] from a string fails.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("Unsupported language: '{input}'. Supported: japanese (ja), chinese (zh), korean (ko)")]
+pub struct ParseLanguageError {
+    input: String,
+}
+
+impl ParseLanguageError {
+    /// Returns the string that failed to parse.
+    #[must_use]
+    pub fn input(&self) -> &str {
+        &self.input
+    }
+}
+
 /// Supported languages for word segmentation.
+///
+/// Marked `#[non_exhaustive]`: new languages are expected to be added (the
+/// language-support guide documents the extension procedure), so external
+/// matches must carry a wildcard arm.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
 pub enum Language {
     /// Japanese (日本語)
     #[default]
@@ -24,17 +44,16 @@ impl fmt::Display for Language {
 }
 
 impl FromStr for Language {
-    type Err = String;
+    type Err = ParseLanguageError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "japanese" | "ja" => Ok(Language::Japanese),
             "chinese" | "zh" => Ok(Language::Chinese),
             "korean" | "ko" => Ok(Language::Korean),
-            _ => Err(format!(
-                "Unsupported language: '{}'. Supported: japanese (ja), chinese (zh), korean (ko)",
-                s
-            )),
+            _ => Err(ParseLanguageError {
+                input: s.to_string(),
+            }),
         }
     }
 }
@@ -175,6 +194,18 @@ mod tests {
         assert_eq!("KOREAN".parse::<Language>().unwrap(), Language::Korean);
         assert!("french".parse::<Language>().is_err());
         assert!("".parse::<Language>().is_err());
+    }
+
+    #[test]
+    fn test_parse_language_error_message() {
+        // #128: the typed parse error must render the exact message the CLI
+        // shows through clap (pinned end-to-end by the CLI integration test).
+        let err = "french".parse::<Language>().unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Unsupported language: 'french'. Supported: japanese (ja), chinese (zh), korean (ko)"
+        );
+        assert_eq!(err.input(), "french");
     }
 
     #[test]

--- a/litsea/src/lib.rs
+++ b/litsea/src/lib.rs
@@ -24,17 +24,17 @@ pub mod upos;
 pub use adaboost::AdaBoost;
 pub use error::{LitseaError, Result};
 pub use extractor::Extractor;
-pub use language::Language;
+pub use language::{Language, ParseLanguageError};
 pub use metrics::{BinaryMetrics, MulticlassMetrics};
 pub use perceptron::AveragedPerceptron;
 pub use segmenter::Segmenter;
 pub use trainer::{PosTrainer, Trainer};
-pub use upos::{SegmentLabel, Upos};
+pub use upos::{ParseSegmentLabelError, ParseUposError, SegmentLabel, Upos};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Returns the version of the litsea crate (the `CARGO_PKG_VERSION` it was
-/// built with), e.g. `"0.5.0"`.
+/// built with), e.g. `"0.6.0"`.
 #[must_use]
 pub fn version() -> &'static str {
     VERSION

--- a/litsea/src/perceptron.rs
+++ b/litsea/src/perceptron.rs
@@ -259,13 +259,17 @@ impl AveragedPerceptron {
                     break;
                 }
 
-                let guess_idx = self
-                    .predict_idx_into(features.iter(), &mut scores)
-                    .expect("classes registered");
-                let truth_idx = self
-                    .classes
-                    .binary_search_by(|c| c.as_str().cmp(truth))
-                    .expect("truth class registered by add_instance");
+                // Invariant: instances are non-empty here, and add_instance
+                // registers a class for every instance, so classes cannot be
+                // empty; degrade gracefully instead of panicking if the
+                // invariant is ever broken.
+                let Some(guess_idx) = self.predict_idx_into(features.iter(), &mut scores) else {
+                    break;
+                };
+                // Invariant: add_instance registered the gold class.
+                let Ok(truth_idx) = self.classes.binary_search_by(|c| c.as_str().cmp(truth)) else {
+                    continue;
+                };
                 if guess_idx != truth_idx {
                     self.update(truth_idx, guess_idx, features);
                 }

--- a/litsea/src/upos.rs
+++ b/litsea/src/upos.rs
@@ -90,8 +90,23 @@ impl fmt::Display for Upos {
     }
 }
 
+/// Error returned when parsing a [`Upos`] tag from a string fails.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("Unknown UPOS tag: '{input}'")]
+pub struct ParseUposError {
+    input: String,
+}
+
+impl ParseUposError {
+    /// Returns the string that failed to parse.
+    #[must_use]
+    pub fn input(&self) -> &str {
+        &self.input
+    }
+}
+
 impl FromStr for Upos {
-    type Err = String;
+    type Err = ParseUposError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
@@ -112,7 +127,9 @@ impl FromStr for Upos {
             "SYM" => Ok(Upos::SYM),
             "VERB" => Ok(Upos::VERB),
             "X" => Ok(Upos::X),
-            _ => Err(format!("Unknown UPOS tag: '{}'", s)),
+            _ => Err(ParseUposError {
+                input: s.to_string(),
+            }),
         }
     }
 }
@@ -135,8 +152,23 @@ impl fmt::Display for SegmentLabel {
     }
 }
 
+/// Error returned when parsing a [`SegmentLabel`] from a string fails.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ParseSegmentLabelError {
+    /// The input is neither `O` nor of the form `B-<UPOS>`.
+    #[error("Invalid segment label: '{input}'. Expected 'O' or 'B-<UPOS>'")]
+    InvalidFormat {
+        /// The string that failed to parse.
+        input: String,
+    },
+    /// The `B-` prefix carried an unknown UPOS tag; the inner error message
+    /// is propagated unchanged.
+    #[error(transparent)]
+    InvalidPos(#[from] ParseUposError),
+}
+
 impl FromStr for SegmentLabel {
-    type Err = String;
+    type Err = ParseSegmentLabelError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s == "O" {
@@ -145,7 +177,9 @@ impl FromStr for SegmentLabel {
             let pos: Upos = pos_str.parse()?;
             Ok(SegmentLabel::B(pos))
         } else {
-            Err(format!("Invalid segment label: '{}'. Expected 'O' or 'B-<UPOS>'", s))
+            Err(ParseSegmentLabelError::InvalidFormat {
+                input: s.to_string(),
+            })
         }
     }
 }
@@ -184,6 +218,26 @@ mod tests {
             let parsed: Upos = s.parse().unwrap();
             assert_eq!(parsed, pos);
         }
+    }
+
+    #[test]
+    fn test_parse_upos_error_message() {
+        // #128: message identical to the former String error.
+        let err = "FOO".parse::<Upos>().unwrap_err();
+        assert_eq!(err.to_string(), "Unknown UPOS tag: 'FOO'");
+        assert_eq!(err.input(), "FOO");
+    }
+
+    #[test]
+    fn test_parse_segment_label_error_messages() {
+        // #128: the invalid-format case keeps its own message...
+        let err = "Z-NOUN".parse::<SegmentLabel>().unwrap_err();
+        assert_eq!(err.to_string(), "Invalid segment label: 'Z-NOUN'. Expected 'O' or 'B-<UPOS>'");
+        // ...and B-<invalid> transparently propagates the Upos message, as
+        // the former `?` on a String error did.
+        let err = "B-FOO".parse::<SegmentLabel>().unwrap_err();
+        assert_eq!(err.to_string(), "Unknown UPOS tag: 'FOO'");
+        assert!(matches!(err, ParseSegmentLabelError::InvalidPos(_)));
     }
 
     #[test]


### PR DESCRIPTION
Closes #128 (part of #109 → #97)

## Summary

Aligns the parsing and error surface with the project's thiserror policy and removes the last panicking calls from production paths.

## Breaking changes & migration

- **Typed `FromStr` errors**: `Language` / `Upos` / `SegmentLabel` now return `ParseLanguageError` / `ParseUposError` / `ParseSegmentLabelError` (thiserror-derived, re-exported at the crate root) instead of `String`. Display messages are byte-identical — including the clap-rendered CLI message (pinned end-to-end by the existing CLI integration test) and the transparent Upos-message propagation for `B-<invalid>` labels — so only code that relied on `Err` being a `String` needs updating.
- **`#[non_exhaustive]`** on `Language` (new languages are roadmapped) and `LitseaError` (gained variants twice this campaign): external exhaustive matches need a wildcard arm. `Upos` (fixed 17-tag UD standard) and `SegmentLabel` (structurally complete) deliberately stay exhaustive; rationale documented on each type.

## Non-breaking pieces

- `LitseaError::Unsupported(&'static str)` kept, with a doc comment justifying the shape (all messages are compile-time constants).
- The two invariant-guarded `expect()`s in `AveragedPerceptron::train` became `let ... else { break/continue }` with invariant comments — **zero panicking calls remain on production paths**.
- Piggybacked doc fix: `workspace-structure.md` dependency table `litsea | 0.5` → `0.6` (leftover from the #127 bump); `version()` doc example → 0.6.0.

## Tests

Three new Display-message pinning tests (incl. transparent `B-FOO` propagation); RED round-trip verified on the representative one (message altered → FAILED → restored). Full suite: 107 lib + 10 golden + 8 CLI + 6 doc tests pass, golden outputs unchanged; clippy `-D warnings`, fmt, markdownlint, `mdbook build docs` clean.