### PR TITLE
Add the two-stage POS tagging runtime behind segment_with_pos()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@
   `AveragedPerceptron::save_model_to_writer` (the format-producing cores of
   the existing `save_model` methods, enabling section embedding), and an
   `AveragedPerceptron::classes()` accessor.
+- The two-stage runtime behind the unchanged `segment_with_pos()` signature
+  (#167): `Segmenter::with_two_stage_learner` installs a two-stage model's
+  stage-1 boundary classifier as the segmenter's AdaBoost-path learner and
+  tags each segmented word through the candidate-tag lexicon
+  (single-candidate and dominance-dominant surfaces skip the classifier
+  entirely) and a packed word-level stage-2 tagger (candidate-masked argmax
+  for ambiguous surfaces, full argmax fallback for unknown surfaces). On
+  the held-out UD GSD test the runtime reproduces the #147 prototype:
+  Japanese word F1 96.48 (joint: 96.56) with tagged-word F1 92.71-93.41
+  depending on the stage-2 feature set (joint: 92.51) at 1.5-2.5x the
+  joint throughput. Word-level feature templates live in a single
+  crate-private module shared with the upcoming training extractor.
 
 ## 0.10.0
 

--- a/docs/ja/src/litsea/segmenter.md
+++ b/docs/ja/src/litsea/segmenter.md
@@ -152,7 +152,7 @@ pub fn segment_with_pos(&self, sentence: &str) -> Result<Vec<(String, Upos)>>
 
 文を単語に分割すると同時に、各単語の UPOS タグを予測します。最初の文字位置での予測結果が最初の単語の品詞を決定します。空の文に対しては、空のベクターを持つ `Ok` を返します。
 
-**エラー**: POS 学習器が設定されていない場合は `LitseaError::PosLearnerNotSet` を返します — `with_pos_learner()` で Segmenter を作成するか、事前に `add_corpus_with_pos()` で学習データを登録してください。
+**エラー**: POS 学習器も二段構成学習器も設定されていない場合は `LitseaError::PosLearnerNotSet` を返します — `with_pos_learner()` または `with_two_stage_learner()` で Segmenter を作成するか、事前に `add_corpus_with_pos()` で学習データを登録してください。
 
 ```rust
 use std::path::Path;
@@ -169,6 +169,22 @@ let tokens = segmenter.segment_with_pos("これはテストです。")?;
 // [("これ", Upos::PRON), ("は", Upos::ADP), ("テスト", Upos::NOUN),
 //  ("です", Upos::AUX), ("。", Upos::PUNCT)]
 ```
+
+### `with_two_stage_learner`
+
+```rust
+pub fn with_two_stage_learner(language: Language, learner: TwoStageLearner) -> Self
+```
+
+二段構成モデル（`litsea-two-stage v1` ファイルを読み込んだ `TwoStageLearner`）を持つ
+Segmenter を作成します。モデルの stage-1 境界分類器はそのまま Segmenter の
+AdaBoost 経路の学習器になり（`segment` は自然に動作します）、`segment_with_pos` は
+分割された各単語を候補タグ語彙表（lexicon）でタグ付けします — 単一候補・優勢候補の
+表層は分類器を完全にスキップし、曖昧な表層は候補マスク付き argmax、未知の表層は
+全クラスの argmax を stage-2 の単語単位タガーが決定します。`segment_with_pos` の
+シグネチャと戻り値は joint モードと同一で、モデル種別だけがパイプラインを選択します。
+二段構成形式については[モデルファイル形式](../advanced/model-file-format.md)を
+参照してください。
 
 ### `add_corpus_with_pos`
 

--- a/docs/src/litsea/segmenter.md
+++ b/docs/src/litsea/segmenter.md
@@ -164,8 +164,9 @@ Segments a sentence and jointly predicts each word's UPOS tag. The
 prediction at the first character position determines the first word's POS.
 An empty sentence yields `Ok` with an empty vector.
 
-**Errors** with `LitseaError::PosLearnerNotSet` if no POS learner is set —
-build the segmenter with `with_pos_learner()` or register training data with
+**Errors** with `LitseaError::PosLearnerNotSet` if neither a POS learner nor
+a two-stage learner is set — build the segmenter with `with_pos_learner()`
+or `with_two_stage_learner()`, or register training data with
 `add_corpus_with_pos()` first.
 
 ```rust
@@ -183,6 +184,24 @@ let tokens = segmenter.segment_with_pos("これはテストです。")?;
 // [("これ", Upos::PRON), ("は", Upos::ADP), ("テスト", Upos::NOUN),
 //  ("です", Upos::AUX), ("。", Upos::PUNCT)]
 ```
+
+### `with_two_stage_learner`
+
+```rust
+pub fn with_two_stage_learner(language: Language, learner: TwoStageLearner) -> Self
+```
+
+Creates a segmenter with a two-stage model (a `litsea-two-stage v1` file
+loaded into a `TwoStageLearner`): the model's stage-1 boundary classifier
+becomes the segmenter's AdaBoost-path learner (so `segment` works
+naturally), and `segment_with_pos` tags each segmented word through the
+candidate-tag lexicon — single-candidate and dominant surfaces skip the
+classifier entirely — with the stage-2 word-level tagger deciding ambiguous
+surfaces (candidate-masked argmax) and unknown surfaces (full argmax over
+all classes). The `segment_with_pos` signature and return type are
+identical to the joint mode; only the model type selects the pipeline. See
+[Model File Format](../advanced/model-file-format.md) for the two-stage
+format.
 
 ### `add_corpus_with_pos`
 

--- a/litsea/src/lib.rs
+++ b/litsea/src/lib.rs
@@ -19,11 +19,13 @@ pub mod metrics;
 mod model_io;
 mod packed_model;
 mod packed_pos_model;
+mod packed_two_stage;
 pub mod perceptron;
 pub mod segmenter;
 pub mod trainer;
 pub mod two_stage;
 pub mod upos;
+mod word_features;
 
 pub use adaboost::AdaBoost;
 pub use error::{LitseaError, Result};

