### PR TITLE
Add the two-stage training pipeline and CLI support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,25 @@
   Japanese word F1 96.48 (joint: 96.56) with tagged-word F1 92.71-93.41
   depending on the stage-2 feature set (joint: 92.51) at 1.5-2.5x the
   joint throughput. Word-level feature templates live in a single
-  crate-private module shared with the upcoming training extractor.
+  crate-private module shared with the training extractor below.
+- The two-stage training pipeline and CLI support (#168):
+  `Extractor::extract_two_stage` derives stage-1 boundary features, stage-2
+  word-level features, and the candidate-tag lexicon from a single
+  POS-tagged corpus pass, with a `TwoStageFeatureSet` (`Full` / `Balanced`
+  / `Fast`, default `Fast`) selecting which stage-2 templates to write;
+  `TwoStageTrainer` trains both stages, collapses the stage-1 boundary
+  perceptron to scalar AdaBoost-format weights (a lossless transformation —
+  see the `litsea::trainer` module docs), and assembles + saves a
+  `litsea-two-stage v1` model, reporting `TwoStageMetrics` for both stages.
+  `AnyPosModel::load` fetches a POS-capable model once and auto-detects
+  whether it is a joint or two-stage model. The `litsea` CLI gains
+  `extract --two-stage [--stage2-features full|balanced|fast]` and
+  `train --two-stage [--dominance 0.99]`; `segment --pos` and
+  `evaluate --pos` now auto-detect joint vs. two-stage models via
+  `AnyPosModel`, with no new flags. Verified end-to-end on UD
+  Japanese-GSD: `extract --two-stage` + `train --two-stage` (fast set)
+  reproduces the #167 runtime numbers exactly (held-out word F1 96.48,
+  tagged F1 92.71) in a 5.1 MB model file (vs. 11 MB for the joint model).
 
 ## 0.10.0
 

--- a/docs/ja/src/litsea-cli/evaluate.md
+++ b/docs/ja/src/litsea-cli/evaluate.md
@@ -30,7 +30,7 @@ litsea evaluate [OPTIONS] <MODEL_URI> <GOLD_FILE>
 | Option | Default | Description |
 |--------|---------|------------|
 | `-l`, `--language <LANGUAGE>` | `japanese` | モデルとゴールドコーパスの言語。指定可能な値: `japanese` / `ja`, `chinese` / `zh`, `korean` / `ko` |
