### PR TITLE
refactor: store the compiled two-stage model directly on the segmenter

### DIFF
--- a/docs/ja/src/architecture/module-design.md
+++ b/docs/ja/src/architecture/module-design.md
@@ -71,7 +71,7 @@ graph TD
 
 主要なユーザー向けモジュールです。
 
-- **`Segmenter`** -- `Language`、`AdaBoost` 学習器、オプションの `AveragedPerceptron` 品詞学習器を保持（フィールドは非公開。`language()`・`learner()`・`learner_mut()`・`pos_learner()`・`pos_learner_mut()` を使用）。加えて、オプションの二段構成状態（`Option<TwoStageState>`。`with_two_stage_learner` で設定）と、`segment()` / `segment_with_pos()` が使うコンパイル済みスコアリングテーブルの内部キャッシュ（`packed`・`packed_pos`・`packed_two_stage`）も保持する
+- **`Segmenter`** -- `Language`、`AdaBoost` 学習器、オプションの `AveragedPerceptron` 品詞学習器を保持（フィールドは非公開。`language()`・`learner()`・`learner_mut()`・`pos_learner()`・`pos_learner_mut()` を使用）。加えて、`segment()` / `segment_with_pos()` が使うコンパイル済みスコアリングテーブルの内部キャッシュ（`packed`・`packed_pos`）と、オプションのコンパイル済み二段構成タグ付けモデル（`with_two_stage_learner` で設定。キャッシュとは異なり stage-2 モデルそのものであり、生の学習器パーツはコンパイル後に破棄される）も保持する
   - `new(language)` -- デフォルト（空）の AdaBoost 学習器付きでセグメンターを作成
   - `with_learner(language, learner)` -- 設定済みの AdaBoost 学習器（例: 学習済みモデルを読み込んだもの）付きでセグメンターを作成
   - `with_pos_learner(language, pos_learner)` -- 分割+品詞付与用のセグメンターを作成

--- a/docs/ja/src/litsea/segmenter.md
+++ b/docs/ja/src/litsea/segmenter.md
@@ -9,14 +9,14 @@ pub struct Segmenter {
     // private: language: Language,
     // private: learner: AdaBoost,
     // private: pos_learner: Option<AveragedPerceptron>,
-    // private: two_stage: Option<TwoStageState>,
-    // internal: packed / packed_pos / packed_two_stage caches (see below)
+    // private: two_stage: Option<PackedTwoStageModel>（コンパイル済み stage-2 モデル）
+    // internal: packed / packed_pos caches (see below)
 }
 ```
 
 フィールドは非公開です。アクセサメソッド `language()`、`learner()`、`learner_mut()`、`pos_learner()`、`pos_learner_mut()` を使ってアクセスしてください。
 
-これらに加えて、構造体は `packed`、`packed_pos`、`packed_two_stage` も保持しています。これらは学習器の重みを `segment()` / `segment_with_pos()` が採点に使う整数インデックスのテーブル群へコンパイルした、遅延再構築されるキャッシュです（[予測パイプライン](../algorithm/prediction-pipeline.md#コンパイル済みスコアリングテーブル)を参照）。これらは内部実装の詳細でありアクセサはなく、対応する学習器が変更されると自動的に無効化されます。`two_stage` は [`with_two_stage_learner`](#with_two_stage_learner)（後述）が設定する stage-2 の状態を保持します。二段構成モデルから作成された Segmenter でなければ `None` です。
+これらに加えて、構造体は `packed` と `packed_pos` も保持しています。これらは学習器の重みを `segment()` / `segment_with_pos()` が採点に使う整数インデックスのテーブル群へコンパイルした、遅延再構築されるキャッシュです（[予測パイプライン](../algorithm/prediction-pipeline.md#コンパイル済みスコアリングテーブル)を参照）。これらは内部実装の詳細でありアクセサはなく、対応する学習器が変更されると自動的に無効化されます。`two_stage` は [`with_two_stage_learner`](#with_two_stage_learner)（後述）が設定するコンパイル済み stage-2 タグ付けモデルを保持します。二段構成モデルから作成された Segmenter でなければ `None` です。キャッシュとは異なり、保持された学習器から導出されるものではありません — 生の stage-2 パーツはコンパイル後に破棄され、このフィールドへの変更経路は存在しません。
 
 ## コンストラクタ
 

--- a/docs/src/architecture/module-design.md
+++ b/docs/src/architecture/module-design.md
@@ -71,7 +71,7 @@ Defines the `Language` enum and character type classification.
 
 The main user-facing module.
 
-- **`Segmenter`** -- Holds a `Language`, an `AdaBoost` learner, and an optional `AveragedPerceptron` POS learner (fields are private; use `language()`, `learner()`, `learner_mut()`, `pos_learner()`, `pos_learner_mut()`), plus an optional two-stage state (`Option<TwoStageState>`, set by `with_two_stage_learner`) and internal caches for the compiled scoring tables (`packed`, `packed_pos`, `packed_two_stage`) that back `segment()` / `segment_with_pos()`
+- **`Segmenter`** -- Holds a `Language`, an `AdaBoost` learner, and an optional `AveragedPerceptron` POS learner (fields are private; use `language()`, `learner()`, `learner_mut()`, `pos_learner()`, `pos_learner_mut()`), plus internal caches for the compiled scoring tables (`packed`, `packed_pos`) that back `segment()` / `segment_with_pos()`, and an optional compiled two-stage tagging model (set by `with_two_stage_learner`; unlike the caches it is the stage-2 model itself -- the raw learner parts are dropped after compilation)
   - `new(language)` -- Create a segmenter with a default (empty) AdaBoost learner
   - `with_learner(language, learner)` -- Create a segmenter with a pre-configured AdaBoost learner (e.g. one that has loaded a pre-trained model)
   - `with_pos_learner(language, pos_learner)` -- Create a segmenter for joint segmentation + POS tagging

--- a/docs/src/litsea/segmenter.md
+++ b/docs/src/litsea/segmenter.md
@@ -9,22 +9,24 @@ pub struct Segmenter {
     // private: language: Language,
     // private: learner: AdaBoost,
     // private: pos_learner: Option<AveragedPerceptron>,
-    // private: two_stage: Option<TwoStageState>,
-    // internal: packed / packed_pos / packed_two_stage caches (see below)
+    // private: two_stage: Option<PackedTwoStageModel> (compiled stage-2 model)
+    // internal: packed / packed_pos caches (see below)
 }
 ```
 
 The fields are private; use the accessor methods `language()`, `learner()`, `learner_mut()`, `pos_learner()`, and `pos_learner_mut()` to reach them.
 
