### PR TITLE
fix: extend Japanese kanji range to U+9FFF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,15 @@ models in `models/` load unchanged.
   were retrained: first-word POS accuracy on the UD-GSD dev sets improved
   from 85.6% to 91.8% (Japanese), 85.2% to 90.9% (Chinese), and 73.2% to
   85.2% (Korean), with first-word boundary accuracy unchanged (#100).
+- `japanese_char_type` classified kanji as `'\u{4E00}'..='\u{9FA0}'`, 95 code
+  points short of the full CJK Unified Ideographs block
+  (`'\u{4E00}'..='\u{9FFF}'`) already used by `chinese_char_type` and
+  `korean_char_type`. Characters in U+9FA1..U+9FFF were classified as `"O"`
+  (Other) for Japanese only. The range is now unified across all three
+  languages. The UD Japanese-GSD corpus that trained `japanese.model` and
+  `japanese_pos.model` contains no characters in the affected range, so this
+  introduces no train/inference asymmetry; the shipped models are unchanged
+  (#130).
 
 ### Changed (breaking)
 

--- a/docs/src/algorithm/character-type-classification.md
+++ b/docs/src/algorithm/character-type-classification.md
@@ -13,7 +13,7 @@ Each language has its own classification function (`japanese_char_type`, `chines
 | Code | Name | Pattern / Range | Examples |
 |------|------|----------------|----------|
 | **M** | Kanji Numbers | `[一二三四五六七八九十百千万億兆]` | 一, 千, 億 |
-| **H** | Kanji / CJK Ideographs | `[一-龠々〆ヵヶ]` | 漢, 字, 学 |
+| **H** | Kanji / CJK Ideographs | U+4E00--U+9FFF, plus 々〆ヵヶ | 漢, 字, 学 |
 | **I** | Hiragana | `[ぁ-ん]` | あ, い, う |
 | **K** | Katakana | `[ァ-ヴーｱ-ﾝﾞﾟ]` | ア, カ, ー |
 | **P** | Punctuation | CJK Symbols (U+3000-303F), Full-width (U+FF01-FF65) | 。, 、, 「 |

--- a/docs/src/language-support/japanese.md
+++ b/docs/src/language-support/japanese.md
@@ -7,7 +7,7 @@ Japanese is the default language in Litsea.
 | Code | Name | Pattern | Examples |
 |------|------|---------|----------|
 | **M** | Kanji Numbers | `[一二三四五六七八九十百千万億兆]` | 一, 三, 千, 億 |
-| **H** | Kanji / CJK | `[一-龠々〆ヵヶ]` | 漢, 字, 学, 々 |
+| **H** | Kanji / CJK | U+4E00--U+9FFF, plus 々〆ヵヶ | 漢, 字, 学, 々 |
 | **I** | Hiragana | `[ぁ-ん]` | あ, い, う, を |
 | **K** | Katakana | `[ァ-ヴーｱ-ﾝﾞﾟ]` | ア, カ, ー, ﾊ |
 | **P** | Punctuation | CJK Symbols + Full-width | 。, 、, 「, 」 |

--- a/litsea/src/language.rs
+++ b/litsea/src/language.rs
@@ -95,7 +95,7 @@ fn punct_latin_digit(c: char) -> Option<&'static str> {
 ///
 /// Type codes:
 /// - "M": Kanji numbers (一二三四五六七八九十百千万億兆)
-/// - "H": Kanji (CJK ideographs, 々〆ヵヶ)
+/// - "H": Kanji (CJK Unified Ideographs, U+4E00..=U+9FFF, plus 々〆ヵヶ)
 /// - "I": Hiragana
 /// - "K": Katakana (full-width and half-width)
 /// - "P" / "A" / "N": see [`punct_latin_digit`]
@@ -104,8 +104,8 @@ fn japanese_char_type(c: char) -> &'static str {
     match c {
         '一' | '二' | '三' | '四' | '五' | '六' | '七' | '八' | '九' | '十' | '百' | '千'
         | '万' | '億' | '兆' => "M",
-        // 一-龠 plus 々〆ヵヶ
-        '\u{4E00}'..='\u{9FA0}' | '々' | '〆' | 'ヵ' | 'ヶ' => "H",
+        // CJK Unified Ideographs (U+4E00..=U+9FFF) plus 々〆ヵヶ
+        '\u{4E00}'..='\u{9FFF}' | '々' | '〆' | 'ヵ' | 'ヶ' => "H",
         // ぁ-ん
         '\u{3041}'..='\u{3093}' => "I",
         // ァ-ヴ, ー, half-width ｱ-ﾝ and ﾞﾟ
@@ -243,6 +243,20 @@ mod tests {
         assert_eq!(lang.char_type('5'), "N"); // Digit
         assert_eq!(lang.char_type('５'), "N"); // Full-width digit
         assert_eq!(lang.char_type('@'), "O"); // Other
+    }
+
+    #[test]
+    fn test_japanese_kanji_range_covers_full_cjk_block() {
+        // #130: the Japanese classifier previously stopped at U+9FA0 while
+        // Chinese and Korean already covered the full CJK Unified
+        // Ideographs block (U+4E00..=U+9FFF). Pin the full range for all
+        // three languages so they can't drift apart again.
+        assert_eq!(Language::Japanese.char_type('\u{9FA0}'), "H"); // old upper bound
+        assert_eq!(Language::Japanese.char_type('\u{9FA1}'), "H"); // 龡, first newly-included
+        assert_eq!(Language::Japanese.char_type('\u{9FFF}'), "H"); // 鿿, block end
+
+        assert_eq!(Language::Chinese.char_type('\u{9FA1}'), "C");
+        assert_eq!(Language::Korean.char_type('\u{9FA1}'), "H");
     }
 
     // --- Chinese pattern tests ---


### PR DESCRIPTION
## Summary

- `japanese_char_type` classified kanji as `'\u{4E00}'..='\u{9FA0}'`, 95 code points short of the full CJK Unified Ideographs block (`'\u{4E00}'..='\u{9FFF}'`) already used by `chinese_char_type`/`korean_char_type`. Characters in U+9FA1..U+9FFF were misclassified as `"O"` (Other) for Japanese only.
- Range unified across all three languages; doc comment and the two `docs/src/` character-class tables synced to the same `U+4E00--U+9FFF` notation.
- New unit test `test_japanese_kanji_range_covers_full_cjk_block` pins the old boundary (U+9FA0), the first newly-included code point (U+9FA1), and the block end (U+9FFF) as `"H"` for Japanese, cross-checked against Chinese/Korean.
- No model regeneration: the UD Japanese-GSD corpus behind `japanese.model`/`japanese_pos.model` has zero occurrences of the affected range (measured and reported in the issue), so there's no train/inference asymmetry to correct.

Closes #130. This is the last of #109's 4 child issues and the final item of the #97 quality campaign.

## Test plan

- [x] `cargo test --workspace` — 110 lib + 10 golden (byte-identical) + 8 CLI integration + 6 doctests, all green
- [x] RED→GREEN verified for the new test (failed pre-fix, passed post-fix)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `markdownlint-cli2 "docs/src/**/*.md"` clean (41 files)
- [x] `mdbook build docs` clean
- [x] Manual: segmented a sentence containing 龢 (U+9FA2) with `models/japanese.model`, no crash