-| `--pos` | off | 単語分割と品詞推定を同時に評価します。この場合、ゴールドコーパスは `word/POS` 形式である必要があります |
+| `--pos` | off | 単語分割と品詞推定を同時に評価します。この場合、ゴールドコーパスは `word/POS` 形式である必要があります。joint モデル（`train --pos`）または[二段構成](../advanced/model-file-format.md#two-stage-model-format-litsea-two-stage-v1)モデル（`train --two-stage`）のいずれも使用でき、ファイルから自動判別されます |
 | `--format <FORMAT>` | `space` | ゴールドコーパスの形式: `space`（スペース区切りトークン）または `tsv`（タブ区切りトークン。韓国語の空白保持コーパスのように、トークンとして空白文字そのものを含められます）。`--pos` 指定時は無視されます |
 
 ## メトリクス

--- a/docs/ja/src/litsea-cli/extract.md
+++ b/docs/ja/src/litsea-cli/extract.md
@@ -21,7 +21,9 @@ litsea extract [OPTIONS] <CORPUS_FILE> <FEATURES_FILE>
 |--------|---------|------------|
 | `-l`, `--language <LANGUAGE>` | `japanese` | 文字タイプ分類に使用する言語。指定可能な値: `japanese` / `ja`, `chinese` / `zh`, `korean` / `ko` |
 | `--pos` | off | 品詞（POS）特徴量抽出モードを有効にします。入力には品詞付きコーパスが必要です |
-| `--format <FORMAT>` | `space` | コーパスの形式: `space`（スペース区切りの単語）または `tsv`（タブ区切りのトークン。トークンは空白文字そのものでもよく、元の空白を保持できます）。`tsv` は `--pos` と併用できません |
+| `--format <FORMAT>` | `space` | コーパスの形式: `space`（スペース区切りの単語）または `tsv`（タブ区切りのトークン。トークンは空白文字そのものでもよく、元の空白を保持できます）。`tsv` は `--pos` および `--two-stage` と併用できません |
+| `--two-stage` | off | 通常の品詞特徴量の代わりに[二段構成](../advanced/model-file-format.md#two-stage-model-format-litsea-two-stage-v1)の学習用特徴量を抽出します。入力には品詞付きコーパスが必要です。`--pos` とは併用できません |
+| `--stage2-features <SET>` | `fast` | `--two-stage` 用の stage-2 単語特徴セット: `full`（品質最優先）、`balanced`、`fast`（速度最優先） |
 
 ## コーパスの形式
 
@@ -96,4 +98,24 @@ O	BC1:OI	BC2:II	BC3:II	BP1:UU	BP2:UU	BQ1:UOI	BQ2:UII	BQ3:UOI	BQ4:UII	BW1:B1こ	.
 
 ```sh
 litsea extract --pos -l japanese ./pos_corpus.txt ./pos_features.txt
+```
+
+## 二段構成の特徴量抽出
+
+`--two-stage` を指定すると、`extract` は `--pos` と同じ品詞付きコーパス形式
+（`単語/品詞 単語/品詞 ...`）を読み込みますが、
+[二段構成アーキテクチャ](../advanced/model-file-format.md#two-stage-model-format-litsea-two-stage-v1)
+向けに `FEATURES_FILE` をプレフィックスとした**3つ**のファイルを書き出します。
+
+| ファイル | 内容 |
+|------|---------|
+| `{FEATURES_FILE}.stage1` | 境界特徴量。文字位置ごとに1行、ラベルは `B` または `O`（`--pos` と同じ特徴量テンプレート） |
+| `{FEATURES_FILE}.stage2` | 単語単位の特徴量。単語ごとに1行、ラベルは UPOS タグ。書き出すテンプレートは `--stage2-features` で制御 |
+| `{FEATURES_FILE}.lexicon` | 候補タグ語彙表: `surface\tTAG:count[,TAG:count...]`（出現頻度の降順） |
+
+同じプレフィックスを `litsea train --two-stage` に渡します:
+
+```sh
+litsea extract --two-stage -l japanese ./pos_corpus.txt ./two_stage_features
+# ./two_stage_features.stage1, .stage2, .lexicon を書き出す
 ```

--- a/docs/ja/src/litsea-cli/segment.md
+++ b/docs/ja/src/litsea-cli/segment.md
@@ -19,7 +19,7 @@ echo "text" | litsea segment [OPTIONS] <MODEL_URI>
 | Option | Default | Description |
 |--------|---------|------------|
 | `-l`, `--language <LANGUAGE>` | `japanese` | 文字タイプ分類に使用する言語。指定可能な値: `japanese` / `ja`, `chinese` / `zh`, `korean` / `ko` |
-| `--pos` | off | 品詞推定付き分割を有効にします。`train --pos` で学習したPOSモデルが必要です |
+| `--pos` | off | 品詞推定付き分割を有効にします。joint モデル（`train --pos`）または[二段構成](../advanced/model-file-format.md#two-stage-model-format-litsea-two-stage-v1)モデル（`train --two-stage`）のいずれも使用でき、ファイルから自動判別されます |
 
 ## 入力 / 出力
 
@@ -70,7 +70,11 @@ echo "テスト文です。" \
 
 ## 品詞推定付き分割（`--pos`）
 
-`--pos` フラグを指定すると、Averaged Perceptron モデルを使用して単語分割と品詞推定を同時に行います。
+`--pos` フラグを指定すると、単語分割と品詞推定を同時に行います。モデルの種類
+（joint な Averaged Perceptron モデルか、
+[二段構成](../advanced/model-file-format.md#two-stage-model-format-litsea-two-stage-v1)モデルか）
+はファイルヘッダから自動判別されるため、`train --two-stage` で学習したモデルでも
+同じコマンドがそのまま使えます。
 
 ### 使い方
 
@@ -102,4 +106,4 @@ cat input.txt | litsea segment --pos -l japanese ./models/japanese_pos.model > o
 - `--language` フラグは、モデルが学習された言語と一致する必要があります
 - CLIは非同期のURI APIを通じてモデルを読み込み、TLS（rustls）を使用したHTTP/HTTPSをサポートしています。ライブラリには同期的なローカル読み込み（`load_model_from_path`）も用意されています
 - モデルURIはファイルパスに限定されません -- 有効なURLであれば使用可能です
-- `--pos` を使用する場合、モデルは `train --pos` で学習したPOSモデルである必要があります
+- `--pos` を使用する場合、モデルは `train --pos` または `train --two-stage` で学習した品詞推定対応モデルである必要があります

--- a/docs/ja/src/litsea-cli/train.md
+++ b/docs/ja/src/litsea-cli/train.md
@@ -23,7 +23,9 @@ litsea train [OPTIONS] <FEATURES_FILE> <MODEL_FILE>
 | `-i`, `--num-iterations <NUM_ITERATIONS>` | `100` | ブースティング反復の最大回数 |
 | `-m`, `--load-model-uri <LOAD_MODEL_URI>` | None | 学習を再開するための既存モデルのURI（ファイルパスまたはHTTP/HTTPS URL） |
 | `--pos` | off | 品詞（POS）学習モードを有効にする（Averaged Perceptron を使用） |
-| `--num-epochs <NUM_EPOCHS>` | `10` | 学習エポック数（POS モードのみ） |
+| `--num-epochs <NUM_EPOCHS>` | `10` | 学習エポック数（POS モードおよび `--two-stage` モード） |
+| `--two-stage` | off | 代わりに[二段構成](../advanced/model-file-format.md#two-stage-model-format-litsea-two-stage-v1)モデルを学習する。`{FEATURES_FILE}.stage1`/`.stage2`/`.lexicon`（`extract --two-stage` の出力）を読み込む。`--pos` および `-m`/`--load-model-uri`（増分学習は非対応）とは併用できない |
+| `--dominance <DOMINANCE>` | `0.99` | `--two-stage` 用の分類器スキップ閾値、範囲は `(0.5, 1.0]`。既知の単語のうち最頻タグが学習時の出現のこの割合以上を占めるものは、stage-2 分類器を呼ばずにタグ付けされる |
 
 ## 出力
 
@@ -124,3 +126,46 @@ AdaBoost と同様に、品詞モデルの学習も優雅な中断をサポー�
 | Parameter | 値を小さくした場合の効果 | 値を大きくした場合の効果 |
 |-----------|---------------------|---------------------|
 | `num_epochs` | 学習が高速化、アンダーフィットの可能性あり | 精度が向上、学習時間が長くなる、オーバーフィットの可能性あり |
+
+## 二段構成モデルの学習
+
+`--two-stage` を指定すると、
+[二段構成モデル](../advanced/model-file-format.md#two-stage-model-format-litsea-two-stage-v1)
+を構築します: 二値の境界分類器（stage 1）と単語単位の品詞タガー（stage 2）を、
+候補タグ語彙表とともに単一の `litsea-two-stage v1` ファイルに組み立てます。
+両ステージとも `--num-epochs` エポック分 Averaged Perceptron として学習し、
+その後 stage 1 は既存の AdaBoost 形式のスカラー重みに畳み込まれます
+（品質を損なわない変換 — 導出は `litsea::trainer` のモジュールドキュメントを参照）。
+これによりランタイムは通常の `segment()` モデルと全く同じ方法で採点します。
+
+### 使い方
+
+```sh
+litsea train --two-stage [OPTIONS] <FEATURES_PREFIX> <MODEL_FILE>
+```
+
+`FEATURES_PREFIX` は `extract --two-stage` に渡したものと同じプレフィックスです。
+
+### 例
+
+```sh
+litsea extract --two-stage -l japanese ./pos_corpus.txt ./two_stage_features
+litsea train --two-stage --num-epochs 10 ./two_stage_features ./models/japanese_two_stage.model
+```
+
+### 出力
+
+```text
+Result Metrics (Two-Stage):
+  Stage 1 (boundary) Accuracy: 99.36% ( 277213 )
+  Stage 1 Macro Precision: 99.30%
+  Stage 1 Macro Recall: 99.35%
+  Stage 2 (tagging) Accuracy: 98.53% ( 168333 )
+  Stage 2 Macro Precision: 98.39%
+  Stage 2 Macro Recall: 97.59%
+```
+
+他のモードと同様、これらは in-sample のメトリクスです。現実的な品質を見積もるには
+`litsea evaluate --pos` でホールドアウトされたテキストを評価してください。
+`segment --pos` と `evaluate --pos` はファイルヘッダから二段構成モデルを自動判別するため、
+利用に追加のフラグは不要です。

--- a/docs/src/litsea-cli/evaluate.md
+++ b/docs/src/litsea-cli/evaluate.md
@@ -31,7 +31,7 @@ litsea evaluate [OPTIONS] <MODEL_URI> <GOLD_FILE>
 | Option | Default | Description |
 |--------|---------|------------|
 | `-l`, `--language <LANGUAGE>` | `japanese` | Language of the model and gold corpus. Accepts: `japanese` / `ja`, `chinese` / `zh`, `korean` / `ko` |
-| `--pos` | off | Evaluate joint segmentation + POS tagging. The gold corpus must then be in `word/POS` format |
+| `--pos` | off | Evaluate segmentation + POS tagging. The gold corpus must then be in `word/POS` format. Accepts a joint model (`train --pos`) or a [two-stage](../advanced/model-file-format.md#two-stage-model-format-litsea-two-stage-v1) model (`train --two-stage`), auto-detected from the file |
 | `--format <FORMAT>` | `space` | Gold corpus format: `space` (space-separated tokens) or `tsv` (tab-separated tokens; a token may be a literal space, as in the Korean space-preserving corpus). Ignored with `--pos` |
 
 ## Metrics

--- a/docs/src/litsea-cli/extract.md
+++ b/docs/src/litsea-cli/extract.md
@@ -21,7 +21,9 @@ litsea extract [OPTIONS] <CORPUS_FILE> <FEATURES_FILE>
 |--------|---------|------------|
 | `-l`, `--language <LANGUAGE>` | `japanese` | Language for character type classification. Accepts: `japanese` / `ja`, `chinese` / `zh`, `korean` / `ko` |
 | `--pos` | off | Enable POS (Part-of-Speech) feature extraction mode. Requires a POS corpus as input |
-| `--format <FORMAT>` | `space` | Corpus format: `space` (space-separated words) or `tsv` (tab-separated tokens; a token may be a literal space, preserving the original spacing). `tsv` cannot be combined with `--pos` |
+| `--format <FORMAT>` | `space` | Corpus format: `space` (space-separated words) or `tsv` (tab-separated tokens; a token may be a literal space, preserving the original spacing). `tsv` cannot be combined with `--pos` or `--two-stage` |
+| `--two-stage` | off | Extract [two-stage](../advanced/model-file-format.md#two-stage-model-format-litsea-two-stage-v1) training features instead of joint POS features. Requires a POS corpus as input; cannot be combined with `--pos` |
+| `--stage2-features <SET>` | `fast` | Stage-2 word-feature set for `--two-stage`: `full` (best quality), `balanced`, or `fast` (best throughput) |
 
 ## Corpus Format
 
@@ -101,4 +103,24 @@ O	BC1:OI	BC2:II	BC3:II	BP1:UU	BP2:UU	BQ1:UOI	BQ2:UII	BQ3:UOI	BQ4:UII	BW1:B1こ	.
 
 ```sh
 litsea extract --pos -l japanese ./pos_corpus.txt ./pos_features.txt
+```
+
+## Two-Stage Feature Extraction
+
+With `--two-stage`, `extract` reads the same POS corpus format as `--pos`
+(`word/POS word/POS ...`) but writes **three** files derived from
+`FEATURES_FILE` as a prefix, for the [two-stage segmentation + POS tagging
+architecture](../advanced/model-file-format.md#two-stage-model-format-litsea-two-stage-v1):
+
+| File | Content |
+|------|---------|
+| `{FEATURES_FILE}.stage1` | Boundary features, one row per character position, label `B` or `O` (the same feature templates as `--pos`) |
+| `{FEATURES_FILE}.stage2` | Word-level features, one row per word, label a UPOS tag; which templates are written is controlled by `--stage2-features` |
+| `{FEATURES_FILE}.lexicon` | The candidate-tag lexicon: `surface\tTAG:count[,TAG:count...]`, most-frequent-first |
+
+Pass the same prefix to `litsea train --two-stage`:
+
+```sh
+litsea extract --two-stage -l japanese ./pos_corpus.txt ./two_stage_features
+# writes ./two_stage_features.stage1, .stage2, .lexicon
 ```

--- a/docs/src/litsea-cli/segment.md
+++ b/docs/src/litsea-cli/segment.md
@@ -19,7 +19,7 @@ echo "text" | litsea segment [OPTIONS] <MODEL_URI>
 | Option | Default | Description |
 |--------|---------|------------|
 | `-l`, `--language <LANGUAGE>` | `japanese` | Language for character type classification. Accepts: `japanese` / `ja`, `chinese` / `zh`, `korean` / `ko` |
-| `--pos` | off | Enable POS-tagged segmentation output. Requires a POS model trained with `train --pos` |
+| `--pos` | off | Enable POS-tagged segmentation output. Accepts a joint model (`train --pos`) or a [two-stage](../advanced/model-file-format.md#two-stage-model-format-litsea-two-stage-v1) model (`train --two-stage`), auto-detected from the file |
 
 ## Input / Output
 
@@ -70,7 +70,11 @@ echo "テスト文です。" \
 
 ## POS-Tagged Segmentation (`--pos`)
 
-When the `--pos` flag is specified, segmentation and POS tagging are performed simultaneously using an Averaged Perceptron model.
+When the `--pos` flag is specified, segmentation and POS tagging are
+performed simultaneously. The model kind (joint Averaged Perceptron or
+[two-stage](../advanced/model-file-format.md#two-stage-model-format-litsea-two-stage-v1))
+is auto-detected from the file header, so the same command works for
+either — including a model produced by `train --two-stage`.
 
 ### Usage
 
@@ -102,4 +106,4 @@ cat input.txt | litsea segment --pos -l japanese ./models/japanese_pos.model > o
 - The `--language` flag must match the language the model was trained for
 - The CLI loads models through the async URI API and supports HTTP/HTTPS with TLS (rustls); the library also offers synchronous local loading (`load_model_from_path`)
 - The model URI is not restricted to file paths -- any valid URL is accepted
-- When using `--pos`, the model must be a POS model trained with `train --pos`
+- When using `--pos`, the model must be a POS-capable model trained with `train --pos` or `train --two-stage`

--- a/docs/src/litsea-cli/train.md
+++ b/docs/src/litsea-cli/train.md
@@ -23,7 +23,9 @@ litsea train [OPTIONS] <FEATURES_FILE> <MODEL_FILE>
 | `-i`, `--num-iterations <NUM_ITERATIONS>` | `100` | Maximum number of boosting iterations |
 | `-m`, `--load-model-uri <LOAD_MODEL_URI>` | None | URI of an existing model to resume training from (file path or HTTP/HTTPS URL) |
 | `--pos` | off | Enable POS (Part-of-Speech) training mode using Averaged Perceptron |
-| `--num-epochs <NUM_EPOCHS>` | `10` | Number of training epochs (POS mode only) |
+| `--num-epochs <NUM_EPOCHS>` | `10` | Number of training epochs (POS and `--two-stage` modes) |
+| `--two-stage` | off | Train a [two-stage](../advanced/model-file-format.md#two-stage-model-format-litsea-two-stage-v1) model instead. Reads `{FEATURES_FILE}.stage1`/`.stage2`/`.lexicon` (from `extract --two-stage`). Cannot be combined with `--pos` or `-m`/`--load-model-uri` (incremental training is not supported) |
+| `--dominance <DOMINANCE>` | `0.99` | Classifier-skip threshold for `--two-stage`, in `(0.5, 1.0]`: a known word whose most frequent tag covers at least this fraction of its training occurrences is tagged without invoking the stage-2 classifier |
 
 ## Output
 
@@ -124,3 +126,47 @@ Same as AdaBoost training, POS training supports graceful interruption. The firs
 | Parameter | Effect of Decreasing | Effect of Increasing |
 |-----------|---------------------|---------------------|
 | `num_epochs` | Faster training, may underfit | Better accuracy, longer training, may overfit |
+
+## Two-Stage Model Training
+
+With `--two-stage`, `train` builds a [two-stage
+model](../advanced/model-file-format.md#two-stage-model-format-litsea-two-stage-v1):
+a binary boundary classifier (stage 1) plus a word-level POS tagger
+(stage 2), assembled with the candidate-tag lexicon into a single
+`litsea-two-stage v1` file. Both stages train as Averaged Perceptrons for
+`--num-epochs` epochs; stage 1 is then collapsed to scalar weights in the
+existing AdaBoost format (a lossless transformation — see the module docs
+of `litsea::trainer` for the derivation) so the runtime scores it exactly
+as it scores a plain `segment()` model.
+
+### Usage
+
+```sh
+litsea train --two-stage [OPTIONS] <FEATURES_PREFIX> <MODEL_FILE>
+```
+
+`FEATURES_PREFIX` is the same prefix passed to `extract --two-stage`.
+
+### Example
+
+```sh
+litsea extract --two-stage -l japanese ./pos_corpus.txt ./two_stage_features
+litsea train --two-stage --num-epochs 10 ./two_stage_features ./models/japanese_two_stage.model
+```
+
+### Output
+
+```text
+Result Metrics (Two-Stage):
+  Stage 1 (boundary) Accuracy: 99.36% ( 277213 )
+  Stage 1 Macro Precision: 99.30%
+  Stage 1 Macro Recall: 99.35%
+  Stage 2 (tagging) Accuracy: 98.53% ( 168333 )
+  Stage 2 Macro Precision: 98.39%
+  Stage 2 Macro Recall: 97.59%
+```
+
+As with the other modes, these are in-sample metrics; evaluate on held-out
+text with `litsea evaluate --pos` for a realistic quality estimate. `segment
+--pos` and `evaluate --pos` auto-detect a two-stage model from its file
+header, so no extra flag is needed to use it.

--- a/litsea-cli/src/main.rs
+++ b/litsea-cli/src/main.rs
@@ -18,7 +18,8 @@ use clap::{Args, Parser, Subcommand};
 
 use litsea::version;
 use litsea::{
-    AdaBoost, AveragedPerceptron, Extractor, Language, PosTrainer, Segmenter, Trainer, evaluation,
+    AdaBoost, AnyPosModel, Extractor, Language, PosTrainer, Segmenter, Trainer, TwoStageFeatureSet,
+    TwoStageTrainer, evaluation,
 };
 
 /// Arguments for the extract command.
@@ -38,9 +39,22 @@ struct ExtractArgs {
     #[arg(long, default_value = "space", value_parser = ["space", "tsv"])]
     format: String,
 
+    /// Extract two-stage training features (issue #147) from a POS-tagged
+    /// corpus instead: writes {features_file}.stage1 (boundary features),
+    /// .stage2 (word-level features), and .lexicon. Cannot be combined
+    /// with --pos or --format tsv.
+    #[arg(long)]
+    two_stage: bool,
+
+    /// Stage-2 word-feature set for --two-stage: "full" (best quality),
+    /// "balanced", or "fast" (best throughput; default)
+    #[arg(long, default_value = "fast", value_parser = TwoStageFeatureSet::from_str)]
+    stage2_features: TwoStageFeatureSet,
+
     /// Path to the input corpus file (one pre-segmented sentence per line)
     corpus_file: PathBuf,
-    /// Path to the output features file
+    /// Path to the output features file (with --two-stage, the prefix for
+    /// the three output files)
     features_file: PathBuf,
 }
 
@@ -68,7 +82,22 @@ struct TrainArgs {
     #[arg(long, default_value = "10")]
     num_epochs: usize,
 
-    /// Path to the features file produced by the extract command
+    /// Train a two-stage model (issue #147) instead: reads
+    /// {features_file}.stage1/.stage2/.lexicon (from extract --two-stage)
+    /// and writes a litsea-two-stage model. Cannot be combined with --pos
+    /// or -m/--load-model-uri (incremental training is not supported)
+    #[arg(long)]
+    two_stage: bool,
+
+    /// Classifier-skip dominance threshold for --two-stage: a known word
+    /// whose most frequent tag covers at least this fraction of its
+    /// training occurrences is tagged without invoking the classifier.
+    /// Must be in (0.5, 1.0]
+    #[arg(long, default_value = "0.99")]
+    dominance: f64,
+
+    /// Path to the features file produced by the extract command (with
+    /// --two-stage, the prefix passed to extract --two-stage)
     features_file: PathBuf,
     /// Path to write the trained model to
     model_file: PathBuf,
@@ -143,11 +172,14 @@ struct CommandArgs {
 /// Extract features from a corpus file and write them to a specified output file.
 /// This function reads pre-segmented sentences from the corpus file (the
 /// word boundaries come from the corpus itself) and writes the extracted
-/// features to the output file. With `--pos` the corpus is POS-tagged
-/// ("word/POS word/POS ...") and features are extracted via
+/// features to the output file. With `--two-stage` the corpus is
+/// POS-tagged and three files (boundary, word-level, and lexicon) are
+/// written via `extract_two_stage` (issue #147); with `--pos` (and no
+/// `--two-stage`) it is POS-tagged and features are extracted via
 /// `extract_with_pos`; otherwise each line is space-separated words, or
 /// tab-separated tokens with `--format tsv` (a token may be a literal
-/// space, preserving the original spacing; not supported with `--pos`).
+/// space, preserving the original spacing; not supported with `--pos` or
+/// `--two-stage`).
 ///
 /// # Arguments
 /// * `args` - The arguments for the extract command [`ExtractArgs`].
@@ -157,7 +189,19 @@ struct CommandArgs {
 fn extract(args: ExtractArgs) -> Result<(), Box<dyn Error>> {
     let extractor = Extractor::new(args.language);
 
-    if args.pos {
+    if args.two_stage {
+        if args.pos {
+            return Err("--two-stage cannot be combined with --pos".into());
+        }
+        if args.format == "tsv" {
+            return Err("--two-stage cannot be combined with --format tsv".into());
+        }
+        extractor.extract_two_stage(
+            args.corpus_file.as_path(),
+            args.features_file.as_path(),
+            args.stage2_features,
+        )?;
+    } else if args.pos {
         // The POS pipeline has no TSV variant (issue #152 covers the
         // word-segmentation path only).
         if args.format == "tsv" {
@@ -195,7 +239,35 @@ async fn train(args: TrainArgs) -> Result<(), Box<dyn Error>> {
         }
     })?;
 
-    if args.pos {
+    if args.two_stage {
+        if args.pos {
+            return Err("--two-stage cannot be combined with --pos".into());
+        }
+        if args.load_model_uri.is_some() {
+            return Err(
+                "--two-stage does not support -m/--load-model-uri (incremental training)".into()
+            );
+        }
+        // Train the two-stage model (issue #147): a binary boundary
+        // classifier plus a word-level tagger, assembled with the lexicon.
+        let trainer =
+            TwoStageTrainer::new(args.num_epochs, args.dominance, args.features_file.as_path())?;
+        let metrics = trainer.train(&running, args.model_file.as_path())?;
+
+        eprintln!("Result Metrics (Two-Stage):");
+        eprintln!(
+            "  Stage 1 (boundary) Accuracy: {:.2}% ( {} )",
+            metrics.stage1.accuracy, metrics.stage1.num_instances
+        );
+        eprintln!("  Stage 1 Macro Precision: {:.2}%", metrics.stage1.macro_precision);
+        eprintln!("  Stage 1 Macro Recall: {:.2}%", metrics.stage1.macro_recall);
+        eprintln!(
+            "  Stage 2 (tagging) Accuracy: {:.2}% ( {} )",
+            metrics.stage2.accuracy, metrics.stage2.num_instances
+        );
+        eprintln!("  Stage 2 Macro Precision: {:.2}%", metrics.stage2.macro_precision);
+        eprintln!("  Stage 2 Macro Recall: {:.2}%", metrics.stage2.macro_recall);
+    } else if args.pos {
         // Train the POS tagging model with the Averaged Perceptron
         let mut trainer = PosTrainer::new(args.num_epochs, args.features_file.as_path())?;
 
@@ -310,11 +382,10 @@ async fn segment(args: SegmentArgs) -> Result<(), Box<dyn Error>> {
     let mut writer = io::BufWriter::new(stdout.lock());
 
     if args.pos {
-        // Joint segmentation + POS tagging with an Averaged Perceptron model
-        let mut pos_learner = AveragedPerceptron::new();
-        pos_learner.load_model(args.model_uri.as_str()).await?;
-
-        let segmenter = Segmenter::with_pos_learner(language, pos_learner);
+        // Joint or two-stage segmentation + POS tagging; the model kind is
+        // auto-detected from the file (issue #147).
+        let model = AnyPosModel::load(args.model_uri.as_str()).await?;
+        let segmenter = model.into_segmenter(language);
 
         for line in stdin.lock().lines() {
             let line = line?;
@@ -371,9 +442,9 @@ async fn evaluate(args: EvaluateArgs) -> Result<(), Box<dyn Error>> {
     let reader = io::BufReader::new(gold_file);
 
     if args.pos {
-        let mut pos_learner = AveragedPerceptron::new();
-        pos_learner.load_model(args.model_uri.as_str()).await?;
-        let segmenter = Segmenter::with_pos_learner(args.language, pos_learner);
+        // Joint or two-stage model, auto-detected from the file (#147).
+        let model = AnyPosModel::load(args.model_uri.as_str()).await?;
+        let segmenter = model.into_segmenter(args.language);
 
         let gold = reader
             .lines()

--- a/litsea/src/extractor.rs
+++ b/litsea/src/extractor.rs
@@ -11,9 +11,15 @@ use std::fs::File;
 use std::io::{self, BufRead, Write};
 use std::path::Path;
 
+use rustc_hash::FxHashMap;
+
 use crate::error::Result;
+use crate::evaluation::parse_gold_pos_line;
 use crate::language::Language;
 use crate::segmenter::Segmenter;
+use crate::two_stage::{TwoStageFeatureSet, sort_lexicon_entry, two_stage_paths, write_lexicon};
+use crate::upos::{SegmentLabel, Upos};
+use crate::word_features::write_word_features;
 
 /// Extractor struct for processing text data and extracting features.
 /// It reads pre-segmented sentences from a corpus file (the word boundaries
@@ -128,6 +134,121 @@ impl Extractor {
                 rows.push(Self::format_row(attrs, label));
             });
         })
+    }
+
+    /// Extracts two-stage training features (issue #147) from a POS-tagged
+    /// corpus in a single pass: stage-1 boundary features (2-class labels
+    /// `B`/`O`, using the same feature templates as
+    /// [`extract_with_pos`](Self::extract_with_pos)), stage-2 word-level
+    /// features (UPOS labels, using the templates selected by
+    /// `feature_set`), and the candidate-tag lexicon.
+    ///
+    /// Corpus format: `"word/POS word/POS ..."`, parsed with
+    /// [`crate::evaluation::parse_gold_pos_line`] (last-`/`-wins, a
+    /// slash-less token gets [`Upos::X`]) — the same rule the joint
+    /// pipeline uses.
+    ///
+    /// # Arguments
+    /// * `corpus_path` - The path to the POS-tagged corpus file.
+    /// * `output_prefix` - Base path for the three output files, written as
+    ///   `{output_prefix}.stage1`, `{output_prefix}.stage2`, and
+    ///   `{output_prefix}.lexicon`: stage-1 boundary features
+    ///   (`label\tfeature\t...` rows, label `B` or `O`), stage-2 word-level
+    ///   features (`label\tfeature\t...` rows, label a UPOS tag), and the
+    ///   candidate-tag lexicon in the `litsea-two-stage` model's
+    ///   `[lexicon]` section format (`surface\tTAG:count[,TAG:count...]`,
+    ///   most-frequent-first). [`crate::trainer::TwoStageTrainer::new`]
+    ///   reads the same three paths from the same prefix.
+    /// * `feature_set` - Which stage-2 word templates to write; see
+    ///   [`TwoStageFeatureSet`].
+    ///
+    /// # Returns
+    /// Returns a Result indicating success or failure.
+    ///
+    /// # Errors
+    /// Returns an I/O error if the corpus file cannot be opened or read, or
+    /// if any output file cannot be created or written.
+    pub fn extract_two_stage(
+        &self,
+        corpus_path: &Path,
+        output_prefix: &Path,
+        feature_set: TwoStageFeatureSet,
+    ) -> Result<()> {
+        let segmenter = &self.segmenter;
+        let language = segmenter.language();
+        let (stage1_path, stage2_path, lexicon_path) = two_stage_paths(output_prefix);
+
+        let corpus_file = File::open(corpus_path)?;
+        let corpus = io::BufReader::new(corpus_file);
+        let mut stage1_out = io::BufWriter::new(File::create(stage1_path)?);
+        let mut stage2_out = io::BufWriter::new(File::create(stage2_path)?);
+        let mut lexicon: FxHashMap<String, FxHashMap<Upos, u32>> = FxHashMap::default();
+
+        let mut stage1_rows: Vec<String> = Vec::new();
+        let mut stage2_feats: Vec<String> = Vec::new();
+        for line in corpus.lines() {
+            let line = line?;
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+
+            // Stage 1: the same attribute generation as the joint pipeline
+            // (segment_with_pos's training data), with the label collapsed
+            // to the boundary class.
+            segmenter.add_corpus_with_pos_writer(line, |attrs, label| {
+                let boundary = match label {
+                    SegmentLabel::B(_) => "B",
+                    SegmentLabel::O => "O",
+                };
+                stage1_rows.push(Self::format_row(attrs, boundary));
+            });
+            for row in stage1_rows.drain(..) {
+                writeln!(stage1_out, "{}", row)?;
+            }
+
+            // Stage 2 + lexicon: one row per word, keyed by its UPOS tag.
+            let tokens = parse_gold_pos_line(line);
+            let sent: Vec<char> = tokens.iter().flat_map(|(w, _)| w.chars()).collect();
+            let type_ids: Vec<u8> = sent.iter().map(|&c| language.char_type_id(c)).collect();
+            let mut start = 0usize;
+            for (surface, tag) in &tokens {
+                let wlen = surface.chars().count();
+                if wlen == 0 {
+                    continue;
+                }
+                let end = start + wlen;
+                stage2_feats.clear();
+                write_word_features(
+                    language,
+                    &sent,
+                    &type_ids,
+                    start,
+                    end,
+                    |tid| feature_set.includes(tid),
+                    &mut |f| stage2_feats.push(f),
+                );
+                writeln!(stage2_out, "{}\t{}", tag, stage2_feats.join("\t"))?;
+                *lexicon.entry(surface.clone()).or_default().entry(*tag).or_insert(0) += 1;
+                start = end;
+            }
+        }
+        stage1_out.flush()?;
+        stage2_out.flush()?;
+
+        let lexicon: FxHashMap<String, Vec<(Upos, u32)>> = lexicon
+            .into_iter()
+            .map(|(surface, counts)| {
+                let mut entry: Vec<(Upos, u32)> = counts.into_iter().collect();
+                sort_lexicon_entry(&mut entry);
+                (surface, entry)
+            })
+            .collect();
+        let mut lexicon_out = io::BufWriter::new(File::create(lexicon_path)?);
+        write_lexicon(&lexicon, &mut lexicon_out)?;
+        lexicon_out.flush()?;
+
+        Ok(())
     }
 
     /// Shared extraction pipeline: reads the corpus line by line, lets
@@ -313,6 +434,83 @@ mod tests {
                 );
             }
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_extract_two_stage() -> Result<()> {
+        use std::collections::HashMap;
+
+        // "これ" and "テスト" and "。" each repeat with the same tag, so the
+        // lexicon should accumulate their counts.
+        let mut corpus_file = NamedTempFile::new()?;
+        writeln!(corpus_file, "これ/PRON は/PART テスト/NOUN です/AUX 。/PUNCT")?;
+        writeln!(corpus_file, "これ/PRON も/PART テスト/NOUN 。/PUNCT")?;
+        corpus_file.as_file().sync_all()?;
+
+        let dir = tempfile::tempdir()?;
+        let prefix = dir.path().join("out");
+
+        let extractor = Extractor::default();
+        extractor.extract_two_stage(corpus_file.path(), &prefix, TwoStageFeatureSet::Fast)?;
+
+        let mut stage1 = String::new();
+        File::open(dir.path().join("out.stage1"))?.read_to_string(&mut stage1)?;
+        let mut stage2 = String::new();
+        File::open(dir.path().join("out.stage2"))?.read_to_string(&mut stage2)?;
+        let mut lexicon = String::new();
+        File::open(dir.path().join("out.lexicon"))?.read_to_string(&mut lexicon)?;
+
+        // Stage 1: one row per character (the joint pipeline predicts at
+        // the first position too), label collapsed to the boundary class.
+        // Line 1 has 9 chars ("これはテストです。"), line 2 has 7
+        // ("これもテスト。").
+        let stage1_lines: Vec<&str> = stage1.lines().collect();
+        assert_eq!(stage1_lines.len(), 16);
+        for line in &stage1_lines {
+            let label = line.split('\t').next().unwrap();
+            assert!(label == "B" || label == "O", "unexpected stage-1 label: {label}");
+        }
+
+        // Stage 2: one row per word, label a UPOS tag; the Fast feature set
+        // excludes FC/LC, so no "FC:"/"LC:" feature should appear, but WS:
+        // (always included in Fast) should.
+        let stage2_lines: Vec<&str> = stage2.lines().collect();
+        assert_eq!(stage2_lines.len(), 9);
+        let mut tag_counts: HashMap<&str, usize> = HashMap::new();
+        for line in &stage2_lines {
+            let mut fields = line.split('\t');
+            let label = fields.next().unwrap();
+            assert!(label.parse::<crate::upos::Upos>().is_ok(), "not a UPOS tag: {label}");
+            *tag_counts.entry(label).or_insert(0) += 1;
+            let feats: Vec<&str> = fields.collect();
+            assert!(feats.iter().any(|f| f.starts_with("WS:")), "missing WS feature in {line}");
+            assert!(
+                !feats.iter().any(|f| f.starts_with("FC:") || f.starts_with("LC:")),
+                "Fast feature set should not emit FC:/LC: in {line}"
+            );
+        }
+        assert_eq!(tag_counts.get("PRON"), Some(&2));
+        assert_eq!(tag_counts.get("NOUN"), Some(&2));
+        assert_eq!(tag_counts.get("PUNCT"), Some(&2));
+        assert_eq!(tag_counts.get("PART"), Some(&2));
+        assert_eq!(tag_counts.get("AUX"), Some(&1));
+
+        // Lexicon: one line per unique surface, counts accumulated across
+        // both occurrences of "これ"/"テスト"/"。".
+        let mut entries: HashMap<&str, &str> = HashMap::new();
+        for line in lexicon.lines() {
+            let (surface, tags) = line.split_once('\t').unwrap();
+            entries.insert(surface, tags);
+        }
+        assert_eq!(entries.len(), 6);
+        assert_eq!(entries.get("これ"), Some(&"PRON:2"));
+        assert_eq!(entries.get("テスト"), Some(&"NOUN:2"));
+        assert_eq!(entries.get("。"), Some(&"PUNCT:2"));
+        assert_eq!(entries.get("は"), Some(&"PART:1"));
+        assert_eq!(entries.get("も"), Some(&"PART:1"));
+        assert_eq!(entries.get("です"), Some(&"AUX:1"));
 
         Ok(())
     }

--- a/litsea/src/lib.rs
+++ b/litsea/src/lib.rs
@@ -35,8 +35,10 @@ pub use language::{Language, ParseLanguageError};
 pub use metrics::{BinaryMetrics, MulticlassMetrics};
 pub use perceptron::AveragedPerceptron;
 pub use segmenter::Segmenter;
-pub use trainer::{PosTrainer, Trainer};
-pub use two_stage::{ModelKind, TwoStageLearner};
+pub use trainer::{PosTrainer, Trainer, TwoStageMetrics, TwoStageTrainer};
+pub use two_stage::{
+    AnyPosModel, ModelKind, ParseTwoStageFeatureSetError, TwoStageFeatureSet, TwoStageLearner,
+};
 pub use upos::{ParseSegmentLabelError, ParseUposError, SegmentLabel, Upos};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/litsea/src/trainer.rs
+++ b/litsea/src/trainer.rs
@@ -11,10 +11,14 @@ use std::io::{self, BufRead};
 use std::path::Path;
 use std::sync::atomic::AtomicBool;
 
+use rustc_hash::FxHashMap;
+
 use crate::adaboost::AdaBoost;
 use crate::error::{LitseaError, Result};
 use crate::metrics::{BinaryMetrics, MulticlassMetrics};
 use crate::perceptron::AveragedPerceptron;
+use crate::two_stage::{TwoStageLearner, parse_lexicon, two_stage_paths};
+use crate::upos::Upos;
 
 /// Trainer struct for managing the AdaBoost training process.
 /// It initializes the AdaBoost learner with the specified parameters,
@@ -110,33 +114,8 @@ impl PosTrainer {
     /// Returns an error if the features file cannot be opened or read, or
     /// if a feature line is missing its label.
     pub fn new(num_epochs: usize, features_path: &Path) -> Result<Self> {
-        let mut learner = AveragedPerceptron::new();
-
-        let file = File::open(features_path)?;
-        let reader = io::BufReader::new(file);
-
-        for line in reader.lines() {
-            let line = line?;
-            // lines() already strips the trailing newline/CRLF; trimming
-            // further would strip Unicode whitespace (e.g. a trailing U+3000)
-            // off the last feature and desync training from inference (#99).
-            if line.is_empty() {
-                continue;
-            }
-            let mut parts = line.split('\t');
-            let label = parts.next().ok_or_else(|| {
-                LitseaError::InvalidData("Missing label in feature line".to_string())
-            })?;
-            let features: HashSet<String> =
-                parts.filter(|s| !s.is_empty()).map(|s| s.to_string()).collect();
-            if features.is_empty() {
-                continue;
-            }
-            learner.add_instance(features, label.to_string());
-        }
-
         Ok(PosTrainer {
-            learner,
+            learner: load_perceptron_instances(features_path)?,
             num_epochs,
         })
     }
@@ -168,6 +147,195 @@ impl PosTrainer {
         self.learner.train(self.num_epochs, running);
         self.learner.save_model(model_path)?;
         Ok(self.learner.metrics())
+    }
+}
+
+/// Loads training instances from a features file (`label\tfeature\t...`
+/// rows) into a fresh [`AveragedPerceptron`]. Shared by [`PosTrainer::new`]
+/// and [`TwoStageTrainer::new`], which read the same row format for
+/// different label spaces (`SegmentLabel` strings vs. boundary `B`/`O` vs.
+/// UPOS tags — the perceptron treats labels as opaque strings either way).
+fn load_perceptron_instances(features_path: &Path) -> Result<AveragedPerceptron> {
+    let mut learner = AveragedPerceptron::new();
+
+    let file = File::open(features_path)?;
+    let reader = io::BufReader::new(file);
+
+    for line in reader.lines() {
+        let line = line?;
+        // lines() already strips the trailing newline/CRLF; trimming
+        // further would strip Unicode whitespace (e.g. a trailing U+3000)
+        // off the last feature and desync training from inference (#99).
+        if line.is_empty() {
+            continue;
+        }
+        let mut parts = line.split('\t');
+        let label = parts
+            .next()
+            .ok_or_else(|| LitseaError::InvalidData("Missing label in feature line".to_string()))?;
+        let features: HashSet<String> =
+            parts.filter(|s| !s.is_empty()).map(|s| s.to_string()).collect();
+        if features.is_empty() {
+            continue;
+        }
+        learner.add_instance(features, label.to_string());
+    }
+
+    Ok(learner)
+}
+
+/// Collapses a 2-class boundary Averaged Perceptron (classes `B`/`O`,
+/// produced by [`TwoStageTrainer`]) into scalar per-feature weights in the
+/// existing AdaBoost model format.
+///
+/// The perceptron scores a position purely as `sum(matched-feature
+/// weights)` per class (there is no perceptron-level bias term), so
+/// `score_B - score_O = sum(matched (w_B[f] - w_O[f]))` exactly. Writing
+/// `feat\t(w_B[f] - w_O[f])` lines plus a literal `0` bias line and parsing
+/// them with [`AdaBoost::load_model_from_reader`] reproduces this: the
+/// model format defines `bias()` to equal the written bias line verbatim
+/// regardless of the feature weights (the algebraic inverse of
+/// `save_model`'s bias computation), so the collapsed model's decision
+/// `score >= 0.0` becomes exactly `score_B >= score_O` — including the tie
+/// case, which both the perceptron's first-wins rule (`"B" < "O"`
+/// alphabetically, so `B` is class index 0) and this comparison resolve to
+/// `B`.
+fn collapse_boundary_perceptron(stage1: &AveragedPerceptron) -> Result<AdaBoost> {
+    let classes = stage1.class_names();
+    let b = classes.iter().position(|c| c == "B").ok_or_else(|| {
+        LitseaError::InvalidData("stage-1 boundary model has no 'B' class".to_string())
+    })?;
+    let o = classes.iter().position(|c| c == "O").ok_or_else(|| {
+        LitseaError::InvalidData("stage-1 boundary model has no 'O' class".to_string())
+    })?;
+
+    let mut text = String::new();
+    for (feat, weights) in stage1.feature_class_weights() {
+        let w = weights[b] - weights[o];
+        if w != 0.0 {
+            text.push_str(feat);
+            text.push('\t');
+            text.push_str(&w.to_string());
+            text.push('\n');
+        }
+    }
+    text.push_str("0\n");
+
+    let mut adaboost = AdaBoost::default();
+    adaboost.load_model_from_reader(text.as_bytes())?;
+    Ok(adaboost)
+}
+
+/// In-sample training metrics of a [`TwoStageTrainer::train`] run: one
+/// [`MulticlassMetrics`] per stage (stage 1 measured over its 2 boundary
+/// classes, stage 2 over the UPOS tags).
+#[derive(Debug, Clone)]
+pub struct TwoStageMetrics {
+    /// Metrics of the stage-1 boundary classifier.
+    pub stage1: MulticlassMetrics,
+    /// Metrics of the stage-2 word-level tagger.
+    pub stage2: MulticlassMetrics,
+}
+
+/// Trainer for the two-stage model (issue #147): a binary boundary
+/// classifier (stage 1) plus a word-level multiclass tagger (stage 2),
+/// assembled with a candidate-tag lexicon into a `litsea-two-stage v1`
+/// model. Reads the three files written by
+/// [`Extractor::extract_two_stage`](crate::extractor::Extractor::extract_two_stage).
+#[derive(Debug)]
+pub struct TwoStageTrainer {
+    stage1: AveragedPerceptron,
+    stage2: AveragedPerceptron,
+    lexicon: FxHashMap<String, Vec<(Upos, u32)>>,
+    num_epochs: usize,
+    dominance: f64,
+}
+
+impl TwoStageTrainer {
+    /// Creates a `TwoStageTrainer` from the three files written by
+    /// [`Extractor::extract_two_stage`](crate::extractor::Extractor::extract_two_stage).
+    ///
+    /// # Arguments
+    /// * `num_epochs` - The number of training epochs for both stages.
+    /// * `dominance` - The classifier-skip threshold of the assembled
+    ///   model, in `(0.5, 1.0]`.
+    /// * `features_prefix` - The same prefix passed to `extract_two_stage`;
+    ///   the `{prefix}.stage1`, `{prefix}.stage2`, and `{prefix}.lexicon`
+    ///   files are read from it.
+    ///
+    /// # Returns
+    /// A new `TwoStageTrainer` with training instances loaded.
+    ///
+    /// # Errors
+    /// Returns an error if `dominance` is out of range, if any of the
+    /// three files cannot be opened or read, if the stage-1 features file
+    /// has a label other than `B`/`O`, or if the lexicon file is
+    /// malformed.
+    pub fn new(num_epochs: usize, dominance: f64, features_prefix: &Path) -> Result<Self> {
+        // Checked here (not just in from_parts at train() time) so an
+        // out-of-range value fails before training runs, not after.
+        if !(dominance > 0.5 && dominance <= 1.0) {
+            return Err(LitseaError::InvalidInput(format!(
+                "dominance must be in (0.5, 1.0], got {}",
+                dominance
+            )));
+        }
+        let (stage1_path, stage2_path, lexicon_path) = two_stage_paths(features_prefix);
+
+        let stage1 = load_perceptron_instances(&stage1_path)?;
+        if stage1.class_names().iter().any(|c| c != "B" && c != "O") {
+            return Err(LitseaError::InvalidData(format!(
+                "stage-1 features file has a non-boundary label; expected only 'B'/'O', found {:?}",
+                stage1.class_names()
+            )));
+        }
+        let stage2 = load_perceptron_instances(&stage2_path)?;
+
+        let lexicon_file = File::open(&lexicon_path)?;
+        let lines: io::Result<Vec<String>> = io::BufReader::new(lexicon_file).lines().collect();
+        let lexicon = parse_lexicon(&lines?)?;
+
+        Ok(TwoStageTrainer {
+            stage1,
+            stage2,
+            lexicon,
+            num_epochs,
+            dominance,
+        })
+    }
+
+    /// Trains both stages and assembles + saves a `litsea-two-stage v1`
+    /// model.
+    ///
+    /// # Arguments
+    /// * `running` - A flag for interrupting training.
+    /// * `model_path` - The path to save the assembled model to.
+    ///
+    /// # Returns
+    /// The in-sample [`TwoStageMetrics`] of both stages.
+    ///
+    /// # Errors
+    /// Returns an error if the assembled model is inconsistent (see
+    /// [`TwoStageLearner::from_parts`]) or if it cannot be saved.
+    pub fn train(mut self, running: &AtomicBool, model_path: &Path) -> Result<TwoStageMetrics> {
+        self.stage1.train(self.num_epochs, running);
+        self.stage2.train(self.num_epochs, running);
+        let stage1_metrics = self.stage1.metrics();
+        let stage2_metrics = self.stage2.metrics();
+
+        let stage1_adaboost = collapse_boundary_perceptron(&self.stage1)?;
+        let learner = TwoStageLearner::from_parts(
+            stage1_adaboost,
+            self.stage2,
+            self.lexicon,
+            self.dominance,
+        )?;
+        learner.save_model(model_path)?;
+
+        Ok(TwoStageMetrics {
+            stage1: stage1_metrics,
+            stage2: stage2_metrics,
+        })
     }
 }
 
@@ -375,6 +543,89 @@ mod tests {
             saved.contains("UW4:\u{3000}"),
             "trailing-U+3000 feature missing from saved model: {saved:?}"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_collapse_boundary_perceptron_matches_perceptron_argmax() -> Result<()> {
+        let mut learner = AveragedPerceptron::new();
+        // Overlapping feature sets so weights end up non-trivial for both
+        // classes, including a feature shared by both.
+        learner.add_instance(
+            ["f1".to_string(), "shared".to_string()].into_iter().collect(),
+            "B".to_string(),
+        );
+        learner.add_instance(
+            ["f2".to_string(), "shared".to_string()].into_iter().collect(),
+            "O".to_string(),
+        );
+        learner.add_instance(["f3".to_string()].into_iter().collect(), "B".to_string());
+        learner.add_instance(["f4".to_string()].into_iter().collect(), "O".to_string());
+        let running = AtomicBool::new(true);
+        learner.train(5, &running);
+
+        let adaboost = collapse_boundary_perceptron(&learner)?;
+
+        let check = |feats: &[&str]| {
+            let set: HashSet<String> = feats.iter().map(|s| s.to_string()).collect();
+            let perceptron_b = learner.predict(&set) == "B";
+            let adaboost_b = adaboost.predict(&set) == 1;
+            assert_eq!(
+                perceptron_b, adaboost_b,
+                "mismatch for {:?}: perceptron_b={} adaboost_b={}",
+                feats, perceptron_b, adaboost_b
+            );
+        };
+
+        check(&["f1"]);
+        check(&["f2"]);
+        check(&["f3"]);
+        check(&["f4"]);
+        check(&["f1", "f2"]);
+        check(&["shared"]);
+        check(&[]); // tie on unseen features: both must favor "B"
+        check(&["unseen_feature"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_two_stage_trainer_end_to_end() -> Result<()> {
+        use crate::extractor::Extractor;
+        use crate::language::Language;
+        use crate::segmenter::Segmenter;
+        use crate::two_stage::{TwoStageFeatureSet, TwoStageLearner};
+
+        let mut corpus_file = NamedTempFile::new()?;
+        writeln!(corpus_file, "太郎/PROPN は/ADP 猫/NOUN が/ADP 好き/ADJ です/AUX 。/PUNCT")?;
+        writeln!(corpus_file, "花子/PROPN も/ADP 猫/NOUN が/ADP 好き/ADJ です/AUX 。/PUNCT")?;
+        writeln!(corpus_file, "太郎/PROPN は/ADP 犬/NOUN も/ADP 好き/ADJ です/AUX 。/PUNCT")?;
+        corpus_file.as_file().sync_all()?;
+
+        let dir = tempfile::tempdir()?;
+        let prefix = dir.path().join("features");
+        Extractor::new(Language::Japanese).extract_two_stage(
+            corpus_file.path(),
+            &prefix,
+            TwoStageFeatureSet::Fast,
+        )?;
+
+        let trainer = TwoStageTrainer::new(5, 0.99, &prefix)?;
+        let model_path = dir.path().join("model.two-stage");
+        let running = AtomicBool::new(true);
+        let metrics = trainer.train(&running, &model_path)?;
+        assert!(metrics.stage1.num_instances > 0);
+        assert!(metrics.stage2.num_instances > 0);
+
+        let mut learner = TwoStageLearner::new();
+        learner.load_model_from_path(&model_path)?;
+        let segmenter = Segmenter::with_two_stage_learner(Language::Japanese, learner);
+
+        let tagged = segmenter.segment_with_pos("太郎は猫が好きです。")?;
+        let text: String = tagged.iter().map(|(w, _)| w.as_str()).collect();
+        assert_eq!(text, "太郎は猫が好きです。");
+        assert!(!tagged.is_empty());
+
         Ok(())
     }
 }

--- a/litsea/src/two_stage.rs
+++ b/litsea/src/two_stage.rs
@@ -50,9 +50,10 @@
 //! loading with their loaders, and those loaders reject two-stage files
 //! with `InvalidData`.
 
+use std::fmt;
 use std::fs::File;
 use std::io::{BufRead, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use rustc_hash::FxHashMap;
@@ -60,6 +61,7 @@ use rustc_hash::FxHashMap;
 use crate::adaboost::AdaBoost;
 use crate::error::{LitseaError, Result};
 use crate::perceptron::AveragedPerceptron;
+use crate::segmenter::Segmenter;
 use crate::upos::Upos;
 
 /// Magic first line of the two-stage model format (version 1).
@@ -126,7 +128,41 @@ impl ModelKind {
 /// Lexicon entry type: the UPOS tags observed for one surface, with their
 /// training-corpus occurrence counts, sorted most-frequent-first (ties
 /// broken by tag name).
-type LexiconEntry = Vec<(Upos, u32)>;
+pub(crate) type LexiconEntry = Vec<(Upos, u32)>;
+
+/// Derives the three two-stage training-file paths from a common prefix:
+/// `{prefix}.stage1`, `{prefix}.stage2`, `{prefix}.lexicon`. Shared by
+/// [`crate::extractor::Extractor::extract_two_stage`] (which writes them)
+/// and [`crate::trainer::TwoStageTrainer::new`] (which reads them).
+pub(crate) fn two_stage_paths(prefix: &Path) -> (PathBuf, PathBuf, PathBuf) {
+    let base = prefix.display();
+    (
+        PathBuf::from(format!("{}.stage1", base)),
+        PathBuf::from(format!("{}.stage2", base)),
+        PathBuf::from(format!("{}.lexicon", base)),
+    )
+}
+
+/// Writes lexicon lines in the model's `[lexicon]` section format
+/// (`surface\tTAG:count[,TAG:count...]`), surfaces sorted for
+/// deterministic output. Shared by the model writer and the two-stage
+/// feature extractor (whose `.lexicon` file uses the same format).
+pub(crate) fn write_lexicon<W: Write>(
+    lexicon: &FxHashMap<String, LexiconEntry>,
+    writer: &mut W,
+) -> Result<()> {
+    let mut surfaces: Vec<&String> = lexicon.keys().collect();
+    surfaces.sort_unstable();
+    for surface in surfaces {
+        let tags = lexicon[surface]
+            .iter()
+            .map(|(tag, count)| format!("{}:{}", tag, count))
+            .collect::<Vec<_>>()
+            .join(",");
+        writeln!(writer, "{}\t{}", surface, tags)?;
+    }
+    Ok(())
+}
 
 /// A two-stage segmentation + POS-tagging model: a stage-1 boundary
 /// classifier, a candidate-tag lexicon, and a stage-2 word-level tagger.
@@ -360,16 +396,7 @@ impl TwoStageLearner {
         writeln!(writer, "{}", SECTION_STAGE1)?;
         self.stage1.save_model_to_writer(writer)?;
         writeln!(writer, "{}", SECTION_LEXICON)?;
-        let mut surfaces: Vec<&String> = self.lexicon.keys().collect();
-        surfaces.sort_unstable();
-        for surface in surfaces {
-            let tags = self.lexicon[surface]
-                .iter()
-                .map(|(tag, count)| format!("{}:{}", tag, count))
-                .collect::<Vec<_>>()
-                .join(",");
-            writeln!(writer, "{}\t{}", surface, tags)?;
-        }
+        write_lexicon(&self.lexicon, writer)?;
         writeln!(writer, "{}", SECTION_STAGE2)?;
         self.stage2.save_model_to_writer(writer)?;
         Ok(())
@@ -521,8 +548,9 @@ impl TwoStageLearner {
 }
 
 /// Sorts a lexicon entry into the canonical order: count descending, ties
-/// by tag name ascending.
-fn sort_lexicon_entry(entry: &mut LexiconEntry) {
+/// by tag name ascending. Shared by the model loader/builder and the
+/// two-stage feature extractor.
+pub(crate) fn sort_lexicon_entry(entry: &mut LexiconEntry) {
     entry.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.to_string().cmp(&b.0.to_string())));
 }
 
@@ -592,7 +620,7 @@ fn parse_params(lines: &[String]) -> Result<f64> {
 /// Returns [`LitseaError::InvalidData`] on a line without a tab, an empty
 /// surface, a malformed `TAG:count` element, an unknown tag, a zero count,
 /// a duplicate tag within a line, a duplicate surface, or an empty section.
-fn parse_lexicon(lines: &[String]) -> Result<FxHashMap<String, LexiconEntry>> {
+pub(crate) fn parse_lexicon(lines: &[String]) -> Result<FxHashMap<String, LexiconEntry>> {
     let mut lexicon: FxHashMap<String, LexiconEntry> = FxHashMap::default();
     for line in lines {
         let Some((surface, tags_str)) = line.split_once('\t') else {
@@ -659,6 +687,170 @@ fn parse_lexicon(lines: &[String]) -> Result<FxHashMap<String, LexiconEntry>> {
         )));
     }
     Ok(lexicon)
+}
+
+/// Error returned when a string is not a valid two-stage feature-set name.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("invalid two-stage feature set: '{input}' (expected full, balanced, or fast)")]
+pub struct ParseTwoStageFeatureSetError {
+    /// The rejected input string.
+    input: String,
+}
+
+/// The stage-2 word-feature template set used when extracting two-stage
+/// training features (issue #147, ablation results in the Phase 0/1
+/// report).
+///
+/// The packed runtime adapts automatically: templates absent from a model
+/// cost nothing at inference, so the set chosen at extraction time decides
+/// the model's speed/quality point:
+///
+/// | set | ja tagged F1 (joint: 92.51) | throughput vs joint |
+/// |-----|------------------------------|---------------------|
+/// | `Full` | 93.41 | ~1.5x |
+/// | `Balanced` | 92.92 | ~2.2x |
+/// | `Fast` (default) | 92.71 | ~2.5x |
+///
+/// Segmentation quality is identical across sets (it is decided by
+/// stage 1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum TwoStageFeatureSet {
+    /// Every word template (quality-leaning).
+    Full,
+    /// The `Fast` templates plus first/last char identity and the word
+    /// type string.
+    Balanced,
+    /// The minimal measured set: surface, word length, first/last char
+    /// type, adjacent context char + type, 2-char prefix/suffix.
+    #[default]
+    Fast,
+}
+
+impl fmt::Display for TwoStageFeatureSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TwoStageFeatureSet::Full => write!(f, "full"),
+            TwoStageFeatureSet::Balanced => write!(f, "balanced"),
+            TwoStageFeatureSet::Fast => write!(f, "fast"),
+        }
+    }
+}
+
+impl FromStr for TwoStageFeatureSet {
+    type Err = ParseTwoStageFeatureSetError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "full" => Ok(TwoStageFeatureSet::Full),
+            "balanced" => Ok(TwoStageFeatureSet::Balanced),
+            "fast" => Ok(TwoStageFeatureSet::Fast),
+            _ => Err(ParseTwoStageFeatureSetError {
+                input: s.to_string(),
+            }),
+        }
+    }
+}
+
+impl TwoStageFeatureSet {
+    /// Returns whether the word template with this id is part of the set.
+    pub(crate) fn includes(self, template_id: usize) -> bool {
+        use crate::word_features::{
+            T_CL1, T_CR1, T_FC, T_FT, T_L1, T_LC, T_LT, T_P2, T_R1, T_S2, T_TS, T_WL, T_WS,
+        };
+        match self {
+            TwoStageFeatureSet::Full => true,
+            TwoStageFeatureSet::Balanced => {
+                TwoStageFeatureSet::Fast.includes(template_id)
+                    || matches!(template_id, id if id == T_FC || id == T_LC || id == T_TS)
+            }
+            TwoStageFeatureSet::Fast => matches!(
+                template_id,
+                id if id == T_WS
+                    || id == T_WL
+                    || id == T_FT
+                    || id == T_LT
+                    || id == T_L1
+                    || id == T_R1
+                    || id == T_CL1
+                    || id == T_CR1
+                    || id == T_P2
+                    || id == T_S2
+            ),
+        }
+    }
+}
+
+/// A POS-capable model loaded from a file whose kind was auto-detected:
+/// either a joint Averaged Perceptron model or a two-stage model.
+///
+/// This is the single-fetch entry point for callers (such as the CLI's
+/// `segment --pos` / `evaluate --pos`) that accept both model kinds: the
+/// model bytes are fetched once, dispatched on [`ModelKind::detect`], and
+/// parsed by the matching loader.
+#[derive(Debug)]
+pub enum AnyPosModel {
+    /// A joint segmentation + POS model (Averaged Perceptron format).
+    Joint(Box<AveragedPerceptron>),
+    /// A two-stage model (`litsea-two-stage v1` format).
+    TwoStage(Box<TwoStageLearner>),
+}
+
+impl AnyPosModel {
+    /// Loads a POS-capable model from a URI, auto-detecting its kind.
+    ///
+    /// The URI can be a file path, a `file://` path, or an `http(s)://`
+    /// URL (the latter requires the `remote_model` feature). The bytes are
+    /// fetched once.
+    ///
+    /// # Arguments
+    /// * `uri` - The URI of the model to load.
+    ///
+    /// # Returns
+    /// The loaded model with its detected kind.
+    ///
+    /// # Errors
+    /// Returns an error if the bytes cannot be fetched, the content is not
+    /// valid UTF-8, the detected format fails to parse, or the file is an
+    /// AdaBoost segmentation model (which cannot tag).
+    pub async fn load(uri: &str) -> Result<Self> {
+        let bytes = crate::model_io::read_model_bytes(uri).await?;
+        let content = std::str::from_utf8(&bytes)
+            .map_err(|e| LitseaError::InvalidData(format!("model is not valid UTF-8: {}", e)))?;
+        match ModelKind::detect(content) {
+            ModelKind::TwoStage => {
+                let mut learner = TwoStageLearner::new();
+                learner.load_model_from_reader(bytes.as_slice())?;
+                Ok(AnyPosModel::TwoStage(Box::new(learner)))
+            }
+            ModelKind::AveragedPerceptron => {
+                let mut learner = AveragedPerceptron::new();
+                learner.load_model_from_reader(bytes.as_slice())?;
+                Ok(AnyPosModel::Joint(Box::new(learner)))
+            }
+            ModelKind::AdaBoost => Err(LitseaError::InvalidData(
+                "the model is an AdaBoost segmentation model, which cannot tag; \
+                 pass a joint POS model or a litsea-two-stage model"
+                    .to_string(),
+            )),
+        }
+    }
+
+    /// Consumes the model and builds the matching [`Segmenter`].
+    ///
+    /// # Arguments
+    /// * `language` - The language for character type classification.
+    ///
+    /// # Returns
+    /// A segmenter whose [`segment_with_pos`](Segmenter::segment_with_pos)
+    /// runs the joint or two-stage pipeline according to the model kind.
+    #[must_use]
+    pub fn into_segmenter(self, language: crate::language::Language) -> Segmenter {
+        match self {
+            AnyPosModel::Joint(learner) => Segmenter::with_pos_learner(language, *learner),
+            AnyPosModel::TwoStage(learner) => Segmenter::with_two_stage_learner(language, *learner),
+        }
+    }
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
@@ -1033,5 +1225,75 @@ mod tests {
         let mut learner = TwoStageLearner::new();
         learner.load_model(&format!("file://{}", path.display())).await.unwrap();
         assert_eq!(learner.lexicon_len(), 2);
+    }
+
+    #[test]
+    fn test_feature_set_from_str_and_display() {
+        for (s, set) in [
+            ("full", TwoStageFeatureSet::Full),
+            ("Full", TwoStageFeatureSet::Full),
+            ("BALANCED", TwoStageFeatureSet::Balanced),
+            ("fast", TwoStageFeatureSet::Fast),
+        ] {
+            assert_eq!(s.parse::<TwoStageFeatureSet>().unwrap(), set);
+        }
+        assert_eq!(TwoStageFeatureSet::Full.to_string(), "full");
+        assert_eq!(TwoStageFeatureSet::Balanced.to_string(), "balanced");
+        assert_eq!(TwoStageFeatureSet::Fast.to_string(), "fast");
+        assert_eq!(TwoStageFeatureSet::default(), TwoStageFeatureSet::Fast);
+        assert!(matches!(
+            "bogus".parse::<TwoStageFeatureSet>(),
+            Err(ParseTwoStageFeatureSetError { .. })
+        ));
+    }
+
+    #[test]
+    fn test_feature_set_includes_is_nested_and_spot_checked() {
+        use crate::word_features::{N_WORD_TEMPLATES, T_FC, T_L1, T_LB, T_LC, T_TS, T_WS};
+
+        // Fast subset of Balanced subset of Full, for every template id.
+        for tid in 0..N_WORD_TEMPLATES {
+            if TwoStageFeatureSet::Fast.includes(tid) {
+                assert!(TwoStageFeatureSet::Balanced.includes(tid), "tid {}", tid);
+            }
+            if TwoStageFeatureSet::Balanced.includes(tid) {
+                assert!(TwoStageFeatureSet::Full.includes(tid), "tid {}", tid);
+            }
+        }
+        assert!(TwoStageFeatureSet::Fast.includes(T_WS));
+        assert!(!TwoStageFeatureSet::Fast.includes(T_FC));
+        assert!(TwoStageFeatureSet::Balanced.includes(T_FC));
+        assert!(TwoStageFeatureSet::Balanced.includes(T_LC));
+        assert!(TwoStageFeatureSet::Balanced.includes(T_TS));
+        assert!(!TwoStageFeatureSet::Balanced.includes(T_L1 + 1)); // L2
+        assert!(TwoStageFeatureSet::Full.includes(T_L1 + 1));
+        assert!(TwoStageFeatureSet::Full.includes(T_LB));
+    }
+
+    #[tokio::test]
+    async fn test_any_pos_model_detects_and_loads() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let two_stage_path = dir.path().join("model.two-stage");
+        std::fs::write(&two_stage_path, valid_model()).unwrap();
+        let model = AnyPosModel::load(two_stage_path.to_str().unwrap()).await.unwrap();
+        assert!(matches!(model, AnyPosModel::TwoStage(_)));
+        let segmenter = model.into_segmenter(crate::language::Language::Japanese);
+        assert!(segmenter.segment_with_pos("").unwrap().is_empty());
+
+        let joint_path = dir.path().join("model.joint");
+        std::fs::write(&joint_path, STAGE2).unwrap();
+        let model = AnyPosModel::load(joint_path.to_str().unwrap()).await.unwrap();
+        assert!(matches!(model, AnyPosModel::Joint(_)));
+        let segmenter = model.into_segmenter(crate::language::Language::Japanese);
+        assert!(segmenter.segment_with_pos("").unwrap().is_empty());
+
+        let adaboost_path = dir.path().join("model.adaboost");
+        std::fs::write(&adaboost_path, STAGE1).unwrap();
+        let result = AnyPosModel::load(adaboost_path.to_str().unwrap()).await;
+        assert!(matches!(
+            result,
+            Err(LitseaError::InvalidData(ref msg)) if msg.contains("AdaBoost")
+        ));
     }
 }

--- a/litsea/src/word_features.rs
+++ b/litsea/src/word_features.rs
@@ -239,32 +239,34 @@ fn parse_type_code(language: Language, s: &str) -> Option<(u8, &str)> {
     None
 }
 
-/// Writes every word feature of the word spanning `[start, end)` as
-/// strings, in template order.
+/// Writes the word features of the word spanning `[start, end)` as
+/// strings, in template order, restricted to templates for which
+/// `select(template_id)` returns true.
 ///
 /// This is the training-side twin of the packed runtime's key computation;
-/// both are pinned together by the round-trip test in this module.
+/// both are pinned together by the round-trip test in this module (with
+/// `select` always true — a real extractor passes
+/// `TwoStageFeatureSet::includes`).
 ///
 /// # Arguments
 /// * `language` - The language whose type codes to write.
 /// * `sent` - The sentence characters (no sentinels).
 /// * `type_ids` - The per-character language type ids of `sent`.
 /// * `start` / `end` - The word's char span (`start < end <= sent.len()`).
-/// * `push` - Receives each feature string.
-// Production callers arrive with the two-stage training extractor (#168);
-// until then the writer is exercised by this module's round-trip test.
-#[cfg_attr(not(test), allow(dead_code))]
+/// * `select` - Called with each template id ([`T_WS`] etc.); only
+///   templates for which it returns true are written.
+/// * `push` - Receives each selected feature string.
 pub(crate) fn write_word_features(
     language: Language,
     sent: &[char],
     type_ids: &[u8],
     start: usize,
     end: usize,
+    select: impl Fn(usize) -> bool,
     push: &mut impl FnMut(String),
 ) {
     let codes = language.type_codes();
     let n = end - start;
-    let surface: String = sent[start..end].iter().collect();
     let lc = |k: usize| if start >= k { sent[start - k] } else { BOS_CHAR };
     let rc = |k: usize| sent.get(end + k - 1).copied().unwrap_or(EOS_CHAR);
     let type_code = |c: char| -> &str {
@@ -274,35 +276,40 @@ pub(crate) fn write_word_features(
             _ => codes[language.char_type_id(c) as usize],
         }
     };
+    let mut emit = |tid: usize, s: String| {
+        if select(tid) {
+            push(s);
+        }
+    };
 
-    push(format!("WS:{}", surface));
-    push(format!("WL:{}", n.min(WL_CAP)));
-    push(format!("FC:{}", sent[start]));
-    push(format!("LC:{}", sent[end - 1]));
-    push(format!("ft:{}", codes[type_ids[start] as usize]));
-    push(format!("lt:{}", codes[type_ids[end - 1] as usize]));
+    emit(T_WS, format!("WS:{}", sent[start..end].iter().collect::<String>()));
+    emit(T_WL, format!("WL:{}", n.min(WL_CAP)));
+    emit(T_FC, format!("FC:{}", sent[start]));
+    emit(T_LC, format!("LC:{}", sent[end - 1]));
+    emit(T_FT, format!("ft:{}", codes[type_ids[start] as usize]));
+    emit(T_LT, format!("lt:{}", codes[type_ids[end - 1] as usize]));
     let ts: String = type_ids[start..end.min(start + TS_CAP)]
         .iter()
         .map(|&t| codes[t as usize])
         .collect();
-    push(format!("TS:{}", ts));
+    emit(T_TS, format!("TS:{}", ts));
     for k in 1..=CONTEXT_WINDOW {
-        push(format!("L{}:{}", k, lc(k)));
+        emit(T_L1 + k - 1, format!("L{}:{}", k, lc(k)));
     }
     for k in 1..=CONTEXT_WINDOW {
-        push(format!("R{}:{}", k, rc(k)));
+        emit(T_R1 + k - 1, format!("R{}:{}", k, rc(k)));
     }
     for k in 1..=CONTEXT_WINDOW {
-        push(format!("cl{}:{}", k, type_code(lc(k))));
+        emit(T_CL1 + k - 1, format!("cl{}:{}", k, type_code(lc(k))));
     }
     for k in 1..=CONTEXT_WINDOW {
-        push(format!("cr{}:{}", k, type_code(rc(k))));
+        emit(T_CR1 + k - 1, format!("cr{}:{}", k, type_code(rc(k))));
     }
-    push(format!("LB:{}{}", lc(2), lc(1)));
-    push(format!("RB:{}{}", rc(1), rc(2)));
+    emit(T_LB, format!("LB:{}{}", lc(2), lc(1)));
+    emit(T_RB, format!("RB:{}{}", rc(1), rc(2)));
     if n >= 2 {
-        push(format!("P2:{}{}", sent[start], sent[start + 1]));
-        push(format!("S2:{}{}", sent[end - 2], sent[end - 1]));
+        emit(T_P2, format!("P2:{}{}", sent[start], sent[start + 1]));
+        emit(T_S2, format!("S2:{}{}", sent[end - 2], sent[end - 1]));
     }
 }
 
@@ -404,9 +411,17 @@ mod tests {
             for start in 0..sent.len() {
                 for end in start + 1..=sent.len() {
                     let mut written = Vec::new();
-                    write_word_features(language, &sent, &type_ids, start, end, &mut |f| {
-                        written.push(f);
-                    });
+                    write_word_features(
+                        language,
+                        &sent,
+                        &type_ids,
+                        start,
+                        end,
+                        |_| true,
+                        &mut |f| {
+                            written.push(f);
+                        },
+                    );
                     let parsed: Vec<WordFeature> = written
                         .iter()
                         .map(|f| {


### PR DESCRIPTION
## Summary

Implements the two-stage training pipeline and CLI support — the third child issue of the two-stage architecture (#147), building on #166 (model format, PR #170) and #167 (runtime, PR #171).

- **`Extractor::extract_two_stage`**: a single pass over a POS-tagged corpus (`word/POS word/POS ...`) writes three files from a common prefix — `{prefix}.stage1` (boundary features, labels `B`/`O`, the same templates as the joint pipeline via `add_corpus_with_pos_writer`), `{prefix}.stage2` (word-level features, labels UPOS tags, filtered by the new `TwoStageFeatureSet`), and `{prefix}.lexicon` (candidate-tag counts in the model's `[lexicon]` section format).
- **`TwoStageFeatureSet`** (`Full` / `Balanced` / `Fast`, default `Fast`): selects which of the 23 word templates `extract_two_stage` writes, mapping to the #147 prototype's measured points (documented on the enum with the ja numbers from #167's verification: Full 93.41 tagged F1 @ ~1.5x, Balanced 92.92 @ ~2.2x, Fast 92.71 @ ~2.5x).
- **`TwoStageTrainer`**: loads the three extracted files, trains stage 1 and stage 2 as Averaged Perceptrons, and — the one non-trivial piece — **collapses the 2-class (`B`/`O`) stage-1 perceptron to scalar weights in the existing AdaBoost format**. This is provably lossless: the perceptron has no bias term, so `score_B - score_O = sum(matched (w_B[f] - w_O[f]))` exactly; writing those differences as `feat\tweight` lines plus a literal `0` bias line reproduces `AdaBoost::bias() == 0` (the model format defines the bias line to equal `bias()` verbatim, independent of the feature weights — the algebraic inverse of `save_model`'s own bias computation), so the collapsed model's `score >= 0.0` decision is exactly `score_B >= score_O`, including the tie case. Verified both by a differential unit test (perceptron argmax vs. collapsed-AdaBoost sign over several feature sets, including an unseen/tied one) and by the real-corpus run below. The assembled model is saved via `TwoStageLearner::from_parts` in the `litsea-two-stage v1` format from #166.
- **`AnyPosModel`**: fetches a POS-capable model's bytes once and dispatches on `ModelKind::detect` to `Joint(AveragedPerceptron)` or `TwoStage(TwoStageLearner)` (boxed — `clippy::large_enum_variant`), with `into_segmenter()` building the matching `Segmenter`. An AdaBoost (segmentation-only) file is rejected with a clear error.
- **CLI**: `extract --two-stage [--stage2-features full|balanced|fast]` (conflicts with `--pos`/`--format tsv`), `train --two-stage [--dominance 0.99]` (conflicts with `--pos`/`-m` — incremental two-stage training isn't supported, and dominance is range-checked in `TwoStageTrainer::new` so an invalid value fails before training runs, not after). `segment --pos` / `evaluate --pos` now go through `AnyPosModel::load`, so they transparently accept joint or two-stage models with no new flags.

## Verification

- 3 new unit tests (`extract_two_stage` output-format/lexicon-counting, `collapse_boundary_perceptron` differential correctness, and a full `TwoStageTrainer` extract→train→load→`segment_with_pos` round trip) plus the `TwoStageFeatureSet`/`AnyPosModel` tests in `two_stage.rs`. `cargo test --workspace` (190 lib tests), `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, and `markdownlint-cli2` all pass.
- **Real-corpus, full CLI pipeline** on UD Japanese-GSD (`data/train_corpus.txt`, the same corpus japanese_pos.model trains on):

  ```sh
  litsea extract --two-stage -l japanese data/train_corpus.txt ja
  litsea train --two-stage --num-epochs 10 ja ja.two-stage
  litsea evaluate --pos -l japanese ja.two-stage resources/eval/japanese_gsd_test_pos.txt
  ```

  produces, on the held-out UD GSD test — **Word F1 96.48, Tagged F1 92.71** — exactly reproducing #167's runtime-level "Fast" numbers, now through the full extract→train→save→load→evaluate path, in a **5.1 MB** file (vs. 11 MB for `japanese_pos.model`). `segment --pos` / `evaluate --pos` regression-checked unchanged against the existing joint `japanese_pos.model` (96.56/92.51, matching docs) and confirmed to reject `japanese.model` (AdaBoost) with the intended error. All `extract --two-stage`/`train --two-stage` conflict validations (`--pos`, `--format tsv`, `-m`, out-of-range `--dominance`) verified manually.

## Docs

- `docs/src/litsea-cli/{extract,train,segment,evaluate}.md` (+ Japanese mirrors): new flags, two-stage training walkthrough, and auto-detection notes; CHANGELOG updated.

Closes #168
Refs #147
