### PR TITLE
refactor!: polish API surface and make remote_model opt-in

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -109,5 +109,10 @@ jobs:
       - name: Check without default features
         run: cargo check -p litsea --no-default-features
 
+      - name: Test with default (local-only) features
+        # The platform matrix tests --all-features; this lane covers the
+        # lean default configuration (remote_model is opt-in since #129).
+        run: cargo test -p litsea
+
       - name: Check wasm32 target
         run: cargo check -p litsea --target wasm32-unknown-unknown --no-default-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ models in `models/` load unchanged.
   Trainer, Upos, BinaryMetrics, MulticlassMetrics}`.
 - `Segmenter` accessors: `language()`, `learner()`, `learner_mut()`,
   `pos_learner()`, `pos_learner_mut()`.
+- `Debug` implementations for `Segmenter`, `Extractor`, `Trainer`, and
+  `PosTrainer`; `Extractor::extract` / `extract_with_pos` take `&self`
+  (they never mutate); CLI help texts are in English and subcommands
+  inherit the version via `propagate_version` (#129).
 
 ### Fixed
 
@@ -85,6 +89,17 @@ models in `models/` load unchanged.
 
 ### Changed (breaking)
 
+- `AdaBoost::threshold` / `num_iterations` are private; read them via the
+  new `threshold()` / `num_iterations()` accessors (set them via `new`) (#129).
+- All `train` methods take `running: &AtomicBool` instead of
+  `Arc<AtomicBool>`. Migration: pass `&running` (keep the `Arc` only if you
+  share the flag with e.g. a signal handler) (#129).
+- `Segmenter::char_type` takes `char` and returns `&'static str`, aligned
+  with `Language::char_type`; the empty-string case no longer exists (#129).
+- The `remote_model` feature is no longer a default feature: the library
+  default is local model loading only. Enable it explicitly for
+  `http(s)://` model URIs (`features = ["remote_model"]`); the CLI enables
+  it and is unchanged (#129).
 - `FromStr` for `Language`, `Upos`, and `SegmentLabel` now uses dedicated
   thiserror-derived error types (`ParseLanguageError`, `ParseUposError`,
   `ParseSegmentLabelError`, re-exported at the crate root) instead of

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -12,7 +12,7 @@ Unlike traditional morphological analyzers such as [MeCab](https://taku910.githu
 - **POS tagging** -- joint segmentation and Part-of-Speech tagging with UPOS tags via Averaged Perceptron
 - **Multilingual support** -- Japanese, Chinese (Simplified/Traditional), and Korean
 - **Model training capabilities** -- train custom models using AdaBoost or Averaged Perceptron with your own corpora
-- **Remote model loading** -- load models from HTTP/HTTPS URLs or local files
+- **Remote model loading** -- load models from HTTP/HTTPS URLs (opt-in `remote_model` feature) or local files
 - **Simple and extensible API** -- easy to integrate into Rust projects as a library
 
 ## How It Works

--- a/docs/src/advanced/remote-model-loading.md
+++ b/docs/src/advanced/remote-model-loading.md
@@ -29,6 +29,17 @@ learner.load_model_from_path(Path::new("./models/japanese.model"))?; // local, s
 learner.load_model("https://example.com/models/japanese.model").await?;
 ```
 
+## Enabling the Feature
+
+Since 0.6.0 the `remote_model` feature is **opt-in** (the library default is
+local loading only, keeping the dependency tree compact). The CLI enables it,
+so `litsea segment https://...` keeps working out of the box; library users
+need:
+
+```toml
+litsea = { version = "0.6.0", features = ["remote_model"] }
+```
+
 ## Implementation Details
 
 - HTTP client: **reqwest** with **rustls** (no OpenSSL dependency)

--- a/docs/src/algorithm/averaged-perceptron.md
+++ b/docs/src/algorithm/averaged-perceptron.md
@@ -88,14 +88,13 @@ For each epoch (1 to num_epochs):
 Training supports graceful interruption via `AtomicBool` -- a Ctrl+C signal stops training and saves the model at its current state.
 
 ```rust
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use litsea::perceptron::AveragedPerceptron;
 
 let mut perceptron = AveragedPerceptron::new();
 // ... add instances ...
-let running = Arc::new(AtomicBool::new(true));
-perceptron.train(10, running);  // 10 epochs
+let running = AtomicBool::new(true);
+perceptron.train(10, &running);  // 10 epochs
 ```
 
 ## Model File Format

--- a/docs/src/architecture/module-design.md
+++ b/docs/src/architecture/module-design.md
@@ -75,7 +75,7 @@ The multiclass classifier used for joint segmentation + POS tagging.
 
 - **`AveragedPerceptron`**
   - `add_instance(features, label)` -- Add a training instance
-  - `train(num_epochs, running)` -- Train with weight averaging
+  - `train(num_epochs, running)` -- Train with weight averaging (`running: &AtomicBool`)
   - `predict(&features)` -- Predict the best class label
   - `load_model(uri)` (async) / `load_model_from_path(path)` / `load_model_from_reader(reader)` -- Load model weights
   - `save_model(path)` -- Save model weights

--- a/docs/src/architecture/workspace-structure.md
+++ b/docs/src/architecture/workspace-structure.md
@@ -72,7 +72,7 @@ The core library provides all segmentation, training, and model I/O functionalit
 |-----------|---------|---------|
 | `rustc-hash` | 2.1 | Fast hashing for internal feature maps |
 | `thiserror` | 2.0 | Error type derivation |
-| `reqwest` | 0.13 | HTTP/HTTPS model loading (rustls, optional `remote_model` feature) |
+| `reqwest` | 0.13 | HTTP/HTTPS model loading (rustls, opt-in `remote_model` feature) |
 | `criterion` | 0.8 | Benchmarking (dev dependency) |
 | `tempfile` | 3.27 | Temporary files for tests (dev dependency) |
 | `tokio` | 1.52+ | Async runtime for tests (dev dependency) |
@@ -86,7 +86,7 @@ The CLI provides a command-line interface to Litsea's functionality.
 | `clap` | 4.6 | Command-line argument parsing |
 | `ctrlc` | 3.5 | Graceful Ctrl+C handling during training |
 | `tokio` | 1.52+ | Async runtime |
-| `litsea` | 0.6 | Core library (workspace member) |
+| `litsea` | 0.6 | Core library (workspace member, `remote_model` enabled) |
 | `tempfile` | 3.27 | Temporary files for integration tests (dev dependency) |
 
 ## Workspace Configuration

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -38,6 +38,13 @@ Add Litsea to your project's `Cargo.toml`:
 litsea = "0.6.0"
 ```
 
+Remote model loading over http(s) is opt-in; enable the `remote_model`
+feature if you need it:
+
+```toml
+litsea = { version = "0.6.0", features = ["remote_model"] }
+```
+
 > **Note:** Loading models from local files (`load_model_from_path`) is synchronous, so no async runtime is needed. An async runtime such as `tokio` is only required if you load models over HTTP/HTTPS with the async `load_model` method (enabled by the `remote_model` feature, which is on by default).
 
 ## Supported Platforms

--- a/docs/src/litsea/adaboost.md
+++ b/docs/src/litsea/adaboost.md
@@ -6,8 +6,8 @@ The `AdaBoost` struct implements binary classification for word boundary detecti
 
 ```rust
 pub struct AdaBoost {
-    pub threshold: f64,
-    pub num_iterations: usize,
+    // private: threshold: f64, num_iterations: usize
+    // (read via threshold() / num_iterations())
     // internal fields: model weights, features, instances, etc.
 }
 ```
@@ -98,7 +98,7 @@ Reads the same features file and initializes labeled instances with their weight
 ### `train`
 
 ```rust
-pub fn train(&mut self, running: Arc<AtomicBool>)
+pub fn train(&mut self, running: &AtomicBool)
 ```
 
 Runs the AdaBoost training loop. Set `running` to `false` to stop early.

--- a/docs/src/litsea/averaged-perceptron.md
+++ b/docs/src/litsea/averaged-perceptron.md
@@ -52,16 +52,15 @@ learner.add_instance(feats, "B-NOUN".to_string());
 ### `train`
 
 ```rust
-pub fn train(&mut self, num_epochs: usize, running: Arc<AtomicBool>)
+pub fn train(&mut self, num_epochs: usize, running: &AtomicBool)
 ```
 
 Runs the Averaged Perceptron training loop for the given number of epochs. Set `running` to `false` to stop early. Weights are automatically averaged at the end of training.
 
 ```rust
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
-let running = Arc::new(AtomicBool::new(true));
+let running = AtomicBool::new(true);
 learner.train(10, running);
 ```
 

--- a/docs/src/litsea/extractor.md
+++ b/docs/src/litsea/extractor.md
@@ -33,7 +33,7 @@ let mut extractor = Extractor::new(Language::Japanese);
 
 ```rust
 pub fn extract(
-    &mut self,
+    &self,
     corpus_path: &Path,
     features_path: &Path,
 ) -> litsea::Result<()>
@@ -68,7 +68,7 @@ The extractor:
 
 ```rust
 pub fn extract_with_pos(
-    &mut self,
+    &self,
     corpus_path: &Path,
     features_path: &Path,
 ) -> litsea::Result<()>

--- a/docs/src/litsea/segmenter.md
+++ b/docs/src/litsea/segmenter.md
@@ -66,16 +66,16 @@ let tokens = segmenter.segment("これはテストです。");
 ### `char_type`
 
 ```rust
-pub fn char_type(&self, ch: &str) -> &str
+pub fn char_type(&self, c: char) -> &'static str
 ```
 
-Classifies a single character into its type code using language-specific rules. The first character of the `&str` is classified; an empty string returns `"O"`.
+Classifies a character into its language-specific type code (delegates to `Language::char_type`).
 
 ```rust
 let segmenter = Segmenter::new(Language::Japanese);
-assert_eq!(segmenter.char_type("あ"), "I");  // Hiragana
-assert_eq!(segmenter.char_type("漢"), "H");  // Kanji
-assert_eq!(segmenter.char_type("A"), "A");   // ASCII
+assert_eq!(segmenter.char_type('あ'), "I");  // Hiragana
+assert_eq!(segmenter.char_type('漢'), "H");  // Kanji
+assert_eq!(segmenter.char_type('A'), "A");   // ASCII
 ```
 
 ### `add_corpus`

--- a/docs/src/litsea/trainer.md
+++ b/docs/src/litsea/trainer.md
@@ -56,7 +56,7 @@ trainer.load_model("./models/japanese.model").await?;
 ```rust
 pub fn train(
     &mut self,
-    running: Arc<AtomicBool>,
+    running: &AtomicBool,
     model_path: &Path,
 ) -> litsea::Result<BinaryMetrics>
 ```
@@ -66,12 +66,11 @@ Trains the model and saves it to the specified path. Returns evaluation metrics.
 The `running` flag enables graceful interruption -- set it to `false` to stop training early.
 
 ```rust
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::path::Path;
 
-let running = Arc::new(AtomicBool::new(true));
-let metrics = trainer.train(running, Path::new("./model.model"))?;
+let running = AtomicBool::new(true);
+let metrics = trainer.train(&running, Path::new("./model.model"))?;
 
 println!("Accuracy: {:.2}%", metrics.accuracy);
 ```
@@ -79,7 +78,6 @@ println!("Accuracy: {:.2}%", metrics.accuracy);
 ## Full Training Example
 
 ```rust
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::path::Path;
 
@@ -96,8 +94,8 @@ async fn main() -> litsea::Result<()> {
     // Optionally resume from an existing model
     // trainer.load_model("./models/japanese.model").await?;
 
-    let running = Arc::new(AtomicBool::new(true));
-    let metrics = trainer.train(running, Path::new("./model.model"))?;
+    let running = AtomicBool::new(true);
+    let metrics = trainer.train(&running, Path::new("./model.model"))?;
 
     println!("Accuracy:  {:.2}%", metrics.accuracy);
     println!("Precision: {:.2}%", metrics.precision);
@@ -137,7 +135,7 @@ registered from the training data are merged with the model's classes.
 ```rust
 pub fn train(
     &mut self,
-    running: Arc<AtomicBool>,
+    running: &AtomicBool,
     model_path: &Path,
 ) -> litsea::Result<MulticlassMetrics>
 ```
@@ -147,7 +145,6 @@ multiclass metrics (accuracy, macro precision, macro recall). The `running`
 flag enables graceful interruption, like `Trainer::train`.
 
 ```rust
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::path::Path;
 
@@ -156,8 +153,8 @@ use litsea::trainer::PosTrainer;
 #[tokio::main]
 async fn main() -> litsea::Result<()> {
     let mut trainer = PosTrainer::new(10, Path::new("./features_pos.txt"))?;
-    let running = Arc::new(AtomicBool::new(true));
-    let metrics = trainer.train(running, Path::new("./japanese_pos.model"))?;
+    let running = AtomicBool::new(true);
+    let metrics = trainer.train(&running, Path::new("./japanese_pos.model"))?;
     println!("Accuracy: {:.2}%", metrics.accuracy);
     Ok(())
 }

--- a/litsea-cli/Cargo.toml
+++ b/litsea-cli/Cargo.toml
@@ -17,7 +17,7 @@ clap.workspace = true
 ctrlc.workspace = true
 tokio.workspace = true
 
-litsea.workspace = true
+litsea = { workspace = true, features = ["remote_model"] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/litsea-cli/src/main.rs
+++ b/litsea-cli/src/main.rs
@@ -12,17 +12,13 @@ use litsea::{AdaBoost, AveragedPerceptron, Extractor, Language, PosTrainer, Segm
 
 /// Arguments for the extract command.
 #[derive(Debug, Args)]
-#[command(
-    author,
-    about = "Extract features from a corpus",
-    version = version(),
-)]
+#[command(about = "Extract features from a corpus")]
 struct ExtractArgs {
     #[arg(short, long, default_value = "japanese", value_parser = Language::from_str)]
     language: Language,
 
-    /// 品詞付きコーパスから特徴量を抽出する（コーパスフォーマット: "単語/品詞 単語/品詞 ..."）
-    #[arg(long, default_value = "false")]
+    /// Extract features from a POS-tagged corpus (format: "word/POS word/POS ...")
+    #[arg(long)]
     pos: bool,
 
     corpus_file: PathBuf,
@@ -31,10 +27,7 @@ struct ExtractArgs {
 
 /// Arguments for the train command.
 #[derive(Debug, Args)]
-#[command(author,
-    about = "Train a segmenter",
-    version = version(),
-)]
+#[command(about = "Train a segmenter")]
 struct TrainArgs {
     #[arg(short, long, default_value = "0.01")]
     threshold: f64,
@@ -45,11 +38,11 @@ struct TrainArgs {
     #[arg(short = 'm', long)]
     load_model_uri: Option<String>,
 
-    /// Averaged Perceptronで品詞推定モデルを学習する
-    #[arg(long, default_value = "false")]
+    /// Train a POS tagging model with the Averaged Perceptron
+    #[arg(long)]
     pos: bool,
 
-    /// 品詞モデル学習時のエポック数
+    /// Number of training epochs for the POS model
     #[arg(long, default_value = "10")]
     num_epochs: usize,
 
@@ -59,16 +52,13 @@ struct TrainArgs {
 
 /// Arguments for the segment command.
 #[derive(Debug, Args)]
-#[command(author,
-    about = "Segment a sentence",
-    version = version(),
-)]
+#[command(about = "Segment a sentence")]
 struct SegmentArgs {
     #[arg(short, long, default_value = "japanese", value_parser = Language::from_str)]
     language: Language,
 
-    /// 品詞推定付きで分割する（Averaged Perceptronモデルを使用）
-    #[arg(long, default_value = "false")]
+    /// Segment with POS tagging (requires an Averaged Perceptron model)
+    #[arg(long)]
     pos: bool,
 
     model_uri: String,
@@ -89,6 +79,7 @@ enum Commands {
     author,
     about = "A morphological analysis command line interface",
     version = version(),
+    propagate_version = true,
 )]
 struct CommandArgs {
     #[command(subcommand)]
@@ -105,7 +96,7 @@ struct CommandArgs {
 /// # Returns
 /// Returns a Result indicating success or failure.
 fn extract(args: ExtractArgs) -> Result<(), Box<dyn Error>> {
-    let mut extractor = Extractor::new(args.language);
+    let extractor = Extractor::new(args.language);
 
     if args.pos {
         extractor.extract_with_pos(args.corpus_file.as_path(), args.features_file.as_path())?;
@@ -139,21 +130,21 @@ async fn train(args: TrainArgs) -> Result<(), Box<dyn Error>> {
     })?;
 
     if args.pos {
-        // Averaged Perceptronによる品詞推定モデルの学習
+        // Train the POS tagging model with the Averaged Perceptron
         let mut trainer = PosTrainer::new(args.num_epochs, args.features_file.as_path())?;
 
         if let Some(model_uri) = &args.load_model_uri {
             trainer.load_model(model_uri).await?;
         }
 
-        let metrics = trainer.train(running, args.model_file.as_path())?;
+        let metrics = trainer.train(&running, args.model_file.as_path())?;
 
         eprintln!("Result Metrics (POS):");
         eprintln!("  Accuracy: {:.2}% ( {} )", metrics.accuracy, metrics.num_instances);
         eprintln!("  Macro Precision: {:.2}%", metrics.macro_precision);
         eprintln!("  Macro Recall: {:.2}%", metrics.macro_recall);
     } else {
-        // 既存のAdaBoostによる単語分割モデルの学習
+        // Train the word segmentation model with AdaBoost
         let mut trainer =
             Trainer::new(args.threshold, args.num_iterations, args.features_file.as_path())?;
 
@@ -161,7 +152,7 @@ async fn train(args: TrainArgs) -> Result<(), Box<dyn Error>> {
             trainer.load_model(model_uri).await?;
         }
 
-        let metrics = trainer.train(running, args.model_file.as_path())?;
+        let metrics = trainer.train(&running, args.model_file.as_path())?;
 
         eprintln!("Result Metrics:");
         eprintln!(
@@ -251,7 +242,7 @@ async fn segment(args: SegmentArgs) -> Result<(), Box<dyn Error>> {
     let mut writer = io::BufWriter::new(stdout.lock());
 
     if args.pos {
-        // Averaged Perceptronモデルで品詞推定付き分割
+        // Joint segmentation + POS tagging with an Averaged Perceptron model
         let mut pos_learner = AveragedPerceptron::new();
         pos_learner.load_model(args.model_uri.as_str()).await?;
 
@@ -271,7 +262,7 @@ async fn segment(args: SegmentArgs) -> Result<(), Box<dyn Error>> {
             }
         }
     } else {
-        // 既存のAdaBoostモデルで単語分割のみ
+        // Word segmentation only, with an AdaBoost model
         let mut learner = AdaBoost::new(0.01, 100);
         learner.load_model(args.model_uri.as_str()).await?;
 

--- a/litsea/Cargo.toml
+++ b/litsea/Cargo.toml
@@ -29,5 +29,7 @@ name = "bench"
 harness = false
 
 [features]
-default = ["remote_model"]
+# The library default is local model loading only, keeping the dependency
+# tree compact; enable `remote_model` for http(s):// model URIs.
+default = []
 remote_model = ["dep:reqwest"]

--- a/litsea/benches/bench.rs
+++ b/litsea/benches/bench.rs
@@ -119,7 +119,7 @@ fn bench_segment_long(c: &mut Criterion) {
 fn bench_char_type(c: &mut Criterion) {
     let segmenter = Segmenter::new(Language::Japanese);
     c.bench_function("get_type_hiragana", |b| {
-        b.iter(|| black_box(segmenter.char_type(black_box("あ"))));
+        b.iter(|| black_box(segmenter.char_type(black_box('あ'))));
     });
 }
 

--- a/litsea/src/adaboost.rs
+++ b/litsea/src/adaboost.rs
@@ -2,7 +2,6 @@ use std::collections::{BTreeMap, HashSet};
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 // Internal maps use FxHashMap: the keys are internally generated feature
@@ -25,9 +24,9 @@ type Label = i8;
 #[derive(Debug)]
 pub struct AdaBoost {
     /// The threshold for stopping the training.
-    pub threshold: f64,
+    threshold: f64,
     /// The maximum number of iterations for training.
-    pub num_iterations: usize,
+    num_iterations: usize,
     instance_weights: Vec<f64>,
     model: Vec<f64>,
     features: Vec<String>,
@@ -82,6 +81,18 @@ impl AdaBoost {
             num_instances: 0,
             cached_bias: 0.0,
         }
+    }
+
+    /// Returns the early-stopping threshold this learner was created with.
+    #[must_use]
+    pub fn threshold(&self) -> f64 {
+        self.threshold
+    }
+
+    /// Returns the maximum number of boosting iterations.
+    #[must_use]
+    pub fn num_iterations(&self) -> usize {
+        self.num_iterations
     }
 
     /// Recomputes the cached bias from the current model weights. Must be
@@ -234,7 +245,7 @@ impl AdaBoost {
     /// This method iteratively updates the model based on the training data.
     ///
     /// # Arguments
-    /// * `running`: An `Arc<AtomicBool>` to control the running state of the training process.
+    /// * `running`: An `AtomicBool` flag to control the running state of the training process.
     ///
     /// # Returns
     /// This method does not return a value.
@@ -253,7 +264,7 @@ impl AdaBoost {
     ///
     /// Training is a no-op when no instances have been added, and stops early
     /// if the instance weight sum degenerates (non-positive or non-finite).
-    pub fn train(&mut self, running: Arc<AtomicBool>) {
+    pub fn train(&mut self, running: &AtomicBool) {
         // Without instances (or features) there is nothing to learn; the
         // error-rate computation below would divide by zero.
         if self.num_instances == 0 || self.features.is_empty() {
@@ -691,7 +702,6 @@ mod tests {
 
     use std::collections::HashSet;
     use std::io::Write;
-    use std::sync::Arc;
     use std::sync::atomic::AtomicBool;
 
     use tempfile::NamedTempFile;
@@ -759,8 +769,8 @@ mod tests {
         learner.initialize_instances(instance_file.path())?;
 
         // Set running to false to immediately exit the learning loop.
-        let running = Arc::new(AtomicBool::new(false));
-        learner.train(running.clone());
+        let running = AtomicBool::new(false);
+        learner.train(&running);
 
         // If normalization of model or instance_weights is performed after learning, it should be OK.
         let weight_sum: f64 = learner.instance_weights.iter().sum();
@@ -894,7 +904,7 @@ mod tests {
         let mut learner = AdaBoost::new(0.01, 20);
         learner.add_instance(attrs_of("a"), 1);
         learner.add_instance(attrs_of("c"), -1);
-        learner.train(Arc::new(AtomicBool::new(true)));
+        learner.train(&AtomicBool::new(true));
         assert!((learner.bias() - expected(&learner)).abs() < 1e-12);
 
         // After a fresh model load.
@@ -1147,7 +1157,7 @@ mod tests {
                 learner.add_instance(attrs_of("c"), -1);
             }
 
-            learner.train(Arc::new(AtomicBool::new(true)));
+            learner.train(&AtomicBool::new(true));
 
             assert_eq!(learner.predict(&attrs_of("a")), 1, "order {:?}", order);
             assert_eq!(learner.predict(&both), 1, "order {:?}", order);
@@ -1175,7 +1185,7 @@ mod tests {
         for _ in 0..3 {
             learner.add_instance(attrs_of("A"), -1);
         }
-        learner.train(Arc::new(AtomicBool::new(true)));
+        learner.train(&AtomicBool::new(true));
 
         let temp = NamedTempFile::new()?;
         learner.save_model(temp.path())?;
@@ -1227,7 +1237,7 @@ mod tests {
         corpus_file.as_file().sync_all()?;
 
         let features_file = NamedTempFile::new()?;
-        let mut extractor = Extractor::default();
+        let extractor = Extractor::default();
         extractor.extract(corpus_file.path(), features_file.path())?;
 
         // The extractor emitted at least one feature embedding U+3000.
@@ -1292,7 +1302,7 @@ mod tests {
             learner.add_instance(attrs_of("f"), -1);
         }
 
-        learner.train(Arc::new(AtomicBool::new(true)));
+        learner.train(&AtomicBool::new(true));
 
         assert!(
             learner.model.iter().all(|w| *w == 0.0),
@@ -1307,7 +1317,7 @@ mod tests {
         // Regression test for #98: train() on a learner with no instances
         // must be a no-op instead of panicking via NaN error rates.
         let mut learner = AdaBoost::new(0.01, 10);
-        learner.train(Arc::new(AtomicBool::new(true)));
+        learner.train(&AtomicBool::new(true));
         assert!(learner.instance_weights.is_empty());
     }
 }

--- a/litsea/src/extractor.rs
+++ b/litsea/src/extractor.rs
@@ -11,6 +11,7 @@ use crate::segmenter::Segmenter;
 /// Extractor struct for processing text data and extracting features.
 /// It reads sentences from a corpus file, segments them into words,
 /// and writes the extracted features to a specified output file.
+#[derive(Debug)]
 pub struct Extractor {
     segmenter: Segmenter,
 }
@@ -47,7 +48,7 @@ impl Extractor {
     ///
     /// # Returns
     /// Returns a Result indicating success or failure.
-    pub fn extract(&mut self, corpus_path: &Path, features_path: &Path) -> Result<()> {
+    pub fn extract(&self, corpus_path: &Path, features_path: &Path) -> Result<()> {
         let segmenter = &self.segmenter;
         Self::write_features(corpus_path, features_path, |line, rows| {
             segmenter.add_corpus_with_writer(line, |attrs, label| {
@@ -65,7 +66,7 @@ impl Extractor {
     /// # Arguments
     /// * `corpus_path` - The path to the POS-tagged corpus file
     /// * `features_path` - The path to the features output file
-    pub fn extract_with_pos(&mut self, corpus_path: &Path, features_path: &Path) -> Result<()> {
+    pub fn extract_with_pos(&self, corpus_path: &Path, features_path: &Path) -> Result<()> {
         let segmenter = &self.segmenter;
         Self::write_features(corpus_path, features_path, |line, rows| {
             segmenter.add_corpus_with_pos_writer(line, |attrs, label| {
@@ -145,7 +146,7 @@ mod tests {
         let features_file = NamedTempFile::new()?;
 
         // Create an instance of Extractor and extract features
-        let mut extractor = Extractor::default();
+        let extractor = Extractor::default();
         extractor.extract(corpus_file.path(), features_file.path())?;
 
         // Read the output from the features file
@@ -182,7 +183,7 @@ mod tests {
 
         let features_file = NamedTempFile::new()?;
 
-        let mut extractor = Extractor::default();
+        let extractor = Extractor::default();
         extractor.extract_with_pos(corpus_file.path(), features_file.path())?;
 
         let mut output = String::new();

--- a/litsea/src/perceptron.rs
+++ b/litsea/src/perceptron.rs
@@ -2,7 +2,6 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, Write};
 use std::path::Path;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 // Internal weight maps use FxHashMap: keys are internally generated feature
@@ -238,7 +237,7 @@ impl AveragedPerceptron {
     /// # Arguments
     /// * `num_epochs` - The number of epochs
     /// * `running` - A flag for interrupting the training
-    pub fn train(&mut self, num_epochs: usize, running: Arc<AtomicBool>) {
+    pub fn train(&mut self, num_epochs: usize, running: &AtomicBool) {
         if self.instances.is_empty() {
             return;
         }
@@ -488,7 +487,6 @@ impl AveragedPerceptron {
 mod tests {
     use super::*;
 
-    use std::sync::Arc;
     use std::sync::atomic::AtomicBool;
 
     use tempfile::NamedTempFile;
@@ -545,8 +543,8 @@ mod tests {
         feats_b.insert("f4".to_string());
         p.add_instance(feats_b.clone(), "B".to_string());
 
-        let running = Arc::new(AtomicBool::new(true));
-        p.train(10, running);
+        let running = AtomicBool::new(true);
+        p.train(10, &running);
 
         // After training, instances are classified correctly
         assert_eq!(p.predict(&feats_a), "A");
@@ -560,8 +558,8 @@ mod tests {
         feats.insert("f1".to_string());
         p.add_instance(feats, "A".to_string());
 
-        let running = Arc::new(AtomicBool::new(false));
-        p.train(10, running);
+        let running = AtomicBool::new(false);
+        p.train(10, &running);
 
         // Stopping immediately must not panic
         assert_eq!(p.step, 0);
@@ -591,8 +589,8 @@ mod tests {
             p.add_instance(fc, "CLASS_C".to_string());
         }
 
-        let running = Arc::new(AtomicBool::new(true));
-        p.train(20, running);
+        let running = AtomicBool::new(true);
+        p.train(20, &running);
 
         // Distinctive features classify correctly
         let mut test_a = HashSet::new();
@@ -616,8 +614,8 @@ mod tests {
         feats_b.insert("f2".to_string());
         p.add_instance(feats_b.clone(), "B".to_string());
 
-        let running = Arc::new(AtomicBool::new(true));
-        p.train(10, running);
+        let running = AtomicBool::new(true);
+        p.train(10, &running);
 
         let mut scores: Vec<f64> = Vec::new();
         let slice_a: Vec<String> = feats_a.iter().cloned().collect();
@@ -637,8 +635,8 @@ mod tests {
         feats_b.insert("f2".to_string());
         p.add_instance(feats_b.clone(), "B".to_string());
 
-        let running = Arc::new(AtomicBool::new(true));
-        p.train(5, running);
+        let running = AtomicBool::new(true);
+        p.train(5, &running);
 
         // Save
         let temp = NamedTempFile::new()?;
@@ -664,8 +662,8 @@ mod tests {
         let mut feats = HashSet::new();
         feats.insert("f1".to_string());
         p.add_instance(feats, "A".to_string());
-        let running = Arc::new(AtomicBool::new(true));
-        p.train(5, running);
+        let running = AtomicBool::new(true);
+        p.train(5, &running);
 
         let temp = NamedTempFile::new()?;
         p.save_model(temp.path())?;
@@ -714,7 +712,7 @@ mod tests {
             let label = if name.len() % 2 == 0 { "A" } else { "B" };
             p.add_instance(feats, label.to_string());
         }
-        p.train(5, Arc::new(AtomicBool::new(true)));
+        p.train(5, &AtomicBool::new(true));
 
         let temp = NamedTempFile::new()?;
         p.save_model(temp.path())?;
@@ -745,8 +743,8 @@ mod tests {
         feats_b.insert("f2".to_string());
         p.add_instance(feats_b, "B".to_string());
 
-        let running = Arc::new(AtomicBool::new(true));
-        p.train(10, running);
+        let running = AtomicBool::new(true);
+        p.train(10, &running);
 
         let metrics = p.metrics();
         assert_eq!(metrics.num_instances, 2);
@@ -795,7 +793,7 @@ mod tests {
         let mut p = AveragedPerceptron::new();
         p.add_instance(feats_a.clone(), "A".to_string());
         p.add_instance(feats_b.clone(), "B".to_string());
-        p.train(5, Arc::new(AtomicBool::new(true)));
+        p.train(5, &AtomicBool::new(true));
         assert!(p.step > 0);
 
         let model_content = "2\nA\nB\nf1\tA\t0.5\nf2\tB\t0.5\n";
@@ -807,13 +805,13 @@ mod tests {
 
         // Behavioral check: train-after-load on the recycled instance matches
         // load-then-train on a fresh perceptron with the same instances.
-        p.train(5, Arc::new(AtomicBool::new(true)));
+        p.train(5, &AtomicBool::new(true));
 
         let mut q = AveragedPerceptron::new();
         q.add_instance(feats_a.clone(), "A".to_string());
         q.add_instance(feats_b.clone(), "B".to_string());
         q.load_model_from_reader(model_content.as_bytes())?;
-        q.train(5, Arc::new(AtomicBool::new(true)));
+        q.train(5, &AtomicBool::new(true));
 
         assert_eq!(p.predict(&feats_a), q.predict(&feats_a));
         assert_eq!(p.predict(&feats_b), q.predict(&feats_b));

--- a/litsea/src/segmenter.rs
+++ b/litsea/src/segmenter.rs
@@ -12,6 +12,7 @@ use crate::upos::{SegmentLabel, Upos};
 /// Averaged Perceptron (see [`segment_with_pos`](Self::segment_with_pos)).
 /// Characters are classified into language-specific type codes with direct
 /// `match`-based rules ([`Language::char_type`]).
+#[derive(Debug)]
 pub struct Segmenter {
     language: Language,
     learner: AdaBoost,
@@ -111,14 +112,15 @@ impl Segmenter {
         self.pos_learner.as_mut()
     }
 
-    /// Gets the type of a character based on language-specific patterns.
+    /// Gets the type of a character based on language-specific rules
+    /// (delegates to [`Language::char_type`]).
     ///
     /// # Arguments
-    /// * `ch` - A string slice representing a single character.
+    /// * `c` - The character to classify.
     ///
     /// # Returns
-    /// A string slice representing the type code of the character.
-    /// The type codes are language-specific. Returns "O" (Other) if no pattern matches.
+    /// The language-specific type code of the character. Returns "O"
+    /// (Other) if no rule matches.
     ///
     /// # Example
     /// ```
@@ -126,15 +128,12 @@ impl Segmenter {
     /// use litsea::segmenter::Segmenter;
     ///
     /// let segmenter = Segmenter::new(Language::Japanese);
-    /// let char_type = segmenter.char_type("あ");
+    /// let char_type = segmenter.char_type('あ');
     /// assert_eq!(char_type, "I"); // Hiragana
     /// ```
     #[must_use]
-    pub fn char_type(&self, ch: &str) -> &str {
-        match ch.chars().next() {
-            Some(c) => self.language.char_type(c),
-            None => "O",
-        }
+    pub fn char_type(&self, c: char) -> &'static str {
+        self.language.char_type(c)
     }
 
     /// Builds the padded character and character-type arrays for a text.
@@ -613,47 +612,45 @@ mod tests {
     use super::*;
 
     use std::path::PathBuf;
-    use std::sync::Arc;
     use std::sync::atomic::AtomicBool;
 
     #[test]
     fn test_char_type_japanese() {
         let segmenter = Segmenter::new(Language::Japanese);
 
-        assert_eq!(segmenter.char_type("あ"), "I"); // Hiragana
-        assert_eq!(segmenter.char_type("漢"), "H"); // Kanji
-        assert_eq!(segmenter.char_type("。"), "P"); // Punctuation
-        assert_eq!(segmenter.char_type("A"), "A"); // Latin
-        assert_eq!(segmenter.char_type("1"), "N"); // Digit
-        assert_eq!(segmenter.char_type("@"), "O"); // Not matching any pattern
-        assert_eq!(segmenter.char_type(""), "O"); // Empty string
+        assert_eq!(segmenter.char_type('あ'), "I"); // Hiragana
+        assert_eq!(segmenter.char_type('漢'), "H"); // Kanji
+        assert_eq!(segmenter.char_type('。'), "P"); // Punctuation
+        assert_eq!(segmenter.char_type('A'), "A"); // Latin
+        assert_eq!(segmenter.char_type('1'), "N"); // Digit
+        assert_eq!(segmenter.char_type('@'), "O"); // Not matching any pattern
     }
 
     #[test]
     fn test_char_type_chinese() {
         let segmenter = Segmenter::new(Language::Chinese);
 
-        assert_eq!(segmenter.char_type("的"), "F"); // Function word
-        assert_eq!(segmenter.char_type("中"), "C"); // CJK Unified
-        assert_eq!(segmenter.char_type("国"), "C"); // CJK Unified
-        assert_eq!(segmenter.char_type("。"), "P"); // Punctuation
-        assert_eq!(segmenter.char_type("A"), "A"); // Latin
-        assert_eq!(segmenter.char_type("5"), "N"); // Digit
-        assert_eq!(segmenter.char_type("@"), "O"); // Other
+        assert_eq!(segmenter.char_type('的'), "F"); // Function word
+        assert_eq!(segmenter.char_type('中'), "C"); // CJK Unified
+        assert_eq!(segmenter.char_type('国'), "C"); // CJK Unified
+        assert_eq!(segmenter.char_type('。'), "P"); // Punctuation
+        assert_eq!(segmenter.char_type('A'), "A"); // Latin
+        assert_eq!(segmenter.char_type('5'), "N"); // Digit
+        assert_eq!(segmenter.char_type('@'), "O"); // Other
     }
 
     #[test]
     fn test_char_type_korean() {
         let segmenter = Segmenter::new(Language::Korean);
 
-        assert_eq!(segmenter.char_type("는"), "E"); // Particle (topic marker)
-        assert_eq!(segmenter.char_type("가"), "SN"); // Hangul Syllable without 받침
-        assert_eq!(segmenter.char_type("한"), "SF"); // Hangul Syllable with 받침
-        assert_eq!(segmenter.char_type("ㄱ"), "G"); // Compatibility Jamo
-        assert_eq!(segmenter.char_type("漢"), "H"); // Hanja
-        assert_eq!(segmenter.char_type("A"), "A"); // Latin
-        assert_eq!(segmenter.char_type("5"), "N"); // Digit
-        assert_eq!(segmenter.char_type("@"), "O"); // Other
+        assert_eq!(segmenter.char_type('는'), "E"); // Particle (topic marker)
+        assert_eq!(segmenter.char_type('가'), "SN"); // Hangul Syllable without 받침
+        assert_eq!(segmenter.char_type('한'), "SF"); // Hangul Syllable with 받침
+        assert_eq!(segmenter.char_type('ㄱ'), "G"); // Compatibility Jamo
+        assert_eq!(segmenter.char_type('漢'), "H"); // Hanja
+        assert_eq!(segmenter.char_type('A'), "A"); // Latin
+        assert_eq!(segmenter.char_type('5'), "N"); // Digit
+        assert_eq!(segmenter.char_type('@'), "O"); // Other
     }
 
     #[test]
@@ -897,8 +894,8 @@ mod tests {
         }
 
         // Train the perceptron
-        let running = Arc::new(AtomicBool::new(true));
-        segmenter.pos_learner.as_mut().unwrap().train(10, running);
+        let running = AtomicBool::new(true);
+        segmenter.pos_learner.as_mut().unwrap().train(10, &running);
 
         // Segmentation + POS tagging
         let result = segmenter.segment_with_pos("これはテストです。").unwrap();
@@ -910,6 +907,15 @@ mod tests {
             // The POS is one of the Upos variants
             let _ = pos.to_string();
         }
+    }
+
+    #[test]
+    fn test_debug_impls() {
+        // #129: user-facing types are debuggable.
+        let segmenter = Segmenter::new(Language::Japanese);
+        assert!(!format!("{:?}", segmenter).is_empty());
+        let extractor = crate::extractor::Extractor::new(Language::Japanese);
+        assert!(!format!("{:?}", extractor).is_empty());
     }
 
     #[test]

--- a/litsea/src/trainer.rs
+++ b/litsea/src/trainer.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 use std::fs::File;
 use std::io::{self, BufRead};
 use std::path::Path;
-use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
 use crate::adaboost::AdaBoost;
@@ -14,12 +13,14 @@ use crate::perceptron::AveragedPerceptron;
 /// It initializes the AdaBoost learner with the specified parameters,
 /// loads the model from a file, and provides methods to train the model
 /// and save the trained model.
+#[derive(Debug)]
 pub struct Trainer {
     learner: AdaBoost,
 }
 
 /// Trainer for the POS tagging model.
 /// Manages multiclass classification training with the Averaged Perceptron.
+#[derive(Debug)]
 pub struct PosTrainer {
     learner: AveragedPerceptron,
     num_epochs: usize,
@@ -64,7 +65,7 @@ impl Trainer {
     /// Train the AdaBoost model.
     ///
     /// # Arguments
-    /// * `running` - An `Arc<AtomicBool>` to control the running state of the training process.
+    /// * `running` - An `AtomicBool` flag to control the running state of the training process.
     /// * `model_path` - The path to save the trained model.
     ///
     /// # Returns
@@ -72,7 +73,7 @@ impl Trainer {
     ///
     /// # Errors
     /// Returns an error if the training fails or if the model cannot be saved.
-    pub fn train(&mut self, running: Arc<AtomicBool>, model_path: &Path) -> Result<BinaryMetrics> {
+    pub fn train(&mut self, running: &AtomicBool, model_path: &Path) -> Result<BinaryMetrics> {
         self.learner.train(running);
 
         // Save the trained model to the specified file
@@ -133,11 +134,7 @@ impl PosTrainer {
     /// # Arguments
     /// * `running` - A flag for interrupting the training
     /// * `model_path` - The path to save the model to
-    pub fn train(
-        &mut self,
-        running: Arc<AtomicBool>,
-        model_path: &Path,
-    ) -> Result<MulticlassMetrics> {
+    pub fn train(&mut self, running: &AtomicBool, model_path: &Path) -> Result<MulticlassMetrics> {
         self.learner.train(self.num_epochs, running);
         self.learner.save_model(model_path)?;
         Ok(self.learner.metrics())
@@ -149,7 +146,6 @@ mod tests {
     use super::*;
 
     use std::io::Write;
-    use std::sync::Arc;
     use std::sync::atomic::AtomicBool;
 
     use tempfile::NamedTempFile;
@@ -220,10 +216,10 @@ mod tests {
         let model_out = NamedTempFile::new()?;
 
         // Set AtomicBool to false and immediately exit the learning loop
-        let running = Arc::new(AtomicBool::new(false));
+        let running = AtomicBool::new(false);
 
         // Execute the train method.
-        let metrics: BinaryMetrics = trainer.train(running, model_out.path())?;
+        let metrics: BinaryMetrics = trainer.train(&running, model_out.path())?;
 
         // Check if the metrics are valid.
         // Since metrics are dummy data, we will consider anything 0 or above to be OK here.
@@ -259,9 +255,9 @@ mod tests {
         let mut trainer = PosTrainer::new(5, features_file.path())?;
 
         let model_out = NamedTempFile::new()?;
-        let running = Arc::new(AtomicBool::new(true));
+        let running = AtomicBool::new(true);
 
-        let metrics = trainer.train(running, model_out.path())?;
+        let metrics = trainer.train(&running, model_out.path())?;
         assert!(metrics.accuracy >= 0.0);
         assert_eq!(metrics.num_instances, 4);
         Ok(())
@@ -273,10 +269,22 @@ mod tests {
         let mut trainer = PosTrainer::new(5, features_file.path())?;
 
         let model_out = NamedTempFile::new()?;
-        let running = Arc::new(AtomicBool::new(false));
+        let running = AtomicBool::new(false);
 
-        let metrics = trainer.train(running, model_out.path())?;
+        let metrics = trainer.train(&running, model_out.path())?;
         assert_eq!(metrics.num_instances, 4);
+        Ok(())
+    }
+
+    #[test]
+    fn test_debug_impls() -> Result<()> {
+        // #129: trainer types are debuggable.
+        let features_file = create_dummy_features_file();
+        let trainer = Trainer::new(0.01, 10, features_file.path())?;
+        assert!(!format!("{:?}", trainer).is_empty());
+        let pos_features = create_dummy_pos_features_file();
+        let pos_trainer = PosTrainer::new(3, pos_features.path())?;
+        assert!(!format!("{:?}", pos_trainer).is_empty());
         Ok(())
     }
 
@@ -294,9 +302,9 @@ mod tests {
 
         let mut trainer = Trainer::new(0.01, 100, file.path())?;
         let model_out = NamedTempFile::new()?;
-        let running = Arc::new(AtomicBool::new(true));
+        let running = AtomicBool::new(true);
 
-        let metrics = trainer.train(running, model_out.path())?;
+        let metrics = trainer.train(&running, model_out.path())?;
 
         assert!(
             (metrics.accuracy - 100.0).abs() < 1e-9,
@@ -329,8 +337,8 @@ mod tests {
 
         let mut trainer = PosTrainer::new(5, file.path())?;
         let model_out = NamedTempFile::new()?;
-        let running = Arc::new(AtomicBool::new(true));
-        trainer.train(running, model_out.path())?;
+        let running = AtomicBool::new(true);
+        trainer.train(&running, model_out.path())?;
 
         let saved = std::fs::read_to_string(model_out.path())?;
         assert!(


### PR DESCRIPTION
Closes #129 (part of #109 → #97)

## Summary

Seven accumulated API-surface issues fixed in the 0.6.0 breaking window.

## Breaking changes & migration

| Before | After |
|---|---|
| `learner.threshold` / `learner.num_iterations` (pub fields) | `learner.threshold()` / `learner.num_iterations()` (set via `new`) |
| `train(running: Arc<AtomicBool>)` (4 signatures) | `train(running: &AtomicBool)` — pass `&running`; keep the `Arc` only for e.g. signal handlers |
| `Segmenter::char_type(&str) -> &str` (classified the first char; `""` → `"O"`) | `char_type(char) -> &'static str`, aligned with `Language::char_type` |
| `remote_model` in default features | opt-in: `litsea = { version = "0.6.0", features = ["remote_model"] }` — the CLI enables it and is unchanged |

## Non-breaking improvements

- `Debug` for `Segmenter` / `Extractor` / `Trainer` / `PosTrainer` (smoke-tested)
- `Extractor::extract` / `extract_with_pos` take `&self`
- CLI: help texts and comments in English, redundant `default_value = "false"` removed, subcommands inherit the version via `propagate_version = true` (verified: `litsea segment --version` → `litsea-segment 0.6.0`)

## CI

Inspection corrected the plan's assumption: the platform matrix already tests `--all-features`, so the gap after the flip was the new lean **default**. The `feature-check` job gained a `cargo test -p litsea` (default-features) lane — both configurations are now exercised.

## Verification

- Default config: 109 lib + 10 golden + 8 CLI + 6 doc tests pass (download tests correctly compiled out)
- `--features remote_model`: all suites incl. download tests pass
- clippy `-D warnings` on both configs, fmt, markdownlint, `mdbook build docs` clean; golden outputs unchanged