-Besides these, the struct also holds `packed`, `packed_pos`, and
-`packed_two_stage`: lazily-rebuilt caches of the learners' weights compiled
-into the integer-indexed tables `segment()` / `segment_with_pos()` score
-against (see [Prediction Pipeline](../algorithm/prediction-pipeline.md#the-compiled-scoring-tables)).
+Besides these, the struct also holds `packed` and `packed_pos`:
+lazily-rebuilt caches of the learners' weights compiled into the
+integer-indexed tables `segment()` / `segment_with_pos()` score against
+(see [Prediction Pipeline](../algorithm/prediction-pipeline.md#the-compiled-scoring-tables)).
 They are internal implementation detail with no accessors of their own,
 invalidated automatically whenever the corresponding learner is mutated.
-`two_stage` holds the stage-2 state set by
+`two_stage` holds the compiled stage-2 tagging model set by
 [`with_two_stage_learner`](#with_two_stage_learner) (see below); it is
-`None` unless the segmenter was built from a two-stage model.
+`None` unless the segmenter was built from a two-stage model. Unlike the
+caches it is not derived from a retained learner — the raw stage-2 parts
+are dropped after compilation and there is no mutation path for it.
 
 ## Constructors
 

--- a/litsea/src/segmenter.rs
+++ b/litsea/src/segmenter.rs
@@ -22,19 +22,6 @@ use crate::perceptron::AveragedPerceptron;
 use crate::two_stage::TwoStageLearner;
 use crate::upos::{SegmentLabel, Upos};
 
-/// The stage-2 half of a decomposed [`TwoStageLearner`], retained alongside
-/// the packed tagging tables built from it once, at construction time
-/// (mirroring how the segmenter retains its other learners).
-#[derive(Debug)]
-struct TwoStageState {
-    /// Stage-2 word-level tagger.
-    stage2: AveragedPerceptron,
-    /// Surface -> observed `(tag, count)` candidates, most frequent first.
-    lexicon: rustc_hash::FxHashMap<String, Vec<(Upos, u32)>>,
-    /// Classifier-skip dominance threshold.
-    dominance: f64,
-}
-
 /// Text segmenter supporting three modes: word segmentation via AdaBoost
 /// binary classification; joint word segmentation + POS tagging via an
 /// Averaged Perceptron; and two-stage word segmentation + POS tagging via a
@@ -67,16 +54,20 @@ pub struct Segmenter {
     /// [`add_corpus_with_pos`](Self::add_corpus_with_pos), which invalidate
     /// it); lazily rebuilt on the next `segment_with_pos` call.
     packed_pos: RwLock<Option<PackedPosModel>>,
-    /// The stage-2 state of a two-stage model, set by
-    /// [`with_two_stage_learner`](Self::with_two_stage_learner) (the
-    /// stage-1 half lives in `learner`). When present,
+    /// The stage-2 half of a two-stage model, compiled into packed tagging
+    /// tables by [`with_two_stage_learner`](Self::with_two_stage_learner)
+    /// (the stage-1 half lives in `learner`). When present,
     /// [`segment_with_pos`](Self::segment_with_pos) takes the two-stage
     /// path instead of the joint POS path.
-    two_stage: Option<TwoStageState>,
-    /// The two-stage state compiled into packed tagging tables. `None`
-    /// when no two-stage learner is set; built eagerly by
-    /// [`with_two_stage_learner`](Self::with_two_stage_learner).
-    packed_two_stage: RwLock<Option<PackedTwoStageModel>>,
+    ///
+    /// Unlike `packed` and `packed_pos` this is not a lazily-rebuilt cache
+    /// of some other field — it *is* the stage-2 model; the raw
+    /// [`TwoStageLearner`] parts are dropped after compilation, and there is
+    /// no mutable accessor for it. If in-place two-stage mutation is ever
+    /// added, follow the [`pos_learner_mut`](Self::pos_learner_mut) shape
+    /// (keep the learner, cache the compilation, invalidate on mutation)
+    /// rather than mutating this field directly.
+    two_stage: Option<PackedTwoStageModel>,
 }
 
 impl Segmenter {
@@ -126,7 +117,6 @@ impl Segmenter {
             packed,
             packed_pos: RwLock::new(None),
             two_stage: None,
-            packed_two_stage: RwLock::new(None),
         }
     }
 
@@ -158,7 +148,6 @@ impl Segmenter {
             packed,
             packed_pos,
             two_stage: None,
-            packed_two_stage: RwLock::new(None),
         }
     }
 
@@ -180,22 +169,19 @@ impl Segmenter {
     pub fn with_two_stage_learner(language: Language, learner: TwoStageLearner) -> Self {
         let (stage1, stage2, lexicon, dominance) = learner.into_parts();
         // Compile both packed tables eagerly so the common
-        // load-then-segment path never rebuilds mid-stream.
+        // load-then-segment path never rebuilds mid-stream. The raw stage-2
+        // parts are dropped after compilation: the packed model contains
+        // everything the tagging path needs, and there is no mutation path
+        // that would require rebuilding it (see the `two_stage` field doc).
         let packed = RwLock::new(Some(PackedModel::build(language, &stage1)));
-        let packed_two_stage =
-            RwLock::new(Some(PackedTwoStageModel::build(language, &stage2, &lexicon, dominance)));
+        let two_stage = PackedTwoStageModel::build(language, &stage2, &lexicon, dominance);
         Segmenter {
             language,
             learner: stage1,
             pos_learner: None,
             packed,
             packed_pos: RwLock::new(None),
-            two_stage: Some(TwoStageState {
-                stage2,
-                lexicon,
-                dominance,
-            }),
-            packed_two_stage,
+            two_stage: Some(two_stage),
         }
     }
 
@@ -355,40 +341,6 @@ impl Segmenter {
         // get_or_insert_with covers the race where another thread rebuilt
         // the table between the two lock acquisitions.
         let packed = guard.get_or_insert_with(|| PackedPosModel::build(self.language, pos_learner));
-        f(packed)
-    }
-
-    /// Runs `f` with the packed two-stage tagging tables, building them on
-    /// first use and caching them for the lifetime of the segmenter (there
-    /// is no mutable accessor for the two-stage state, so unlike
-    /// [`with_packed`](Self::with_packed) and
-    /// [`with_packed_pos`](Self::with_packed_pos) this cache is never
-    /// invalidated after it is first populated). The fast path takes only
-    /// an uncontended read lock (one per sentence). The caller passes the
-    /// two-stage state it already borrowed (presence is checked by
-    /// [`segment_with_pos`](Self::segment_with_pos)).
-    fn with_packed_two_stage<R>(
-        &self,
-        state: &TwoStageState,
-        f: impl FnOnce(&PackedTwoStageModel) -> R,
-    ) -> R {
-        {
-            let guard = self.packed_two_stage.read().unwrap_or_else(PoisonError::into_inner);
-            if let Some(packed) = guard.as_ref() {
-                return f(packed);
-            }
-        }
-        let mut guard = self.packed_two_stage.write().unwrap_or_else(PoisonError::into_inner);
-        // get_or_insert_with covers the race where another thread rebuilt
-        // the table between the two lock acquisitions.
-        let packed = guard.get_or_insert_with(|| {
-            PackedTwoStageModel::build(
-                self.language,
-                &state.stage2,
-                &state.lexicon,
-                state.dominance,
-            )
-        });
         f(packed)
     }
 
@@ -939,10 +891,9 @@ impl Segmenter {
         if sentence.is_empty() {
             return Ok(Vec::new());
         }
-        if let Some(state) = self.two_stage.as_ref() {
+        if let Some(packed) = self.two_stage.as_ref() {
             let words = self.segment(sentence);
-            let tags =
-                self.with_packed_two_stage(state, |packed| packed.tag_words(self.language, &words));
+            let tags = packed.tag_words(self.language, &words);
             return Ok(words.into_iter().zip(tags).collect());
         }
         let pos_learner = self.pos_learner.as_ref().ok_or(LitseaError::PosLearnerNotSet)?;


### PR DESCRIPTION
## Summary

#180 flagged that `Segmenter`'s `packed_two_stage` cache is never invalidated, unlike its siblings `packed`/`packed_pos`. Investigation on current `main` showed the situation is both better and worse than the issue assumed:

- **Better**: it is not a bug. `TwoStageState` has no mutable accessor, so nothing can stale the cache through today's API.
- **Worse**: the lazily-rebuilding machinery is **dead code**. `with_two_stage_learner` builds the packed model eagerly, nothing ever clears it, so the rebuild closure inside `with_packed_two_stage` can never run — and that closure was the *only* reader of `TwoStageState`'s three fields.

So the struct was paying real costs for an impossible rebuild:

1. A read-lock acquisition **per sentence** to guard against a rebuild that cannot happen.
2. The raw stage-2 perceptron + full lexicon (several MB for the bundled models) retained for the segmenter's lifetime, purely as inputs to that impossible rebuild.
3. The exact trap the issue describes: two sibling caches whose laziness is real, making it easy to assume this one's invalidation was also wired up.

## Change

Rather than documenting the invariant (option 1) or adding invalidation machinery for a mutation path that doesn't exist (option 2), this takes option 3 — make the hazard structurally impossible — **by deletion**:

- `two_stage: Option<TwoStageState>` + `packed_two_stage: RwLock<Option<PackedTwoStageModel>>` collapse into a single `two_stage: Option<PackedTwoStageModel>`.
- `TwoStageState` and `with_packed_two_stage` are deleted; `segment_with_pos`'s two-stage branch calls `packed.tag_words(...)` directly on the borrowed field.
- `with_two_stage_learner` drops the raw stage-2 parts after compilation instead of storing them.
- The field doc records the invariant ("this is the model, not a cache") and points any future in-place-mutation work at the `pos_learner_mut` shape (keep the learner, cache the compilation, invalidate on mutation).

There is no longer a cache to forget to invalidate. Side benefits: one fewer lock acquisition per sentence on the two-stage path, and a two-stage segmenter no longer holds several MB of raw model data it never reads.

**No public API changes** — `TwoStageState`, `with_packed_two_stage`, and both fields were private. `packed`/`packed_pos` are untouched; their laziness is load-bearing.

Doc pages describing the old two-field structure (`litsea/segmenter.md`, `architecture/module-design.md`, EN + JA) are updated to match.

## Why behavior preservation is verifiable

The #181 golden tests pin `segment_with_pos` output for **all three bundled two-stage models** (and were themselves verified load-bearing via sabotage runs in that PR). They pass unchanged here, so the collapse is proven behavior-preserving on the real shipped models, not just on synthetic fixtures.

## Test plan

- [x] `cargo test --workspace` — 190 lib + 14 golden + 13 CLI + 8 doc tests, all green
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps -p litsea` — no new warnings (the 2 remaining are pre-existing on `main`)
- [x] `markdownlint-cli2` over both doc trees — 0 errors; `mdbook build` EN/JA clean

Closes #180