--- a/litsea/src/packed_two_stage.rs
+++ b/litsea/src/packed_two_stage.rs
@@ -1,0 +1,483 @@
+//! Packed scoring tables for the two-stage POS tagger (issue #147).
+//!
+//! [`PackedTwoStageModel`] compiles a two-stage model's stage-2 tagger
+//! (a string-keyed [`AveragedPerceptron`] over the word-level templates of
+//! [`crate::word_features`]) and its candidate-tag lexicon into the
+//! structures the tagging hot loop needs:
+//!
+//! - a **surface map**: one `FxHashMap<String, _>` probe per word covering
+//!   the lexicon (candidate restriction, dominance-fixed tags) *and* the
+//!   `WS` surface-feature weight row;
+//! - **sparse class rows** keyed by packed integers for the char-valued
+//!   templates, with per-template gating (a template with no weights costs
+//!   nothing at runtime, so feature-subset models are automatically
+//!   cheaper);
+//! - **dense tables** for the type-valued and word-length templates
+//!   (direct indexing, no hashing).
+//!
+//! Words whose surface has a single observed tag — or one that covers at
+//! least the `dominance` fraction of its training occurrences — are tagged
+//! without touching the classifier at all; this skip is the main cost
+//! lever of the two-stage design (see #147). Ambiguous known words get a
+//! candidate-masked argmax; unknown words fall back to the full argmax
+//! over all classes.
+
+use rustc_hash::FxHashMap;
+
+use crate::language::Language;
+use crate::perceptron::AveragedPerceptron;
+use crate::upos::Upos;
+use crate::word_features::{
+    BOS_CODE, CONTEXT_WINDOW, EOS_CODE, F_CL1, F_CR1, F_FT, F_LT, N_TYPE_FAMILIES,
+    N_WORD_TEMPLATES, T_FC, T_L1, T_LB, T_LC, T_P2, T_R1, T_RB, T_S2, T_TS, TS_CAP, WL_CAP,
+    WordFeature, hash_key, parse_word_feature, ts_payload,
+};
+
+/// Build-time accumulator for one surface: fixed tag, candidate class
+/// indices, and the `WS` weight row (frozen into a [`WordEntry`]).
+type WordEntryBuild = (Option<Upos>, Vec<u16>, Vec<(u16, f64)>);
+
+/// Per-surface entry of the packed surface map.
+#[derive(Debug, Default)]
+struct WordEntry {
+    /// Tag assigned without scoring: present when the surface has a single
+    /// observed tag or a dominant one (see `dominance`). May be a tag the
+    /// classifier does not know (a tag observed only on unambiguous
+    /// words).
+    fixed: Option<Upos>,
+    /// Candidate class indices for the masked argmax, sorted ascending
+    /// (the perceptron's first-wins tie-break order). Lexicon tags the
+    /// classifier does not know are dropped; if none remain the word is
+    /// scored as unknown.
+    candidates: Box<[u16]>,
+    /// Sparse `(class, weight)` row of the `WS` surface feature.
+    ws_row: Box<[(u16, f64)]>,
+}
+
+/// The compiled two-stage tagging tables. Built once per model (re)load by
+/// [`build`](Self::build); consulted by
+/// [`crate::segmenter::Segmenter::segment_with_pos`].
+#[derive(Debug)]
+pub(crate) struct PackedTwoStageModel {
+    /// Class index -> UPOS tag (the stage-2 class order).
+    classes: Box<[Upos]>,
+    /// Number of stage-2 classes.
+    n_classes: usize,
+    /// `language.type_codes().len() + 2` (the two extra slots are the
+    /// BOS/EOS sentinel type indices).
+    type_stride: usize,
+    /// Surface -> lexicon + `WS` data (single String probe per word).
+    words: FxHashMap<String, WordEntry>,
+    /// Packed integer key -> sparse `(class, weight)` row for the
+    /// char-valued templates.
+    hash: FxHashMap<u64, Box<[(u16, f64)]>>,
+    /// Per-template gating for the hash-keyed templates.
+    has: [bool; N_WORD_TEMPLATES],
+    /// Dense word-length rows: `(WL_CAP + 1) * n_classes`.
+    dense_wl: Box<[f64]>,
+    /// Whether any `WL` weight exists.
+    wl_used: bool,
+    /// Dense type rows: `N_TYPE_FAMILIES * type_stride * n_classes`.
+    dense_t: Box<[f64]>,
+    /// Per-family gating for the dense type families.
+    t_used: [bool; N_TYPE_FAMILIES],
+}
+
+impl PackedTwoStageModel {
+    /// Compiles the stage-2 tagger and lexicon into packed tables for
+    /// `language`. Called once per model (re)load, not on the hot path.
+    ///
+    /// # Arguments
+    /// * `language` - The language whose type codes to compile for.
+    /// * `stage2` - The stage-2 word-level tagger (classes are UPOS tags,
+    ///   validated by [`crate::two_stage::TwoStageLearner`]).
+    /// * `lexicon` - Surface -> observed `(tag, count)` candidates, most
+    ///   frequent first (the [`crate::two_stage::TwoStageLearner`]
+    ///   invariant).
+    /// * `dominance` - The classifier-skip threshold in `(0.5, 1.0]`.
+    ///
+    /// # Returns
+    /// The compiled model.
+    pub(crate) fn build(
+        language: Language,
+        stage2: &AveragedPerceptron,
+        lexicon: &FxHashMap<String, Vec<(Upos, u32)>>,
+        dominance: f64,
+    ) -> Self {
+        let class_names = stage2.class_names();
+        let n = class_names.len();
+        // TwoStageLearner validates every class name as a UPOS tag; the
+        // fallback mirrors PackedPosModel::build's defensive parse.
+        let classes: Box<[Upos]> =
+            class_names.iter().map(|c| c.parse().unwrap_or(Upos::X)).collect();
+        let type_stride = language.type_codes().len() + 2;
+
+        let mut words: FxHashMap<String, WordEntryBuild> = FxHashMap::default();
+        let mut hash: FxHashMap<u64, Vec<(u16, f64)>> = FxHashMap::default();
+        let mut has = [false; N_WORD_TEMPLATES];
+        let mut dense_wl = vec![0.0f64; (WL_CAP + 1) * n].into_boxed_slice();
+        let mut wl_used = false;
+        let mut dense_t = vec![0.0f64; N_TYPE_FAMILIES * type_stride * n].into_boxed_slice();
+        let mut t_used = [false; N_TYPE_FAMILIES];
+
+        for (feature, class_weights) in stage2.feature_class_weights() {
+            let sparse = || {
+                class_weights
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, w)| **w != 0.0)
+                    .map(|(c, &w)| (c as u16, w))
+            };
+            match parse_word_feature(language, feature) {
+                Some(WordFeature::Surface(surface)) => {
+                    words.entry(surface.to_string()).or_default().2.extend(sparse());
+                }
+                Some(WordFeature::WordLen(len)) => {
+                    dense_wl[len * n..][..n].copy_from_slice(class_weights);
+                    wl_used = true;
+                }
+                Some(WordFeature::TypeDense { family, type_idx }) => {
+                    dense_t[(family * type_stride + type_idx) * n..][..n]
+                        .copy_from_slice(class_weights);
+                    t_used[family] = true;
+                }
+                Some(WordFeature::Hash(key)) => {
+                    let row = hash.entry(key).or_default();
+                    row.extend(sparse());
+                    if !row.is_empty() {
+                        has[(key >> 56) as usize] = true;
+                    }
+                }
+                // Features no word template of this language can render
+                // are unreachable at inference and skipped, mirroring the
+                // other packed builders.
+                None => {}
+            }
+        }
+
+        for (surface, entry) in lexicon {
+            let slot = words.entry(surface.clone()).or_default();
+            // The entry is sorted most-frequent-first with a deterministic
+            // tie-break (TwoStageLearner invariant), so entry[0] is the
+            // dominant candidate.
+            let total: u32 = entry.iter().map(|(_, count)| count).sum();
+            if entry.len() == 1 || f64::from(entry[0].1) / f64::from(total) >= dominance {
+                slot.0 = Some(entry[0].0);
+            }
+            let mut candidates: Vec<u16> = entry
+                .iter()
+                .filter_map(|(tag, _)| classes.iter().position(|c| c == tag).map(|i| i as u16))
+                .collect();
+            candidates.sort_unstable();
+            slot.1 = candidates;
+        }
+
+        let words = words
+            .into_iter()
+            .filter(|(_, (fixed, candidates, ws_row))| {
+                fixed.is_some() || !candidates.is_empty() || !ws_row.is_empty()
+            })
+            .map(|(surface, (fixed, candidates, mut ws_row))| {
+                ws_row.sort_unstable_by_key(|&(c, _)| c);
+                (
+                    surface,
+                    WordEntry {
+                        fixed,
+                        candidates: candidates.into_boxed_slice(),
+                        ws_row: ws_row.into_boxed_slice(),
+                    },
+                )
+            })
+            .collect();
+        let hash = hash
+            .into_iter()
+            .filter(|(_, row)| !row.is_empty())
+            .map(|(key, mut row)| {
+                row.sort_unstable_by_key(|&(c, _)| c);
+                (key, row.into_boxed_slice())
+            })
+            .collect();
+
+        PackedTwoStageModel {
+            classes,
+            n_classes: n,
+            type_stride,
+            words,
+            hash,
+            has,
+            dense_wl,
+            wl_used,
+            dense_t,
+            t_used,
+        }
+    }
+
+    /// Adds a sparse hash row to the score vector.
+    #[inline]
+    fn add_hash(&self, scores: &mut [f64], key: u64) {
+        if let Some(row) = self.hash.get(&key) {
+            for &(c, w) in row.iter() {
+                scores[c as usize] += w;
+            }
+        }
+    }
+
+    /// Adds a dense type row to the score vector.
+    #[inline]
+    fn add_type(&self, scores: &mut [f64], family: usize, type_idx: usize) {
+        if self.t_used[family] {
+            let row = &self.dense_t[(family * self.type_stride + type_idx) * self.n_classes..]
+                [..self.n_classes];
+            for (s, w) in scores.iter_mut().zip(row) {
+                *s += w;
+            }
+        }
+    }
+
+    /// Tags every word of a segmented sentence.
+    ///
+    /// The words must concatenate to the original sentence (the shape
+    /// produced by [`crate::segmenter::Segmenter::segment`]); context
+    /// features read the neighboring characters across word boundaries.
+    ///
+    /// # Arguments
+    /// * `language` - The language for character type classification.
+    /// * `words` - The segmented words, in order.
+    ///
+    /// # Returns
+    /// One UPOS tag per word. Words the classifier cannot decide (an empty
+    /// stage-2 model and no lexicon answer) receive [`Upos::X`].
+    pub(crate) fn tag_words(&self, language: Language, words: &[String]) -> Vec<Upos> {
+        let mut sent: Vec<char> = Vec::new();
+        let mut type_ids: Vec<u8> = Vec::new();
+        for word in words {
+            for c in word.chars() {
+                sent.push(c);
+                type_ids.push(language.char_type_id(c));
+            }
+        }
+        let radix = self.type_stride - 2;
+        let n = self.n_classes;
+        let mut scores = vec![0.0f64; n];
+        let mut out = Vec::with_capacity(words.len());
+        let mut start = 0usize;
+
+        for word in words {
+            let wlen = word.chars().count();
+            if wlen == 0 {
+                // Not producible by segment(); kept total for safety.
+                out.push(Upos::X);
+                continue;
+            }
+            let end = start + wlen;
+            let entry = self.words.get(word.as_str());
+            if let Some(e) = entry {
+                if let Some(tag) = e.fixed {
+                    out.push(tag);
+                    start = end;
+                    continue;
+                }
+            }
+            if n == 0 {
+                out.push(Upos::X);
+                start = end;
+                continue;
+            }
+
+            scores.iter_mut().for_each(|s| *s = 0.0);
+            if let Some(e) = entry {
+                for &(c, w) in e.ws_row.iter() {
+                    scores[c as usize] += w;
+                }
+            }
+            if self.wl_used {
+                let row = &self.dense_wl[wlen.min(WL_CAP) * n..][..n];
+                for (s, w) in scores.iter_mut().zip(row) {
+                    *s += w;
+                }
+            }
+            self.add_type(&mut scores, F_FT, type_ids[start] as usize);
+            self.add_type(&mut scores, F_LT, type_ids[end - 1] as usize);
+            if self.has[T_FC] {
+                self.add_hash(&mut scores, hash_key(T_FC, sent[start] as u64));
+            }
+            if self.has[T_LC] {
+                self.add_hash(&mut scores, hash_key(T_LC, sent[end - 1] as u64));
+            }
+            if self.has[T_TS] {
+                let payload = ts_payload(&type_ids[start..end.min(start + TS_CAP)]);
+                self.add_hash(&mut scores, hash_key(T_TS, payload));
+            }
+            // Context characters at distance k, as packed codes and dense
+            // type indices (BOS/EOS sentinels beyond the sentence).
+            let lc = |k: usize| if start >= k { sent[start - k] as u64 } else { BOS_CODE };
+            let rc = |k: usize| sent.get(end + k - 1).map_or(EOS_CODE, |&c| c as u64);
+            let lt = |k: usize| if start >= k { type_ids[start - k] as usize } else { radix };
+            let rt = |k: usize| type_ids.get(end + k - 1).map_or(radix + 1, |&t| t as usize);
+            for k in 1..=CONTEXT_WINDOW {
+                if self.has[T_L1 + k - 1] {
+                    self.add_hash(&mut scores, hash_key(T_L1 + k - 1, lc(k)));
+                }
+                if self.has[T_R1 + k - 1] {
+                    self.add_hash(&mut scores, hash_key(T_R1 + k - 1, rc(k)));
+                }
+                self.add_type(&mut scores, F_CL1 + k - 1, lt(k));
+                self.add_type(&mut scores, F_CR1 + k - 1, rt(k));
+            }
+            if self.has[T_LB] {
+                self.add_hash(&mut scores, hash_key(T_LB, (lc(2) << 24) | lc(1)));
+            }
+            if self.has[T_RB] {
+                self.add_hash(&mut scores, hash_key(T_RB, (rc(1) << 24) | rc(2)));
+            }
+            if wlen >= 2 {
+                if self.has[T_P2] {
+                    let payload = ((sent[start] as u64) << 24) | sent[start + 1] as u64;
+                    self.add_hash(&mut scores, hash_key(T_P2, payload));
+                }
+                if self.has[T_S2] {
+                    let payload = ((sent[end - 2] as u64) << 24) | sent[end - 1] as u64;
+                    self.add_hash(&mut scores, hash_key(T_S2, payload));
+                }
+            }
+
+            // Argmax with the perceptron's first-wins tie-break (lowest
+            // class index), restricted to the candidates when the surface
+            // has usable ones.
+            let best = match entry {
+                Some(e) if !e.candidates.is_empty() => {
+                    let mut best = e.candidates[0] as usize;
+                    let mut best_score = scores[best];
+                    for &c in &e.candidates[1..] {
+                        if scores[c as usize] > best_score {
+                            best = c as usize;
+                            best_score = scores[best];
+                        }
+                    }
+                    best
+                }
+                _ => {
+                    let mut best = 0usize;
+                    let mut best_score = scores[0];
+                    for (c, &s) in scores.iter().enumerate().skip(1) {
+                        if s > best_score {
+                            best = c;
+                            best_score = s;
+                        }
+                    }
+                    best
+                }
+            };
+            out.push(self.classes[best]);
+            start = end;
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::adaboost::AdaBoost;
+    use crate::segmenter::Segmenter;
+    use crate::two_stage::TwoStageLearner;
+
+    fn stage2(model: &str) -> AveragedPerceptron {
+        let mut p = AveragedPerceptron::new();
+        p.load_model_from_reader(model.as_bytes()).unwrap();
+        p
+    }
+
+    fn lexicon(entries: &[(&str, &[(Upos, u32)])]) -> FxHashMap<String, Vec<(Upos, u32)>> {
+        entries.iter().map(|(s, e)| (s.to_string(), e.to_vec())).collect()
+    }
+
+    const MODEL: &str = "2\nNOUN\nVERB\nL1:あ\tVERB\t1\nWS:x\tNOUN\t0.6\nWS:x\tVERB\t0.5";
+
+    fn tag(model: &PackedTwoStageModel, words: &[&str]) -> Vec<Upos> {
+        let words: Vec<String> = words.iter().map(|w| w.to_string()).collect();
+        model.tag_words(Language::Japanese, &words)
+    }
+
+    #[test]
+    fn test_fixed_tags_skip_scoring() {
+        let lex = lexicon(&[
+            // Single candidate: always fixed.
+            ("y", &[(Upos::NOUN, 1)]),
+            // Dominant candidate: 100/101 >= 0.99.
+            ("w", &[(Upos::VERB, 100), (Upos::NOUN, 1)]),
+            // Non-dominant: 3/5 < 0.99, classifier decides.
+            ("x", &[(Upos::NOUN, 3), (Upos::VERB, 2)]),
+        ]);
+        let model = PackedTwoStageModel::build(Language::Japanese, &stage2(MODEL), &lex, 0.99);
+        // "y" and "w" are fixed; "x" is scored: WS gives NOUN 0.6 > VERB 0.5.
+        assert_eq!(tag(&model, &["y", "w", "x"]), [Upos::NOUN, Upos::VERB, Upos::NOUN]);
+    }
+
+    #[test]
+    fn test_context_feature_flips_masked_argmax() {
+        let lex = lexicon(&[("x", &[(Upos::NOUN, 3), (Upos::VERB, 2)])]);
+        let model = PackedTwoStageModel::build(Language::Japanese, &stage2(MODEL), &lex, 0.99);
+        // Preceded by 'あ', the L1 context feature adds VERB +1:
+        // VERB 1.5 > NOUN 0.6. ('あ' itself is unknown: all-zero scores,
+        // first-wins tie-break picks class 0 = NOUN.)
+        assert_eq!(tag(&model, &["あ", "x"]), [Upos::NOUN, Upos::VERB]);
+        // Without that context the WS row decides: NOUN 0.6 > VERB 0.5.
+        assert_eq!(tag(&model, &["x"]), [Upos::NOUN]);
+    }
+
+    #[test]
+    fn test_lexicon_tags_unknown_to_classifier() {
+        // Candidates outside the classifier's classes are unusable for
+        // masking: with none left the word falls back to the full argmax,
+        // but a *dominant* out-of-class tag is still assigned via `fixed`.
+        let lex = lexicon(&[("z", &[(Upos::ADP, 5), (Upos::PART, 4)]), ("q", &[(Upos::SYM, 1)])]);
+        let model = PackedTwoStageModel::build(Language::Japanese, &stage2(MODEL), &lex, 0.99);
+        // "z": both candidates unknown to the classifier, not dominant ->
+        // full argmax over all-zero scores -> class 0 (NOUN).
+        // "q": single candidate -> fixed SYM even though the classifier
+        // does not know it.
+        assert_eq!(tag(&model, &["z", "q"]), [Upos::NOUN, Upos::SYM]);
+    }
+
+    #[test]
+    fn test_empty_stage2_yields_x_for_unknown() {
+        // A single-class degenerate model cannot be built (the perceptron
+        // format requires classes), so exercise the n_classes == 0 guard
+        // through an empty perceptron.
+        let lex = lexicon(&[("y", &[(Upos::NOUN, 1)])]);
+        let model =
+            PackedTwoStageModel::build(Language::Japanese, &AveragedPerceptron::new(), &lex, 0.99);
+        assert_eq!(tag(&model, &["y", "??"]), [Upos::NOUN, Upos::X]);
+    }
+
+    #[test]
+    fn test_segmenter_two_stage_integration() {
+        // The default (empty) stage-1 AdaBoost segments one char per word,
+        // which makes the boundary behavior deterministic for this test.
+        let lex = vec![("こ".to_string(), vec![(Upos::NOUN, 1)])];
+        let learner = TwoStageLearner::from_parts(
+            AdaBoost::default(),
+            stage2("2\nNOUN\nVERB\nL1:こ\tVERB\t1"),
+            lex,
+            0.99,
+        )
+        .unwrap();
+        let segmenter = Segmenter::with_two_stage_learner(Language::Japanese, learner);
+
+        // segment() runs stage-1 only.
+        assert_eq!(segmenter.segment("これ"), ["こ", "れ"]);
+        // segment_with_pos(): "こ" is lexicon-fixed NOUN; "れ" is unknown
+        // and the L1 context feature ('こ') pushes it to VERB.
+        let tagged = segmenter.segment_with_pos("これ").unwrap();
+        assert_eq!(tagged, [("こ".to_string(), Upos::NOUN), ("れ".to_string(), Upos::VERB)]);
+        // Words always concatenate back to the input.
+        let text: String = tagged.iter().map(|(w, _)| w.as_str()).collect();
+        assert_eq!(text, "これ");
+        // Empty input stays empty.
+        assert!(segmenter.segment_with_pos("").unwrap().is_empty());
+        // The two-stage segmenter has no joint POS learner.
+        assert!(segmenter.pos_learner().is_none());
+    }
+}

--- a/litsea/src/segmenter.rs
+++ b/litsea/src/segmenter.rs
@@ -15,8 +15,23 @@ use crate::packed_model::{
     PackedModel, SENTINEL_BASE, Slot, TAG_B, TAG_O, TAG_U, TEMPLATES, templates_for, wc_key,
 };
 use crate::packed_pos_model::PackedPosModel;
+use crate::packed_two_stage::PackedTwoStageModel;
 use crate::perceptron::AveragedPerceptron;
+use crate::two_stage::TwoStageLearner;
 use crate::upos::{SegmentLabel, Upos};
+
+/// The stage-2 half of a decomposed [`TwoStageLearner`], retained so the
+/// packed tagging tables can be rebuilt if they are ever invalidated
+/// (mirroring how the segmenter retains its other learners).
+#[derive(Debug)]
+struct TwoStageState {
+    /// Stage-2 word-level tagger.
+    stage2: AveragedPerceptron,
+    /// Surface -> observed `(tag, count)` candidates, most frequent first.
+    lexicon: rustc_hash::FxHashMap<String, Vec<(Upos, u32)>>,
+    /// Classifier-skip dominance threshold.
+    dominance: f64,
+}
 
 /// Text segmenter supporting two modes: word segmentation via AdaBoost
 /// binary classification, and joint word segmentation + POS tagging via an
@@ -43,6 +58,16 @@ pub struct Segmenter {
     /// [`add_corpus_with_pos`](Self::add_corpus_with_pos), which invalidate
     /// it); lazily rebuilt on the next `segment_with_pos` call.
     packed_pos: RwLock<Option<PackedPosModel>>,
+    /// The stage-2 state of a two-stage model, set by
+    /// [`with_two_stage_learner`](Self::with_two_stage_learner) (the
+    /// stage-1 half lives in `learner`). When present,
+    /// [`segment_with_pos`](Self::segment_with_pos) takes the two-stage
+    /// path instead of the joint POS path.
+    two_stage: Option<TwoStageState>,
+    /// The two-stage state compiled into packed tagging tables. `None`
+    /// when no two-stage learner is set; built eagerly by
+    /// [`with_two_stage_learner`](Self::with_two_stage_learner).
+    packed_two_stage: RwLock<Option<PackedTwoStageModel>>,
 }
 
 impl Segmenter {
@@ -91,6 +116,8 @@ impl Segmenter {
             pos_learner: None,
             packed,
             packed_pos: RwLock::new(None),
+            two_stage: None,
+            packed_two_stage: RwLock::new(None),
         }
     }
 
@@ -121,6 +148,45 @@ impl Segmenter {
             pos_learner: Some(pos_learner),
             packed,
             packed_pos,
+            two_stage: None,
+            packed_two_stage: RwLock::new(None),
+        }
+    }
+
+    /// Creates a new instance of [`Segmenter`] with a two-stage model
+    /// (issue #147): the learner's stage-1 boundary classifier becomes the
+    /// segmenter's AdaBoost-path learner (so [`segment`](Self::segment)
+    /// works naturally), and [`segment_with_pos`](Self::segment_with_pos)
+    /// tags each segmented word through the lexicon (candidate
+    /// restriction, dominance skip) and the stage-2 word-level tagger.
+    ///
+    /// # Arguments
+    /// * `language` - The language to use for character type classification.
+    /// * `learner` - The two-stage learner (typically one that has loaded
+    ///   a `litsea-two-stage v1` model).
+    ///
+    /// # Returns
+    /// A new Segmenter instance configured for two-stage segmentation +
+    /// POS tagging.
+    pub fn with_two_stage_learner(language: Language, learner: TwoStageLearner) -> Self {
+        let (stage1, stage2, lexicon, dominance) = learner.into_parts();
+        // Compile both packed tables eagerly so the common
+        // load-then-segment path never rebuilds mid-stream.
+        let packed = RwLock::new(Some(PackedModel::build(language, &stage1)));
+        let packed_two_stage =
+            RwLock::new(Some(PackedTwoStageModel::build(language, &stage2, &lexicon, dominance)));
+        Segmenter {
+            language,
+            learner: stage1,
+            pos_learner: None,
+            packed,
+            packed_pos: RwLock::new(None),
+            two_stage: Some(TwoStageState {
+                stage2,
+                lexicon,
+                dominance,
+            }),
+            packed_two_stage,
         }
     }
 
