### PR TITLE
docs: bump documented crate version to 0.12.0

### DIFF
--- a/docs/ja/src/README.md
+++ b/docs/ja/src/README.md
@@ -49,7 +49,7 @@ Output: 今日/NOUN は/ADP いい/ADJ 天気/NOUN です/AUX ね/PART 。/PUNCT
 
 ## 現在のバージョン
 
-Litsea v0.11.0 -- Rust Edition 2024、最低 Rust バージョン 1.87。
+Litsea v0.12.0 -- Rust Edition 2024、最低 Rust バージョン 1.87。
 
 ## リンク
 

--- a/docs/ja/src/advanced/remote-model-loading.md
+++ b/docs/ja/src/advanced/remote-model-loading.md
@@ -34,7 +34,7 @@ learner.load_model("https://example.com/models/japanese.model").await?;
 0.6.0 以降、`remote_model` フィーチャーは**オプトイン**です（ライブラリのデフォルトはローカル読み込みのみとし、依存関係のツリーをコンパクトに保っています）。CLI ではこのフィーチャーが有効化されているため、`litsea segment https://...` はそのまま動作します。ライブラリ利用者は以下が必要です:
 
 ```toml
-litsea = { version = "0.11.0", features = ["remote_model"] }
+litsea = { version = "0.12.0", features = ["remote_model"] }
 ```
 
 ## 実装の詳細

--- a/docs/ja/src/getting-started/installation.md
+++ b/docs/ja/src/getting-started/installation.md
@@ -35,13 +35,13 @@ cargo build --release
 
 ```toml
 [dependencies]
-litsea = "0.11.0"
+litsea = "0.12.0"
 ```
 
 http(s) 経由のリモートモデル読み込みはオプトイン（opt-in）です。必要な場合は `remote_model` フィーチャーを有効にしてください:
 
 ```toml
-litsea = { version = "0.11.0", features = ["remote_model"] }
+litsea = { version = "0.12.0", features = ["remote_model"] }
 ```
 
 > **注意:** ローカルファイルからのモデル読み込み（`load_model_from_path`）は同期処理のため、非同期ランタイムは不要です。非同期ランタイム（`tokio` など）が必要になるのは、非同期の `load_model` メソッドを使って HTTP/HTTPS 経由でモデルを読み込む場合のみです（オプトインの `remote_model` フィーチャーを有効にした場合にのみ利用できます）。

--- a/docs/ja/src/litsea.md
+++ b/docs/ja/src/litsea.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-litsea = "0.11.0"
+litsea = "0.12.0"
 ```
 
 ローカルファイルからのモデル読み込みは同期 API（`load_model_from_path`）で行えるため、tokio などの非同期ランタイムは不要です。HTTP(S) からのリモートモデル取得など async API（`load_model`）を使う場合のみ、非同期ランタイムを追加してください（`AnyPosModel::load` も常に同じ非同期経路でモデル URI を解決するため、これに該当します）。

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -49,7 +49,7 @@ There is a small plant called *Litsea cubeba* (Aomoji) in the same Lauraceae fam
 
 ## Current Version
 
-Litsea v0.11.0 -- Rust Edition 2024, minimum Rust version 1.87.
+Litsea v0.12.0 -- Rust Edition 2024, minimum Rust version 1.87.
 
 ## Links
 

--- a/docs/src/advanced/remote-model-loading.md
+++ b/docs/src/advanced/remote-model-loading.md
@@ -37,7 +37,7 @@ so `litsea segment https://...` keeps working out of the box; library users
 need:
 
 ```toml
-litsea = { version = "0.11.0", features = ["remote_model"] }
+litsea = { version = "0.12.0", features = ["remote_model"] }
 ```
 
 ## Implementation Details

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -35,14 +35,14 @@ Add Litsea to your project's `Cargo.toml`:
 
 ```toml
 [dependencies]
-litsea = "0.11.0"
+litsea = "0.12.0"
 ```
 
 Remote model loading over http(s) is opt-in; enable the `remote_model`
 feature if you need it:
 
 ```toml
-litsea = { version = "0.11.0", features = ["remote_model"] }
+litsea = { version = "0.12.0", features = ["remote_model"] }
 ```
 
 > **Note:** Loading models from local files (`load_model_from_path`) is synchronous, so no async runtime is needed. An async runtime such as `tokio` is only required if you load models over HTTP/HTTPS with the async `load_model` method (available only when the opt-in `remote_model` feature is enabled).

--- a/docs/src/litsea.md
+++ b/docs/src/litsea.md
@@ -6,7 +6,7 @@ The `litsea` crate provides a Rust API for word segmentation, model training, an
 
 ```toml
 [dependencies]
-litsea = "0.11.0"
+litsea = "0.12.0"
 ```
 
 Loading models from local files is synchronous and needs no async runtime. An async runtime such as `tokio` is only required when loading models over HTTP/HTTPS with the async `load_model` method (this includes `AnyPosModel::load`, which always resolves the model URI through the same async path).


### PR DESCRIPTION
## Summary

The 0.12.0 release (tag `v0.12.0`, release workflow green) left the documented version strings at `0.11.0` — the same class of drift #177 cleaned up after the 0.11.0 release. This updates all ten occurrences (EN + JA: the book introduction, `litsea.md`, `getting-started/installation.md` ×2 each, `advanced/remote-model-loading.md`) to `0.12.0`.

One-off docs sync, no issue filed (same treatment as the post-release doc fixes before it; grep-verified zero `0.11.0` references remain outside the CHANGELOG's historical sections).

## Test plan

- [x] `grep -rn '"0.11.0"\|v0.11.0' docs/ README.md` → only CHANGELOG history
- [x] `markdownlint-cli2` — 0 errors