### PR TITLE
test: add golden coverage for the bundled two-stage models

### DIFF
--- a/litsea/tests/golden.rs
+++ b/litsea/tests/golden.rs
@@ -1,15 +1,12 @@
 //! Golden tests: snapshot the segmentation output of every pre-trained
-//! AdaBoost/Averaged-Perceptron model in `models/` so that refactoring can
-//! be verified to preserve behavior.
+//! model in `models/` — the AdaBoost-format segmentation models, the joint
+//! Averaged Perceptron POS models, and the two-stage models — so that
+//! refactoring can be verified to preserve behavior.
 //!
 //! These snapshots capture the current behavior of the bundled models. If a
 //! behavior change is intentional (e.g. fixing the first-word POS handling
 //! or retraining a model), update the affected expectations in the same PR
 //! and call the change out explicitly in the PR description.
-//!
-//! Note: the bundled two-stage models (`japanese_two_stage.model`,
-//! `chinese_two_stage.model`, `korean_two_stage.model`, issue #147)
-//! currently have no golden-test coverage in this file.
 
 use std::path::PathBuf;
 
@@ -17,6 +14,7 @@ use litsea::adaboost::AdaBoost;
 use litsea::language::Language;
 use litsea::perceptron::AveragedPerceptron;
 use litsea::segmenter::Segmenter;