@@ -275,6 +341,36 @@ impl Segmenter {
         // get_or_insert_with covers the race where another thread rebuilt
         // the table between the two lock acquisitions.
         let packed = guard.get_or_insert_with(|| PackedPosModel::build(self.language, pos_learner));
+        f(packed)
+    }
+
+    /// Runs `f` with the packed two-stage tagging tables, rebuilding them
+    /// first if they were invalidated. The fast path takes only an
+    /// uncontended read lock (one per sentence). The caller passes the
+    /// two-stage state it already borrowed (presence is checked by
+    /// [`segment_with_pos`](Self::segment_with_pos)).
+    fn with_packed_two_stage<R>(
+        &self,
+        state: &TwoStageState,
+        f: impl FnOnce(&PackedTwoStageModel) -> R,
+    ) -> R {
+        {
+            let guard = self.packed_two_stage.read().unwrap_or_else(PoisonError::into_inner);
+            if let Some(packed) = guard.as_ref() {
+                return f(packed);
+            }
+        }
+        let mut guard = self.packed_two_stage.write().unwrap_or_else(PoisonError::into_inner);
+        // get_or_insert_with covers the race where another thread rebuilt
+        // the table between the two lock acquisitions.
+        let packed = guard.get_or_insert_with(|| {
+            PackedTwoStageModel::build(
+                self.language,
+                &state.stage2,
+                &state.lexicon,
+                state.dominance,
+            )
+        });
         f(packed)
     }
 
