### PR TITLE
Fix macOS 26 Intel runner label typo

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -45,7 +45,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
           - runner: macos-latest
             target: aarch64-apple-darwin
-          - runner: mamacos-26-intel
+          - runner: macos-26-intel
             target: x86_64-apple-darwin
           - runner: windows-latest
             target: x86_64-pc-windows-msvc


### PR DESCRIPTION
`mamacos-26-intel` (introduced with the runner upgrade in #163) is not a GitHub-hosted runner label, so the macOS Intel test job waits for a runner indefinitely and never builds. The correct label is `macos-26-intel`, which is generally available (macOS 26 ships Intel and arm64 variants: `macos-26`, `macos-26-intel`, `-large`, `-xlarge`).

One-character CI-config fix; no issue filed (same convention as the version-bump chore PRs).