+use litsea::two_stage::TwoStageLearner;
 use litsea::upos::Upos;
 
 fn model_path(name: &str) -> PathBuf {
@@ -37,6 +35,14 @@ fn pos_segmenter(language: Language, model: &str) -> Segmenter {
         .load_model_from_path(&model_path(model))
         .unwrap_or_else(|e| panic!("failed to load {}: {}", model, e));
     Segmenter::with_pos_learner(language, learner)
+}
+
+fn two_stage_segmenter(language: Language, model: &str) -> Segmenter {
+    let mut learner = TwoStageLearner::new();
+    learner
+        .load_model_from_path(&model_path(model))
+        .unwrap_or_else(|e| panic!("failed to load {}: {}", model, e));
+    Segmenter::with_two_stage_learner(language, learner)
 }
 
 fn assert_segment(segmenter: &Segmenter, cases: &[(&str, &[&str])]) {
@@ -348,6 +354,193 @@ fn golden_segment_with_pos_korean() {
 }
 
 // ---------------------------------------------------------------------------
+// Two-stage segmentation + POS tagging (issue #147)
+//
+// These use the same sentences as the joint tests above so the two
+// architectures' outputs can be compared side by side. They are genuinely
+// different pipelines, not a reimplementation of the same one: stage 1
+// segments with a binary boundary classifier, then stage 2 tags each word
+// through the candidate-tag lexicon (skipping the classifier entirely for
+// single-candidate and dominance-dominant surfaces). Divergences from the
+// joint snapshots above are therefore expected — several of them are
+// improvements, e.g. Chinese "我喜欢吃中国菜。" segments correctly here
+// while the joint model splits it as "我喜"/"欢吃".
+// ---------------------------------------------------------------------------
+
+#[test]
+fn golden_segment_with_pos_japanese_two_stage() {
+    let segmenter = two_stage_segmenter(Language::Japanese, "japanese_two_stage.model");
+    assert_segment_with_pos(
+        &segmenter,
+        &[
+            (
+                "これはテストです。",
+                &[
+                    ("これ", "PRON"),
+                    ("は", "ADP"),
+                    ("テスト", "NOUN"),
+                    ("です", "AUX"),
+                    ("。", "PUNCT"),
+                ],
+            ),
+            (
+                "私の猫は可愛い。",
+                &[
+                    ("私", "PRON"),
+                    ("の", "ADP"),
+                    ("猫", "NOUN"),
+                    ("は", "ADP"),
+                    ("可愛い", "ADJ"),
+                    ("。", "PUNCT"),
+                ],
+            ),
+            (
+                "東京都に住んでいます。",
+                &[
+                    ("東京", "PROPN"),
+                    ("都", "NOUN"),
+                    ("に", "ADP"),
+                    ("住ん", "VERB"),
+                    ("で", "SCONJ"),
+                    ("い", "VERB"),
+                    ("ます", "AUX"),
+                    ("。", "PUNCT"),
+                ],
+            ),
+            ("字", &[("字", "NOUN")]),
+            (
+                "こんにちは",
+                &[("こん", "VERB"), ("に", "SCONJ"), ("ち", "NOUN"), ("は", "ADP")],
+            ),
+            (
+                "価格は1000円です。",
+                &[
+                    ("価格", "NOUN"),
+                    ("は", "ADP"),
+                    ("1000", "NUM"),
+                    ("円", "NOUN"),
+                    ("です", "AUX"),
+                    ("。", "PUNCT"),
+                ],
+            ),
+            (
+                "RustでNLPを実装する。",
+                &[
+                    ("Rust", "NOUN"),
+                    ("で", "ADP"),
+                    ("NLP", "NOUN"),
+                    ("を", "ADP"),
+                    ("実装", "VERB"),
+                    ("する", "AUX"),
+                    ("。", "PUNCT"),
+                ],
+            ),
+        ],
+    );
+    assert!(segmenter.segment_with_pos("").expect("two-stage learner is set").is_empty());
+}
+
+#[test]
+fn golden_segment_with_pos_chinese_two_stage() {
+    let segmenter = two_stage_segmenter(Language::Chinese, "chinese_two_stage.model");
+    assert_segment_with_pos(
+        &segmenter,
+        &[
+            (
+                "这是一个测试。",
+                &[
+                    ("这", "PROPN"),
+                    ("是", "AUX"),
+                    ("一", "NUM"),
+                    ("个", "NOUN"),
+                    ("测试", "NOUN"),
+                    ("。", "PUNCT"),
+                ],
+            ),
+            (
+                "我喜欢吃中国菜。",
+                &[
+                    ("我", "PRON"),
+                    ("喜欢", "VERB"),
+                    ("吃", "VERB"),
+                    ("中", "ADP"),
+                    ("国菜", "NOUN"),
+                    ("。", "PUNCT"),
+                ],
+            ),
+            (
+                "他在北京工作。",
+                &[
+                    ("他", "PRON"),
+                    ("在", "VERB"),
+                    ("北京", "PROPN"),
+                    ("工作", "NOUN"),
+                    ("。", "PUNCT"),
+                ],
+            ),
+            ("好", &[("好", "ADJ")]),
+            (
+                "2024年的春天。",
+                &[
+                    ("2024", "NUM"),
+                    ("年", "NOUN"),
+                    ("的", "PART"),
+                    ("春天", "NOUN"),
+                    ("。", "PUNCT"),
+                ],
+            ),
+        ],
+    );
+    assert!(segmenter.segment_with_pos("").expect("two-stage learner is set").is_empty());
+}
+
+#[test]
+fn golden_segment_with_pos_korean_two_stage() {
+    // Note: korean_two_stage.model is trained on the unspaced `word/POS`
+    // corpus (like korean_pos.model), not the space-preserving TSV corpus
+    // korean.model uses. Inference still receives the spaced text as-is, so
+    // spaces surface as their own tokens here.
+    let segmenter = two_stage_segmenter(Language::Korean, "korean_two_stage.model");
+    assert_segment_with_pos(
+        &segmenter,
+        &[
+            (
+                "이것은 테스트입니다.",
+                &[("이것은", "PRON"), (" ", "PUNCT"), ("테스트입니다", "VERB"), (".", "PUNCT")],
+            ),
+            (
+                "나는 고양이를 좋아한다.",
+                &[
+                    ("나는", "PRON"),
+                    (" ", "PUNCT"),
+                    ("고양이를", "NOUN"),
+                    (" ", "PUNCT"),
+                    ("좋아한다", "VERB"),
+                    (".", "PUNCT"),
+                ],
+            ),
+            (
+                "한국어 형태소 분석기.",
+                &[
+                    ("한국어", "NOUN"),
+                    (" ", "PUNCT"),
+                    ("형태소", "NOUN"),
+                    (" ", "PUNCT"),
+                    ("분석기", "NOUN"),
+                    (".", "PUNCT"),
+                ],
+            ),
+            ("글", &[("글", "NOUN")]),
+            (
+                "2024년 봄.",
+                &[("2024년", "NOUN"), (" ", "PUNCT"), ("봄", "NOUN"), (".", "PUNCT")],
+            ),
+        ],
+    );
+    assert!(segmenter.segment_with_pos("").expect("two-stage learner is set").is_empty());
+}
+
+// ---------------------------------------------------------------------------
 // Model file round-trip: load -> save -> load must preserve predictions.
 // Guards the on-disk model format compatibility across refactoring.
 // ---------------------------------------------------------------------------
@@ -397,6 +590,31 @@ fn roundtrip_perceptron_model() {
             seg_original.segment_with_pos(s).expect("POS learner is set"),
             seg_reloaded.segment_with_pos(s).expect("POS learner is set"),
             "round-tripped Perceptron model diverged on {:?}",
+            s
+        );
+    }
+}
+
+#[test]
+fn roundtrip_two_stage_model() {
+    let sentences = ["これはテストです。", "私の猫は可愛い。", "価格は1000円です。", "こんにちは"];
+
+    let mut original = TwoStageLearner::new();
+    original.load_model_from_path(&model_path("japanese_two_stage.model")).unwrap();
+
+    let temp = tempfile::NamedTempFile::new().unwrap();
+    original.save_model(temp.path()).unwrap();
+
+    let mut reloaded = TwoStageLearner::new();
+    reloaded.load_model_from_path(temp.path()).unwrap();
+
+    let seg_original = Segmenter::with_two_stage_learner(Language::Japanese, original);
+    let seg_reloaded = Segmenter::with_two_stage_learner(Language::Japanese, reloaded);
+    for s in sentences {
+        assert_eq!(
+            seg_original.segment_with_pos(s).expect("two-stage learner is set"),
+            seg_reloaded.segment_with_pos(s).expect("two-stage learner is set"),
+            "round-tripped two-stage model diverged on {:?}",
             s
         );
     }

--- a/litsea/tests/golden.rs
+++ b/litsea/tests/golden.rs
@@ -362,9 +362,16 @@ fn golden_segment_with_pos_korean() {
 // segments with a binary boundary classifier, then stage 2 tags each word
 // through the candidate-tag lexicon (skipping the classifier entirely for
 // single-candidate and dominance-dominant surfaces). Divergences from the
-// joint snapshots above are therefore expected — several of them are
-// improvements, e.g. Chinese "我喜欢吃中国菜。" segments correctly here
-// while the joint model splits it as "我喜"/"欢吃".
+// joint snapshots above are therefore expected.
+//
+// These are snapshots of current behavior, not of correct behavior: both
+// architectures get things wrong, and often in different places. Chinese
+// "我喜欢吃中国菜。" (gold: 我 / 喜欢 / 吃 / 中国 / 菜) is the clearest
+// case — two-stage recovers the first three tokens that joint mangles into
+// "我喜"/"欢吃", but then splits "中国" as "中"/"国菜", where "国菜" is not
+// a word (UD Chinese-GSD tokenizes 中國 as one token throughout). Joint
+// gets that tail right and the head wrong. Neither is a target to converge
+// on; when a model is retrained, re-derive these from its actual output.
 // ---------------------------------------------------------------------------
 
 #[test]


### PR DESCRIPTION
## Summary

The three bundled two-stage models (`japanese_two_stage.model`, `chinese_two_stage.model`, `korean_two_stage.model`) had **no behavioral pinning at all**. The two-stage runtime's only end-to-end coverage was against synthetic models built inside unit tests, so a refactor of `packed_two_stage.rs`, `word_features.rs`, or `segment_with_pos`'s two-stage branch could silently change what the shipped models produce with every test still passing.

The plain and joint models did not have this exposure, so the gap was an asymmetry in the safety net rather than a uniform limitation. This closes it.

## What's added

- **`two_stage_segmenter()` helper**, matching the existing `adaboost_segmenter` / `pos_segmenter` shape.
- **`golden_segment_with_pos_{japanese,chinese,korean}_two_stage`**, reusing the same sentences as the joint POS tests so the two architectures' snapshots sit side by side and can be compared by eye.
- **`roundtrip_two_stage_model`**, so all three on-disk formats are now guarded against save/load drift on a real bundled file (the `litsea-two-stage v1` round-trip in `two_stage.rs` only exercises synthetic models).
- Module doc updated — the "no golden-test coverage" note from #178 is removed and the scope sentence now covers all three model kinds.

Expectations are whatever the bundled models produce **today**, generated by running each model through the CLI — not what they arguably should produce. Nothing in `packed_two_stage.rs`, `word_features.rs`, or the segmenter changed; this adds coverage for existing behavior.

## These snapshots pin current behavior, not correct behavior

Several outputs differ from the joint models', and a section comment says so explicitly so a future reader doesn't "fix" an intentional difference. But it is worth being precise about what the differences are, because **both architectures get things wrong, often in different places**:

| Input | Gold (UD Chinese-GSD) | Joint | Two-stage |
|---|---|---|---|
| `我喜欢吃中国菜。` | `我`/`喜欢`/`吃`/`中国`/`菜` | ❌ `我喜`/`欢吃` … ✅ `中国`/`菜` | ✅ `我`/`喜欢`/`吃` … ❌ `中`/`国菜` |

Two-stage recovers the head that joint mangles into `我喜`/`欢吃` (splitting the word 喜欢 across a boundary), but then splits `中国` into `中`/`国菜` — and `国菜` is not a word; the corpus tokenizes 中國 as a single token in all 22 of its occurrences. Joint gets that tail right and the head wrong. **Neither output is a target to converge on.**

Other divergences, without a correctness claim attached:

| Input | Joint | Two-stage |
|---|---|---|
| `こんにちは` | `こん/PRON` `にち/ADP` `は/ADP` | `こん/VERB` `に/SCONJ` `ち/NOUN` `は/ADP` |
| `이것은 테스트입니다.` | `이` + `것은` | `이것은` (one token) |

The Korean test carries a note that `korean_two_stage.model` is trained on the unspaced `word/POS` corpus (not the space-preserving TSV corpus `korean.model` uses), which is why spaces still surface as their own tokens at inference.

## Verifying the tests are load-bearing

Passing tests prove nothing on their own — a golden test that accidentally routed through the joint path would pass while guarding nothing. Each new test was checked for RED by temporarily breaking the code it guards, covering both branches of the two-stage tagger:

1. **Lexicon / dominance fast path** — made the precomputed fixed-tag branch in `tag_words` return `Upos::X`. → the 3 new tests failed, all 11 pre-existing tests stayed green.
2. **Stage-2 classifier scoring** — flipped the sign of the WL dense-row contribution. → same result.

Both sabotages were reverted and the file confirmed byte-identical to `main` before committing.

`roundtrip_two_stage_model` stayed **green** under both sabotages, which is correct rather than a sign of inertness: it compares original against reloaded, both running the same code, so it pins format preservation, not behavior.

## Test plan

- [x] `cargo test --workspace` — 190 lib + 14 golden (was 10) + 13 CLI + 8 doc tests, all green
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Both sabotage runs confirmed RED for the new tests and green for the old ones

Closes #179