@@ -800,13 +896,32 @@ impl Segmenter {
     /// `Result<Vec<(String, Upos)>>` - Pairs of words and their POS tags.
     /// An empty sentence yields `Ok` with an empty vector.
     ///
+    /// # Two-stage mode
+    /// When the segmenter was built with
+    /// [`with_two_stage_learner`](Self::with_two_stage_learner), this
+    /// method instead runs the two-stage pipeline (issue #147): the
+    /// sentence is segmented by the stage-1 boundary classifier (exactly
+    /// as [`segment`](Self::segment)), then each word is tagged through
+    /// the candidate-tag lexicon — single-candidate and dominant surfaces
+    /// skip the classifier entirely — with the stage-2 word-level tagger
+    /// deciding ambiguous surfaces (candidate-masked argmax) and unknown
+    /// surfaces (full argmax).
+    ///
     /// # Errors
-    /// Returns [`LitseaError::PosLearnerNotSet`] if no POS learner is set.
-    /// Set one beforehand with [`with_pos_learner`](Self::with_pos_learner)
-    /// or [`add_corpus_with_pos`](Self::add_corpus_with_pos).
+    /// Returns [`LitseaError::PosLearnerNotSet`] if neither a POS learner
+    /// nor a two-stage learner is set. Set one beforehand with
+    /// [`with_pos_learner`](Self::with_pos_learner),
+    /// [`with_two_stage_learner`](Self::with_two_stage_learner), or
+    /// [`add_corpus_with_pos`](Self::add_corpus_with_pos).
     pub fn segment_with_pos(&self, sentence: &str) -> Result<Vec<(String, Upos)>> {
         if sentence.is_empty() {
             return Ok(Vec::new());
+        }
+        if let Some(state) = self.two_stage.as_ref() {
+            let words = self.segment(sentence);
+            let tags =
+                self.with_packed_two_stage(state, |packed| packed.tag_words(self.language, &words));
+            return Ok(words.into_iter().zip(tags).collect());
         }
         let pos_learner = self.pos_learner.as_ref().ok_or(LitseaError::PosLearnerNotSet)?;
         let (chars, char_codes, type_ids) = self.packed_context(sentence);

--- a/litsea/src/two_stage.rs
+++ b/litsea/src/two_stage.rs
@@ -268,6 +268,18 @@ impl TwoStageLearner {
         })
     }
 
