### PR TITLE
Bump up version to 0.10.0

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -42,7 +42,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
           - runner: macos-latest
             target: aarch64-apple-darwin
-          - runner: macos-15-intel
+          - runner: mamacos-26-intel
             target: x86_64-apple-darwin
           - runner: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -45,7 +45,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
           - runner: macos-latest
             target: aarch64-apple-darwin
-          - runner: macos-15-intel
+          - runner: mamacos-26-intel
             target: x86_64-apple-darwin
           - runner: windows-latest
             target: x86_64-pc-windows-msvc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
           - runner: macos-latest
             target: aarch64-apple-darwin
-          - runner: macos-15-intel
+          - runner: mamacos-26-intel
             target: x86_64-apple-darwin
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
@@ -121,7 +121,7 @@ jobs:
             target: aarch64-apple-darwin
             archive: .zip
             extension: ""
-          - runner: macos-15-intel
+          - runner: mamacos-26-intel
             target: x86_64-apple-darwin
             archive: .zip
             extension: ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.10.0
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "litsea"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "criterion",
  "reqwest",
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "litsea-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "clap",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ lto = "thin"
 codegen-units = 1
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.87"
 description = "Litsea is an extremely compact word segmentation and model training tool implemented in Rust."
@@ -39,4 +39,4 @@ criterion = { version = "0.8.2", default-features = false, features = [
     "html_reports",
 ] }
 
-litsea = { version = "0.9.0", path = "./litsea" }
+litsea = { version = "0.10.0", path = "./litsea" }

--- a/litsea-cli/tests/cli.rs
+++ b/litsea-cli/tests/cli.rs
@@ -20,7 +20,12 @@ fn run_litsea(args: &[&str], stdin: Option<&str>) -> Output {
         .expect("failed to spawn litsea");
     if let Some(input) = stdin {
         let mut handle = child.stdin.take().expect("stdin");
-        handle.write_all(input.as_bytes()).expect("write stdin");
+        // A child that fails fast (e.g. a missing model) may exit before
+        // reading stdin, closing the pipe; that BrokenPipe is part of the
+        // scenario under test, not a harness error.
+        if let Err(e) = handle.write_all(input.as_bytes()) {
+            assert_eq!(e.kind(), std::io::ErrorKind::BrokenPipe, "write stdin: {e}");
+        }
     }
     drop(child.stdin.take());
     child.wait_with_output().expect("wait")


### PR DESCRIPTION
Bump the workspace version to 0.10.0 and finalize the CHANGELOG's Unreleased section as 0.10.0.

This release ships:

- **Performance**: WC templates scored with merged per-character row probes (#157/#158) — segment() ~10-18% faster for models with WC features (japanese/chinese)
- **Added**: `litsea evaluate` subcommand + `litsea::evaluation` module with bundled UD GSD held-out gold data (#161/#162); `external_corpus` Criterion benchmark group matching tokenizer-speed-bench (#159/#160)

After tagging `v0.10.0`, the tokenizer-speed-bench litsea crates can move from 0.9.0 to 0.10.0 (and the model download pin from the main SHA to the tag), which will let the published litsea-japanese/chinese figures reflect the WC optimization.