+    /// Decomposes the learner into its parts. Crate-private: used by the
+    /// segmenter runtime, which installs stage-1 as its boundary learner
+    /// and compiles the rest into packed tagging tables.
+    ///
+    /// # Returns
+    /// `(stage1, stage2, lexicon, dominance)`.
+    pub(crate) fn into_parts(
+        self,
+    ) -> (AdaBoost, AveragedPerceptron, FxHashMap<String, LexiconEntry>, f64) {
+        (self.stage1, self.stage2, self.lexicon, self.dominance)
+    }
+
     /// Returns the stage-1 boundary classifier.
     #[must_use]
     pub fn stage1(&self) -> &AdaBoost {

--- a/litsea/src/word_features.rs
+++ b/litsea/src/word_features.rs
@@ -1,0 +1,467 @@
+//! Word-level feature templates for the two-stage POS tagger (issue #147).
+//!
+//! This module is the single source of truth for the stage-2 feature
+//! inventory: the training extractor writes feature *strings* with
+//! [`write_word_features`], and the packed runtime compiles the same
+//! strings back into integer keys / dense indices with
+//! [`parse_word_feature`]. The two directions are pinned against each other
+//! by a round-trip unit test, and the runtime builds its probe keys with
+//! the same helpers ([`hash_key`], [`ts_payload`]) that the parser
+//! produces.
+//!
+//! # Templates
+//!
+//! For a word spanning `[start, end)` of a sentence (`w` = surface,
+//! `n = end - start`):
+//!
+//! | prefix | value | representation |
+//! |--------|-------|----------------|
+//! | `WS` | the surface itself | surface string |
+//! | `WL` | `min(n, 4)` | dense (word length) |
+//! | `FC` / `LC` | first / last char | hashed char key |
+//! | `ft` / `lt` | first / last char type | dense (type) |
+//! | `TS` | type codes of the first ≤8 chars | hashed key |
+//! | `L1`-`L3` / `R1`-`R3` | context chars at distance 1-3 | hashed char key |
+//! | `cl1`-`cl3` / `cr1`-`cr3` | context char types | dense (type) |
+//! | `LB` / `RB` | context bigrams (distance 2+1 / 1+2) | hashed pair key |
+//! | `P2` / `S2` | first / last two chars (words with n ≥ 2) | hashed pair key |
+//!
+//! Context positions beyond the sentence use the sentinel characters
+//! [`BOS_CHAR`] / [`EOS_CHAR`] (U+0001 / U+0002) in feature strings — a
+//! single character, so parsing is unambiguous, and never produced by real
+//! text — and the out-of-Unicode codes [`BOS_CODE`] / [`EOS_CODE`] in
+//! packed keys (the same trick as `packed_model::SENTINEL_BASE`). Type
+//! strings use the language's type codes, which are prefix-free by design,
+//! so the concatenated `TS` payload parses unambiguously.
+
+use crate::language::Language;
+
+/// Sentinel character standing for "before the sentence" in feature
+/// strings (control character U+0001; real text never contains it).
+pub(crate) const BOS_CHAR: char = '\u{1}';
+/// Sentinel character standing for "after the sentence" in feature
+/// strings (control character U+0002).
+pub(crate) const EOS_CHAR: char = '\u{2}';
+/// Packed char code of [`BOS_CHAR`] (first code above Unicode).
+pub(crate) const BOS_CODE: u64 = 0x11_0000;
+/// Packed char code of [`EOS_CHAR`].
+pub(crate) const EOS_CODE: u64 = 0x11_0001;
+
+/// Word-length cap of the `WL` template.
+pub(crate) const WL_CAP: usize = 4;
+/// Character cap of the `TS` (word type string) template.
+pub(crate) const TS_CAP: usize = 8;
+/// Context window of the `L*`/`R*`/`cl*`/`cr*` templates.
+pub(crate) const CONTEXT_WINDOW: usize = 3;
+
+/// Number of word-feature templates.
+pub(crate) const N_WORD_TEMPLATES: usize = 23;
+
+/// Template prefixes, indexed by template id. The id order is load-bearing
+/// for packed hash keys (`id << 56`); append-only.
+pub(crate) const WORD_TEMPLATE_PREFIXES: [&str; N_WORD_TEMPLATES] = [
+    "WS", "WL", "FC", "LC", "ft", "lt", "TS", "L1", "L2", "L3", "R1", "R2", "R3", "cl1", "cl2",
+    "cl3", "cr1", "cr2", "cr3", "LB", "RB", "P2", "S2",
+];
+
+/// Template ids (indices into [`WORD_TEMPLATE_PREFIXES`]).
+pub(crate) const T_WS: usize = 0;
+pub(crate) const T_WL: usize = 1;
+pub(crate) const T_FC: usize = 2;
+pub(crate) const T_LC: usize = 3;
+pub(crate) const T_FT: usize = 4;
+pub(crate) const T_LT: usize = 5;
+pub(crate) const T_TS: usize = 6;
+/// First of the three left-context char templates (`L1`..`L3`).
+pub(crate) const T_L1: usize = 7;
+/// First of the three right-context char templates (`R1`..`R3`).
+pub(crate) const T_R1: usize = 10;
+/// First of the three left-context type templates (`cl1`..`cl3`).
+pub(crate) const T_CL1: usize = 13;
+/// First of the three right-context type templates (`cr1`..`cr3`).
+pub(crate) const T_CR1: usize = 16;
+pub(crate) const T_LB: usize = 19;
+pub(crate) const T_RB: usize = 20;
+pub(crate) const T_P2: usize = 21;
+pub(crate) const T_S2: usize = 22;
+
+/// Number of dense type-valued families (`ft`, `lt`, `cl1`-`cl3`,
+/// `cr1`-`cr3`), in that family order.
+pub(crate) const N_TYPE_FAMILIES: usize = 8;
+/// Dense family index of `ft`.
+pub(crate) const F_FT: usize = 0;
+/// Dense family index of `lt`.
+pub(crate) const F_LT: usize = 1;
+/// Dense family index of `cl1` (`cl2`/`cl3` follow).
+pub(crate) const F_CL1: usize = 2;
+/// Dense family index of `cr1` (`cr2`/`cr3` follow).
+pub(crate) const F_CR1: usize = 5;
+
+/// A parsed word feature, routed to its storage class by the packed
+/// runtime.
+#[derive(Debug, PartialEq)]
+pub(crate) enum WordFeature<'a> {
+    /// `WS`: the word surface (stored on the surface map).
+    Surface(&'a str),
+    /// `WL`: capped word length in `1..=WL_CAP` (dense).
+    WordLen(usize),
+    /// Type-valued template (dense): family index and type index, where
+    /// the type index is a language type id, `radix` (BOS), or `radix + 1`
+    /// (EOS).
+    TypeDense { family: usize, type_idx: usize },
+    /// Char-valued or type-string template: a packed hash key
+    /// (`template_id << 56 | payload`).
+    Hash(u64),
+}
+
+/// Builds a packed hash key for a template id and payload.
+#[inline]
+pub(crate) fn hash_key(template_id: usize, payload: u64) -> u64 {
+    ((template_id as u64) << 56) | payload
+}
+
+/// Packed code of a real or sentinel context character.
+#[inline]
+pub(crate) fn char_code(c: char) -> u64 {
+    match c {
+        BOS_CHAR => BOS_CODE,
+        EOS_CHAR => EOS_CODE,
+        _ => c as u64,
+    }
+}
+
+/// Builds the `TS` payload from the word's leading type ids
+/// (`len <= TS_CAP`, each id `< 16`): the length in the high nibble
+/// (bits 32+), one 4-bit id per character.
+#[inline]
+pub(crate) fn ts_payload(type_ids: &[u8]) -> u64 {
+    let mut payload = (type_ids.len() as u64) << 32;
+    for (i, &id) in type_ids.iter().enumerate() {
+        payload |= u64::from(id) << (4 * i);
+    }
+    payload
+}
+
+/// Parses one feature string written by [`write_word_features`] back into
+/// its routed form.
+///
+/// # Arguments
+/// * `language` - The language whose type codes to parse against.
+/// * `feature` - The feature string (`prefix:payload`).
+///
+/// # Returns
+/// The parsed feature, or `None` if the string does not match any word
+/// template for this language (such features are unreachable at inference
+/// and are skipped by the packed build, mirroring
+/// `packed_model::parse_feature_keys`).
+pub(crate) fn parse_word_feature(language: Language, feature: &str) -> Option<WordFeature<'_>> {
+    let (prefix, payload) = feature.split_once(':')?;
+    let tid = WORD_TEMPLATE_PREFIXES.iter().position(|p| *p == prefix)?;
+    match tid {
+        T_WS => Some(WordFeature::Surface(payload)),
+        T_WL => {
+            let len: usize = payload.parse().ok()?;
+            (1..=WL_CAP).contains(&len).then_some(WordFeature::WordLen(len))
+        }
+        T_FT | T_LT => {
+            let family = if tid == T_FT { F_FT } else { F_LT };
+            Some(WordFeature::TypeDense {
+                family,
+                type_idx: parse_type_idx(language, payload)?,
+            })
+        }
+        _ if (T_CL1..T_CL1 + CONTEXT_WINDOW).contains(&tid) => Some(WordFeature::TypeDense {
+            family: F_CL1 + (tid - T_CL1),
+            type_idx: parse_type_idx(language, payload)?,
+        }),
+        _ if (T_CR1..T_CR1 + CONTEXT_WINDOW).contains(&tid) => Some(WordFeature::TypeDense {
+            family: F_CR1 + (tid - T_CR1),
+            type_idx: parse_type_idx(language, payload)?,
+        }),
+        T_TS => {
+            let mut ids = Vec::with_capacity(TS_CAP);
+            let mut rest = payload;
+            while !rest.is_empty() {
+                if ids.len() == TS_CAP {
+                    return None;
+                }
+                // Type-code sets are prefix-free, so greedy matching is
+                // the unique parse.
+                let (id, r) = parse_type_code(language, rest)?;
+                ids.push(id);
+                rest = r;
+            }
+            (!ids.is_empty()).then(|| WordFeature::Hash(hash_key(T_TS, ts_payload(&ids))))
+        }
+        T_LB | T_RB | T_P2 | T_S2 => {
+            let mut chars = payload.chars();
+            let c1 = chars.next()?;
+            let c2 = chars.next()?;
+            if chars.next().is_some() {
+                return None;
+            }
+            Some(WordFeature::Hash(hash_key(tid, (char_code(c1) << 24) | char_code(c2))))
+        }
+        // FC / LC / L1..L3 / R1..R3: exactly one (possibly sentinel) char.
+        _ => {
+            let mut chars = payload.chars();
+            let c = chars.next()?;
+            if chars.next().is_some() {
+                return None;
+            }
+            Some(WordFeature::Hash(hash_key(tid, char_code(c))))
+        }
+    }
+}
+
+/// Parses a full payload as a single type code or sentinel, returning the
+/// dense type index.
+fn parse_type_idx(language: Language, payload: &str) -> Option<usize> {
+    let (id, rest) = parse_type_code(language, payload)?;
+    rest.is_empty().then_some(usize::from(id))
+}
+
+/// Greedily parses one leading type code (or sentinel char) off `s`,
+/// returning its index and the remainder. Sentinels map to `radix` /
+/// `radix + 1`.
+fn parse_type_code(language: Language, s: &str) -> Option<(u8, &str)> {
+    if let Some(rest) = s.strip_prefix(BOS_CHAR) {
+        return Some((language.type_codes().len() as u8, rest));
+    }
+    if let Some(rest) = s.strip_prefix(EOS_CHAR) {
+        return Some(((language.type_codes().len() + 1) as u8, rest));
+    }
+    for (id, code) in language.type_codes().iter().enumerate() {
+        if let Some(rest) = s.strip_prefix(code) {
+            return Some((id as u8, rest));
+        }
+    }
+    None
+}
+
+/// Writes every word feature of the word spanning `[start, end)` as
+/// strings, in template order.
+///
+/// This is the training-side twin of the packed runtime's key computation;
+/// both are pinned together by the round-trip test in this module.
+///
+/// # Arguments
+/// * `language` - The language whose type codes to write.
+/// * `sent` - The sentence characters (no sentinels).
+/// * `type_ids` - The per-character language type ids of `sent`.
+/// * `start` / `end` - The word's char span (`start < end <= sent.len()`).
+/// * `push` - Receives each feature string.
+// Production callers arrive with the two-stage training extractor (#168);
+// until then the writer is exercised by this module's round-trip test.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn write_word_features(
+    language: Language,
+    sent: &[char],
+    type_ids: &[u8],
+    start: usize,
+    end: usize,
+    push: &mut impl FnMut(String),
+) {
+    let codes = language.type_codes();
+    let n = end - start;
+    let surface: String = sent[start..end].iter().collect();
+    let lc = |k: usize| if start >= k { sent[start - k] } else { BOS_CHAR };
+    let rc = |k: usize| sent.get(end + k - 1).copied().unwrap_or(EOS_CHAR);
+    let type_code = |c: char| -> &str {
+        match c {
+            BOS_CHAR => "\u{1}",
+            EOS_CHAR => "\u{2}",
+            _ => codes[language.char_type_id(c) as usize],
+        }
+    };
+
+    push(format!("WS:{}", surface));
+    push(format!("WL:{}", n.min(WL_CAP)));
+    push(format!("FC:{}", sent[start]));
+    push(format!("LC:{}", sent[end - 1]));
+    push(format!("ft:{}", codes[type_ids[start] as usize]));
+    push(format!("lt:{}", codes[type_ids[end - 1] as usize]));
+    let ts: String = type_ids[start..end.min(start + TS_CAP)]
+        .iter()
+        .map(|&t| codes[t as usize])
+        .collect();
+    push(format!("TS:{}", ts));
+    for k in 1..=CONTEXT_WINDOW {
+        push(format!("L{}:{}", k, lc(k)));
+    }
+    for k in 1..=CONTEXT_WINDOW {
+        push(format!("R{}:{}", k, rc(k)));
+    }
+    for k in 1..=CONTEXT_WINDOW {
+        push(format!("cl{}:{}", k, type_code(lc(k))));
+    }
+    for k in 1..=CONTEXT_WINDOW {
+        push(format!("cr{}:{}", k, type_code(rc(k))));
+    }
+    push(format!("LB:{}{}", lc(2), lc(1)));
+    push(format!("RB:{}{}", rc(1), rc(2)));
+    if n >= 2 {
+        push(format!("P2:{}{}", sent[start], sent[start + 1]));
+        push(format!("S2:{}{}", sent[end - 2], sent[end - 1]));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Type index of a context character for the dense type families:
+    /// a language type id, or the BOS/EOS sentinel indices `radix` /
+    /// `radix + 1`.
+    fn context_type_idx(language: Language, c: char) -> usize {
+        match c {
+            BOS_CHAR => language.type_codes().len(),
+            EOS_CHAR => language.type_codes().len() + 1,
+            _ => language.char_type_id(c) as usize,
+        }
+    }
+
+    fn context(language: Language, text: &str) -> (Vec<char>, Vec<u8>) {
+        let chars: Vec<char> = text.chars().collect();
+        let type_ids = chars.iter().map(|&c| language.char_type_id(c)).collect();
+        (chars, type_ids)
+    }
+
+    /// Computes the packed-runtime view of every feature of a span the
+    /// same way `PackedTwoStageModel` does, for the round-trip test.
+    fn runtime_features(
+        language: Language,
+        sent: &[char],
+        type_ids: &[u8],
+        start: usize,
+        end: usize,
+    ) -> Vec<WordFeature<'static>> {
+        let n = end - start;
+        let lc = |k: usize| if start >= k { sent[start - k] } else { BOS_CHAR };
+        let rc = |k: usize| sent.get(end + k - 1).copied().unwrap_or(EOS_CHAR);
+        let mut out: Vec<WordFeature<'static>> = vec![
+            WordFeature::WordLen(n.min(WL_CAP)),
+            WordFeature::Hash(hash_key(T_FC, char_code(sent[start]))),
+            WordFeature::Hash(hash_key(T_LC, char_code(sent[end - 1]))),
+            WordFeature::TypeDense {
+                family: F_FT,
+                type_idx: type_ids[start] as usize,
+            },
+            WordFeature::TypeDense {
+                family: F_LT,
+                type_idx: type_ids[end - 1] as usize,
+            },
+            WordFeature::Hash(hash_key(
+                T_TS,
+                ts_payload(&type_ids[start..end.min(start + TS_CAP)]),
+            )),
+        ];
+        for k in 1..=CONTEXT_WINDOW {
+            out.push(WordFeature::Hash(hash_key(T_L1 + k - 1, char_code(lc(k)))));
+        }
+        for k in 1..=CONTEXT_WINDOW {
+            out.push(WordFeature::Hash(hash_key(T_R1 + k - 1, char_code(rc(k)))));
+        }
+        for k in 1..=CONTEXT_WINDOW {
+            out.push(WordFeature::TypeDense {
+                family: F_CL1 + k - 1,
+                type_idx: context_type_idx(language, lc(k)),
+            });
+        }
+        for k in 1..=CONTEXT_WINDOW {
+            out.push(WordFeature::TypeDense {
+                family: F_CR1 + k - 1,
+                type_idx: context_type_idx(language, rc(k)),
+            });
+        }
+        out.push(WordFeature::Hash(hash_key(T_LB, (char_code(lc(2)) << 24) | char_code(lc(1)))));
+        out.push(WordFeature::Hash(hash_key(T_RB, (char_code(rc(1)) << 24) | char_code(rc(2)))));
+        if n >= 2 {
+            out.push(WordFeature::Hash(hash_key(
+                T_P2,
+                (char_code(sent[start]) << 24) | char_code(sent[start + 1]),
+            )));
+            out.push(WordFeature::Hash(hash_key(
+                T_S2,
+                (char_code(sent[end - 2]) << 24) | char_code(sent[end - 1]),
+            )));
+        }
+        out
+    }
+
+    /// The writer's strings, parsed back, must equal the runtime's direct
+    /// key computation for every span — including sentence edges (BOS/EOS
+    /// sentinels) and multi-char Korean type codes.
+    #[test]
+    fn test_writer_parser_round_trip() {
+        for (language, text) in [
+            (Language::Japanese, "これは犬です"),
+            (Language::Japanese, "3匹のネコ"),
+            (Language::Korean, "고양이가 3마리"),
+            (Language::Chinese, "我爱北京"),
+        ] {
+            let (sent, type_ids) = context(language, text);
+            for start in 0..sent.len() {
+                for end in start + 1..=sent.len() {
+                    let mut written = Vec::new();
+                    write_word_features(language, &sent, &type_ids, start, end, &mut |f| {
+                        written.push(f);
+                    });
+                    let parsed: Vec<WordFeature> = written
+                        .iter()
+                        .map(|f| {
+                            parse_word_feature(language, f)
+                                .unwrap_or_else(|| panic!("unparsable feature {:?}", f))
+                        })
+                        .collect();
+                    // The first parsed feature is the surface; the rest
+                    // must equal the runtime computation in order.
+                    let surface: String = sent[start..end].iter().collect();
+                    assert_eq!(parsed[0], WordFeature::Surface(surface.as_str()));
+                    let expected = runtime_features(language, &sent, &type_ids, start, end);
+                    assert_eq!(
+                        &parsed[1..],
+                        &expected[..],
+                        "span {}..{} of {:?}",
+                        start,
+                        end,
+                        text
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_rejects_unknown_and_malformed() {
+        let language = Language::Japanese;
+        for feature in [
+            "XX:foo",       // unknown prefix
+            "WSfoo",        // no colon
+            "WL:0",         // below range
+            "WL:5",         // above cap
+            "WL:x",         // not a number
+            "FC:ab",        // two chars where one is expected
+            "FC:",          // empty payload
+            "ft:Z",         // unknown type code
+            "TS:",          // empty type string
+            "TS:HHHHHHHHH", // more than TS_CAP codes
+            "LB:a",         // one char where two are expected
+            "LB:abc",       // three chars where two are expected
+        ] {
+            assert!(
+                parse_word_feature(language, feature).is_none(),
+                "{:?} should not parse",
+                feature
+            );
+        }
+    }
+
+    #[test]
+    fn test_sentinel_codes_are_outside_unicode() {
+        assert!(BOS_CODE > char::MAX as u64);
+        assert_eq!(char_code(BOS_CHAR), BOS_CODE);
+        assert_eq!(char_code(EOS_CHAR), EOS_CODE);
+        assert_eq!(char_code('あ'), 'あ' as u64);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the two-stage POS tagging runtime behind the unchanged `segment_with_pos()` signature — the second child issue of the two-stage architecture (#147), building on the `litsea-two-stage v1` format from #166 / #170.

- **`litsea::word_features`** (crate-private): single source of truth for the 23 stage-2 word-level feature templates — surface, word length, first/last char + type, word type string, ±3 context chars + types, context bigrams, 2-char prefix/suffix. A string writer (for the upcoming #168 training extractor) and a parser (for the packed runtime) are pinned against each other by an exhaustive round-trip test over every span of ja/zh/ko sample sentences (including sentence-edge sentinels U+0001/U+0002 and multi-char Korean type codes, which parse unambiguously because type-code sets are prefix-free).
- **`litsea::packed_two_stage`** (crate-private): compiles the stage-2 perceptron + lexicon into a surface map (one String probe per word: dominance-fixed tag, candidate class indices, `WS` weight row), integer-keyed sparse class rows with per-template gating (feature-subset models skip the corresponding probes automatically), and dense tables for type/length templates. Single-candidate and dominant surfaces (`>= dominance` of training occurrences) skip the classifier entirely; ambiguous known surfaces get a candidate-masked argmax (perceptron first-wins tie-break); unknown surfaces get the full-argmax fallback per the #147 design decisions.
- **`Segmenter::with_two_stage_learner`**: decomposes the `TwoStageLearner`, installs stage-1 as the segmenter's AdaBoost-path learner — so `segment()` works naturally and its hot loop is untouched — and dispatches `segment_with_pos()` to segment-then-tag when two-stage state is present. The joint path is unchanged.

## Verification

- 12 new unit tests (word-feature round-trip and malformed-input rejection; fixed-tag skip, dominance skip, context-feature-driven masked argmax, out-of-class lexicon tags, empty-classifier guard; full Segmenter integration). `cargo test --workspace` (216 tests), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, and `markdownlint-cli2` all pass.
- **End-to-end on real models**: the #147 prototype artifacts (collapsed binary-AP stage-1, stage-2 perceptrons, UD Japanese-GSD lexicon) were assembled via `TwoStageLearner::from_parts`, saved to a 7.9 MB `litsea-two-stage v1` file, reloaded, and evaluated with `litsea::evaluation::evaluate_pos` on the held-out UD GSD test:

| stage-2 feature set | Word F1 | Tagged F1 (joint: 92.51) | throughput (bocchan, same-process A/B) | ratio vs joint |
|---|---|---|---|---|
| Full | 96.48 | **93.41** | 2.2-2.5M chars/s | 1.5-1.6x |
| C | 96.48 | 92.92 | 3.6-3.8M | 2.2x |
| D | 96.48 | 92.71 | 3.8-4.2M | 2.3-2.5x |

  This reproduces the #147 prototype quality exactly (seg parity at -0.08pt vs joint, tagged F1 above joint in every set) on the production runtime including the full file round-trip. The formal >=2.5x gate measurement on `cargo bench -- external_corpus` (idle machine) belongs to #169, together with the per-language feature-set choice.

## Docs

- `docs/src/litsea/segmenter.md` (+ Japanese mirror): `with_two_stage_learner` API section and updated `segment_with_pos` error note; CHANGELOG updated. The user-facing tutorial/model docs land with the bundled models in #169.

Closes #167
Refs #147
