### PR TITLE
feat: add litsea-python, the Python binding

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,25 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  - package-ecosystem: "pip"
+    directory: "/litsea-python"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      # Same batching rationale as the cargo ecosystem above.
+      pip-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -83,6 +83,45 @@ jobs:
             cargo test --target "${{ matrix.platform.target }}" --all-features
           fi
 
+  test-litsea-python:
+    name: Test litsea-python
+    needs: [format]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - name: Run checkout
+        uses: actions/checkout@v7
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-python-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run Python test
+        # Builds the extension with maturin, then runs pytest. The parity
+        # tests build and invoke the CLI themselves, so they compare against
+        # the reference implementation rather than hardcoded expectations.
+        run: make test-litsea-python
+
+      - name: Run Python lint
+        run: make lint-litsea-python
+
   feature-check:
     name: Feature check
     needs: [format]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,48 @@ jobs:
             cargo test --target "${{ matrix.platform.target }}" --all-features
           fi
 
+  test-litsea-python:
+    name: Test litsea-python
+    needs: [format]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - name: Run checkout
+        uses: actions/checkout@v7
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-python-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run Python test
+        # Builds the extension with maturin, then runs pytest. The parity
+        # tests build and invoke the CLI themselves, so they compare against
+        # the reference implementation rather than hardcoded expectations.
+        run: make test-litsea-python
+
+      - name: Run Python lint
+        run: make lint-litsea-python
+
   create-release:
     name: Create Release
-    needs: [test]
+    needs: [test, test-litsea-python]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
@@ -254,3 +293,71 @@ jobs:
           fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
+
+  build-python-wheels:
+    name: Build wheel (${{ matrix.platform.target }})
+    needs: [test-litsea-python]
+    if: startsWith(github.ref, 'refs/tags/v')
+    strategy:
+      matrix:
+        platform:
+          - runner: ubuntu-latest
+            target: x86_64
+            manylinux: auto
+          - runner: ubuntu-24.04-arm
+            target: aarch64
+            manylinux: auto
+          - runner: macos-latest
+            target: aarch64
+          - runner: macos-26-intel
+            target: x86_64
+          - runner: windows-latest
+            target: x64
+    runs-on: ${{ matrix.platform.runner }}
+    steps:
+      - name: Run checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Build wheel
+        # abi3-py310, so one wheel per platform covers every supported
+        # Python version.
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          manylinux: ${{ matrix.platform.manylinux }}
+          args: --release --out dist --manifest-path litsea-python/Cargo.toml
+          sccache: "true"
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.platform.runner }}-${{ matrix.platform.target }}
+          path: dist
+
+  publish-python:
+    name: Publish litsea to PyPI
+    needs: [build-python-wheels, publish-crates]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download wheels
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist
+
+      - name: Publish to PyPI
+        # Requires the PYPI_TOKEN repository secret; until it is set this
+        # step fails and the rest of the release is unaffected.
+        uses: PyO3/maturin-action@v1
+        with:
+          command: upload
+          args: --non-interactive --skip-existing dist/*
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,15 @@ CLAUDE.md
 
 .tmp
 data/
+
+# Python virtualenv and build artifacts of the litsea-python binding
+.venv/
+__pycache__/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+dist/
+# compiled extension modules produced by `maturin develop`
+*.so
+*.pyd
+*.dylib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ### Added
 
+- New crate `litsea-python` (#202): the Python binding, published to PyPI
+  as `litsea`. Built with PyO3 0.29 + maturin against the stable ABI
+  (`abi3-py310`), so one wheel per platform covers Python 3.10+. It exposes
+  `Segmenter` (`open` / `from_bytes` / `from_uri`, `segment`,
+  `segment_batch`, `segment_tokens`, `segment_with_pos`,
+  `segment_with_pos_batch`), `Language` / `Upos` / `Token`, the training
+  pipeline (`Extractor`, `Trainer`, `PerceptronTrainer`, `TwoStageTrainer`)
+  with an explicit `CancelToken`, and an exception hierarchy rooted at
+  `LitseaError`. The model kind is detected from the file, so there is no
+  `--pos`-style flag; language arguments accept a `Language` member or its
+  name (`"ja"`, `"japanese"`). `segment_batch`, `segment_with_pos_batch`,
+  `extract`, and every `train` release the GIL, so training can be cancelled
+  from another thread. Ships type stubs and `py.typed`. The package embeds
+  no models: supply one by path, bytes, or URL.
+
 - New crate `litsea-binding-core` (#201): the FFI-independent logic shared
   by the upcoming language bindings (#200) -- Python, Node.js, PHP, Ruby,
   and WebAssembly. It provides `CoreSegmenter` (segmentation and POS

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,6 +826,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "litsea-python"
+version = "0.12.0"
+dependencies = [
+ "litsea",
+ "litsea-binding-core",
+ "pyo3",
+ "tempfile",
+]
+
+[[package]]
 name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,6 +953,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,6 +983,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4688ddedf473e32662b9b067670129a8afb8c18e351482c70d62ba4a88171e8b"
+dependencies = [
+ "libc",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f41027e41b4bd03f6e60f9f417fe24a6341a6bb744edd62b6f709f2a52ea30e9"
+dependencies = [
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e591a95526fead067432c3b3a33fc74770b87b1e04e73671090d9c2055a2b327"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73225868fc1cd84eef2c3c230ddb91273bf1de46aeb8a4248da76d32a0924a1c"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "571575aa3749fa6216757dd47d2a3e7ef360f329a40f0666a9fbd14889024952"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1418,6 +1491,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,11 @@
 [workspace]
 resolver = "3"
-members = ["litsea", "litsea-cli", "litsea-binding-core"]
+members = ["litsea", "litsea-cli", "litsea-binding-core", "litsea-python"]
+# The language bindings are members (so `cargo clippy --workspace` covers
+# them) but not default members: the six-platform regression matrix would
+# otherwise build a Python extension module on runners with no Python
+# development environment. Each binding gets its own CI job instead.
+default-members = ["litsea", "litsea-cli", "litsea-binding-core"]
 
 # CPU-bound hot loops (feature-template scoring per character) benefit from
 # cross-codegen-unit inlining; thin LTO + a single codegen unit trades

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,14 @@ LITSEA_VERSION ?= $(shell cargo metadata --no-deps --format-version=1 | jq -r '.
 LITSEA_BINDING_CORE_VERSION ?= $(shell cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.name=="litsea-binding-core") | .version')
 LITSEA_CLI_VERSION ?= $(shell cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | select(.name=="litsea-cli") | .version')
 
+# Python tooling for the litsea-python binding, kept in a venv inside the
+# crate so it never touches the user's interpreter.
+PYTHON_VENV_DIR := litsea-python/.venv
+PYTHON          := $(PYTHON_VENV_DIR)/bin/python
+PIP             := $(PYTHON_VENV_DIR)/bin/pip
+MATURIN         := $(PYTHON_VENV_DIR)/bin/maturin
+PYTEST          := $(PYTHON_VENV_DIR)/bin/pytest
+
 USER_AGENT ?= $(shell curl --version | head -n1 | awk '{print $1"/"$2}')
 USER ?= $(shell whoami)
 HOSTNAME ?= $(shell hostname)
@@ -10,10 +18,17 @@ HOSTNAME ?= $(shell hostname)
 
 help: ## Show help
 	@echo "Available targets:"
-	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-24s %s\n", $$1, $$2}'
 
-clean: ## Clean the project
+clean: clean-litsea-python ## Clean the project
 	cargo clean
+
+clean-litsea-python: ## Clean litsea-python build artifacts
+	rm -rf $(PYTHON_VENV_DIR)
+	rm -rf litsea-python/dist
+	rm -rf litsea-python/.pytest_cache
+	rm -rf litsea-python/python/litsea/__pycache__
+	rm -rf litsea-python/tests/__pycache__
 
 format: ## Format the project
 	cargo fmt
@@ -21,11 +36,30 @@ format: ## Format the project
 lint: ## Lint the project
 	cargo clippy --workspace --all-targets -- -D warnings
 
-test: ## Test the project
+test: ## Test the project (Rust workspace only; see test-litsea-python)
 	cargo test --workspace
+
+$(PYTHON_VENV_DIR):
+	python3 -m venv $(PYTHON_VENV_DIR)
+	$(PIP) install --quiet --upgrade pip
+
+setup-venv: $(PYTHON_VENV_DIR) ## Create the litsea-python venv and install dev tools
+	$(PIP) install --quiet maturin pytest mypy ruff
+
+test-litsea-python: setup-venv ## Test litsea-python (Rust unit tests + pytest)
+	cargo test -p litsea-python --lib
+	cd litsea-python && VIRTUAL_ENV=$(abspath $(PYTHON_VENV_DIR)) $(abspath $(MATURIN)) develop --quiet && $(abspath $(PYTEST)) tests/ -v
+
+lint-litsea-python: setup-venv ## Lint litsea-python (clippy + ruff + mypy)
+	cargo clippy -p litsea-python --all-targets -- -D warnings
+	cd litsea-python && $(abspath $(PYTHON_VENV_DIR))/bin/ruff check python/ tests/ examples/
+	cd litsea-python && $(abspath $(PYTHON_VENV_DIR))/bin/ruff format --check python/ tests/ examples/
 
 build: ## Build the project
 	cargo build --release
+
+build-litsea-python: setup-venv ## Build a release wheel for litsea-python
+	cd litsea-python && VIRTUAL_ENV=$(abspath $(PYTHON_VENV_DIR)) $(abspath $(MATURIN)) build --release --out dist
 
 check-wasm: ## Check the wasm32 build (litsea and the binding core)
 	cargo check -p litsea --target wasm32-unknown-unknown --no-default-features

--- a/README.md
+++ b/README.md
@@ -9,6 +9,28 @@ Litsea is an extremely compact word segmentation and POS (Part-of-Speech) taggin
 - **Multilingual Support** for Japanese, Korean, Chinese, and English
 - **Backward Compatible** — existing segmentation-only workflows continue to work as before
 
+## Language bindings
+
+Litsea is usable from other languages through bindings that live in this repository:
+
+| Package | Language | Status |
+|---------|----------|--------|
+| [`litsea-python`](litsea-python/README.md) (PyPI: `litsea`) | Python 3.10+ | Available |
+| `litsea-nodejs` | Node.js | Planned ([#203](https://github.com/mosuka/litsea/issues/203)) |
+| `litsea-php` | PHP | Planned ([#204](https://github.com/mosuka/litsea/issues/204)) |
+| `litsea-ruby` | Ruby | Planned ([#205](https://github.com/mosuka/litsea/issues/205)) |
+| `litsea-wasm` | WebAssembly | Planned ([#206](https://github.com/mosuka/litsea/issues/206)) |
+
+Bindings ship code only; models are supplied by the caller as a path, bytes, or URL. `litsea-binding-core` holds the logic they share.
+
+```python
+from litsea import Language, Segmenter
+
+seg = Segmenter.open(Language.JAPANESE, "models/japanese.model")
+seg.segment("これはテストです。")
+# ['これ', 'は', 'テスト', 'です', '。']
+```
+
 There is a small plant called Litsea cubeba (Aomoji) in the same camphoraceae family as Lindera (Kuromoji). This is the origin of the name Litsea.
 
 ## How to build Litsea

--- a/docs/ja/src/SUMMARY.md
+++ b/docs/ja/src/SUMMARY.md
@@ -53,6 +53,7 @@
 
 - [言語バインディング](bindings.md)
   - [litsea-binding-core](bindings/binding-core.md)
+  - [Python](bindings/python.md)
 
 # トレーニングガイド
 

--- a/docs/ja/src/bindings.md
+++ b/docs/ja/src/bindings.md
@@ -7,7 +7,7 @@ Litsea は Rust のライブラリですが、他の言語からも利用でき�
 | クレート | 対象ランタイム | FFI スタック | 状態 |
 |---------|--------------|-------------|------|
 | [`litsea-binding-core`](bindings/binding-core.md) | （共通・FFI 非依存） | — | 提供済み |
-| `litsea-python` | Python 3.10+ | PyO3 + maturin | 予定（[#202](https://github.com/mosuka/litsea/issues/202)） |
+| [`litsea-python`](bindings/python.md) | Python 3.10+ | PyO3 + maturin | 提供済み |
 | `litsea-nodejs` | Node.js 20+ | napi-rs | 予定（[#203](https://github.com/mosuka/litsea/issues/203)） |
 | `litsea-php` | PHP 8.1+ | ext-php-rs | 予定（[#204](https://github.com/mosuka/litsea/issues/204)） |
 | `litsea-ruby` | Ruby 3.1+ | magnus + rb-sys | 予定（[#205](https://github.com/mosuka/litsea/issues/205)） |

--- a/docs/ja/src/bindings/binding-core.md
+++ b/docs/ja/src/bindings/binding-core.md
@@ -43,10 +43,12 @@ use litsea_binding_core::CoreSegmenter;
 let segmenter = CoreSegmenter::from_path(Language::Japanese, "models/japanese.model".as_ref())?;
 
 assert_eq!(
-    segmenter.segment("すもももももももものうち"),
-    vec!["すもも", "も", "もも", "も", "もも", "の", "うち"]
+    segmenter.segment("これはテストです。"),
+    vec!["これ", "は", "テスト", "です", "。"]
 );
 ```
+
+空白区切りの言語では空白自体が 1 トークンとして返るため、トークンを連結すると入力が正確に復元されます。例えば `korean.model` は `"안녕하세요 반갑습니다"` を `["안녕하세요", " ", "반갑습니다"]` に分割します。
 
 `CoreSegmenter` は `Arc<Segmenter>` と `Mutex<SegmentBuffer>` を保持します。`Segmenter` は `Send + Sync` であり、モデル読み込み済みのインスタンスは packed テーブルが構築済みのため、並行した `segment` 呼び出しは内部の read ロックしか取りません。ミューテックスが保護するのはスクラッチバッファだけです。したがって 1 つのインスタンスをスレッド間で共有し、継続的に再利用できます（各バインディングはそのように使います）。
 

--- a/docs/ja/src/bindings/python.md
+++ b/docs/ja/src/bindings/python.md
@@ -1,0 +1,130 @@
+# Python
+
+`litsea-python` は [PyO3](https://pyo3.rs) と [maturin](https://www.maturin.rs) を用いて Litsea を Python 3.10 以降へ公開するバインディングです。PyPI では `litsea` という名前で配布します。
+
+## インストール
+
+```sh
+pip install litsea
+```
+
+wheel は安定 ABI（`abi3-py310`）でビルドされるため、プラットフォームごとに 1 つの wheel がサポート対象の全 Python バージョンをカバーします。
+
+## モデルの入手
+
+パッケージにモデルは含まれません。[`models/`](https://github.com/mosuka/litsea/tree/main/models) ディレクトリから取得してパスを渡してください（[事前学習済みモデル](../pre-trained-models.md)を参照）。
+
+モデルの種別を指定するフラグはありません。ファイル自身が種別を持っており、読み込んだモデルで何ができるかは `has_pos` が示します。
+
+## 分割
+
+```python
+from litsea import Language, Segmenter
+
+seg = Segmenter.open(Language.JAPANESE, "models/japanese.model")
+
+seg.segment("これはテストです。")
+# ['これ', 'は', 'テスト', 'です', '。']
+```
+
+`Language` を受け取る箇所では言語名も使えます。`Segmenter.open("ja", ...)` と `Segmenter.open("japanese", ...)` は等価です。
+
+空白区切りの言語では空白自体が 1 トークンとして返るため、トークンを連結すると常に入力が復元されます。
+
+```python
+Segmenter.open("ko", "models/korean.model").segment("안녕하세요 반갑습니다")
+# ['안녕하세요', ' ', '반갑습니다']
+```
+
+## POS タグ付け
+
+```python
+seg = Segmenter.open(Language.JAPANESE, "models/japanese_pos.model")
+
+for token in seg.segment_with_pos("これはテストです。"):
+    print(token.surface, token.pos.name, token.start, token.end)
+# これ PRON 0 6
+# は ADP 6 9
+# テスト NOUN 9 18
+# です AUX 18 24
+# 。 PUNCT 24 27
+```
+
+`start` と `end` は入力に対するバイトオフセットです。`text.encode()[token.start:token.end].decode()` で表層形が得られます。分割専用モデルに対して `segment_with_pos` を呼ぶと `PosUnavailableError` が送出されます。
+
+## API
+
+| 呼び出し | 戻り値 |
+|---------|-------|
+| `Segmenter.open(language, path)` | ファイルから読み込んだセグメンタ |
+| `Segmenter.from_bytes(language, data)` | バイト列から読み込んだセグメンタ |
+| `Segmenter.from_uri(language, uri)` | パス・`file://`・`http(s)://` から読み込んだセグメンタ |
+| `segment(text)` | `list[str]` |
+| `segment_batch(texts)` | `list[list[str]]` |
+| `segment_tokens(text)` | バイトオフセット付き `list[Token]` |
+| `segment_with_pos(text)` | タグとオフセット付き `list[Token]` |
+| `segment_with_pos_batch(texts)` | `list[list[Token]]` |
+| `Extractor(language).extract(...)` | 特徴量ファイルを書き出す |
+| `Extractor(language).extract_two_stage(...)` | `.stage1` / `.stage2` / `.lexicon` を書き出す |
+| `Trainer(threshold, iterations, features).train(model, cancel=None)` | `BinaryMetrics` |
+| `PerceptronTrainer(epochs, features).train(model, cancel=None)` | `MulticlassMetrics` |
+| `TwoStageTrainer(epochs, prefix, dominance=0.99).train(model, cancel=None)` | `TwoStageMetrics` |
+
+`Language` と `Upos` は `enum.Enum` のサブクラスではなく PyO3 のクラスです。メンバーはクラス属性なので、列挙には `for x in Language` ではなく `Language.all()` / `Upos.all()` を使ってください。
+
+## 学習
+
+```python
+from litsea import Extractor, Language, Trainer
+
+Extractor(Language.JAPANESE).extract("corpus.txt", "features.txt")
+metrics = Trainer(0.01, 10_000, "features.txt").train("japanese.model")
+print(f"accuracy: {metrics.accuracy:.2f}%")
+```
+
+`TwoStageTrainer` は 1 度しか実行できません。学習時に stage 1 が AdaBoost モデルへ collapse され、トレーナが消費されるためです。再利用可能かどうかは `available` が示し、2 回目の `train()` は `InvalidArgumentError` を送出します。
+
+### キャンセル
+
+学習中は GIL が解放されるため、別スレッドから停止できます。
+
+```python
+import threading
+from litsea import CancelToken, Trainer
+
+cancel = CancelToken()
+threading.Timer(60.0, cancel.cancel).start()
+metrics = Trainer(0.01, 100_000, "features.txt").train("japanese.model", cancel=cancel)
+```
+
+キャンセルは**エラーではありません**。次のチェックポイントで停止し、部分的に学習されたモデルを保存してメトリクスを返します。バインディングはシグナルハンドラを登録しないため、Ctrl-C の扱いはアプリケーション側のままです。
+
+## エラー
+
+すべての例外は `LitseaError` を継承します。
+
+| 例外 | 発生条件 |
+|------|---------|
+| `InvalidArgumentError` | 未知の言語名、未知の feature set、使用済みトレーナ |
+| `ModelError` | ダウンロード失敗、または旧 joint POS モデル |
+| `IoError` | ファイルの読み書き失敗 |
+| `ParseError` | モデルまたは学習データの形式不正 |
+| `UnsupportedError` | このビルドでは利用できないスキームや操作 |
+| `PosUnavailableError` | 分割専用モデルに対する POS タグ付けの要求 |
+
+## スレッドと GIL
+
+`Segmenter` はイミュータブルで、スレッド間で共有できます。`segment_batch`・`segment_with_pos_batch`・`extract`・各 `train` は GIL を解放します。
+
+単文の `segment` / `segment_with_pos` は GIL を保持します。GIL を解放するには入力文字列を所有する必要があり（PyO3 の `Ungil` 境界により、GIL 解放中に Python 所有のメモリへ触れられないため）、そのコピーのコストが 1 文の分割コストを上回るからです。大量処理にはバッチ版を使ってください。
+
+## 開発
+
+```sh
+make setup-venv            # venv 作成と開発ツールのインストール
+make test-litsea-python    # cargo test + maturin develop + pytest
+make lint-litsea-python    # clippy + ruff
+make build-litsea-python   # リリース wheel を litsea-python/dist へ出力
+```
+
+パリティテストは `litsea` CLI をビルドして、その出力とバインディングの出力を突き合わせます。何が正しいかを決めるのはハードコードした期待値ではなく参照実装です。

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -53,6 +53,7 @@
 
 - [Language Bindings](bindings.md)
   - [litsea-binding-core](bindings/binding-core.md)
+  - [Python](bindings/python.md)
 
 # Training Guide
 

--- a/docs/src/bindings.md
+++ b/docs/src/bindings.md
@@ -7,7 +7,7 @@ Litsea is a Rust library, but it is also usable from other languages. The bindin
 | Crate | Target runtime | FFI stack | Status |
 |-------|----------------|-----------|--------|
 | [`litsea-binding-core`](bindings/binding-core.md) | (shared, no FFI) | — | Available |
-| `litsea-python` | Python 3.10+ | PyO3 + maturin | Planned ([#202](https://github.com/mosuka/litsea/issues/202)) |
+| [`litsea-python`](bindings/python.md) | Python 3.10+ | PyO3 + maturin | Available |
 | `litsea-nodejs` | Node.js 20+ | napi-rs | Planned ([#203](https://github.com/mosuka/litsea/issues/203)) |
 | `litsea-php` | PHP 8.1+ | ext-php-rs | Planned ([#204](https://github.com/mosuka/litsea/issues/204)) |
 | `litsea-ruby` | Ruby 3.1+ | magnus + rb-sys | Planned ([#205](https://github.com/mosuka/litsea/issues/205)) |

--- a/docs/src/bindings/binding-core.md
+++ b/docs/src/bindings/binding-core.md
@@ -43,10 +43,12 @@ use litsea_binding_core::CoreSegmenter;
 let segmenter = CoreSegmenter::from_path(Language::Japanese, "models/japanese.model".as_ref())?;
 
 assert_eq!(
-    segmenter.segment("すもももももももものうち"),
-    vec!["すもも", "も", "もも", "も", "もも", "の", "うち"]
+    segmenter.segment("これはテストです。"),
+    vec!["これ", "は", "テスト", "です", "。"]
 );
 ```
+
+For space-delimited languages the whitespace is returned as its own token, so the tokens still reconstruct the input exactly — `korean.model` splits `"안녕하세요 반갑습니다"` into `["안녕하세요", " ", "반갑습니다"]`.
 
 `CoreSegmenter` holds an `Arc<Segmenter>` plus a `Mutex<SegmentBuffer>`. `Segmenter` is `Send + Sync` and a segmenter built from a loaded model has its packed tables already compiled, so concurrent `segment` calls take only an internal read lock; the mutex protects the scratch buffer alone. One instance can therefore be shared across threads and reused indefinitely, which is what the bindings do.
 

--- a/docs/src/bindings/python.md
+++ b/docs/src/bindings/python.md
@@ -1,0 +1,130 @@
+# Python
+
+`litsea-python` exposes Litsea to Python 3.10+ through [PyO3](https://pyo3.rs) and [maturin](https://www.maturin.rs). It is published to PyPI as `litsea`.
+
+## Installation
+
+```sh
+pip install litsea
+```
+
+Wheels are built against the stable ABI (`abi3-py310`), so one wheel per platform covers every supported Python version.
+
+## Getting a model
+
+The package contains no models. Download one from the [`models/`](https://github.com/mosuka/litsea/tree/main/models) directory and pass its path — see [Pre-trained Models](../pre-trained-models.md).
+
+There is no flag to say what kind of model you have: the file identifies itself, and `has_pos` reports what the loaded model can do.
+
+## Segmentation
+
+```python
+from litsea import Language, Segmenter
+
+seg = Segmenter.open(Language.JAPANESE, "models/japanese.model")
+
+seg.segment("これはテストです。")
+# ['これ', 'は', 'テスト', 'です', '。']
+```
+
+A language name works anywhere a `Language` does — `Segmenter.open("ja", ...)` and `Segmenter.open("japanese", ...)` are equivalent.
+
+For space-delimited languages the whitespace is returned as its own token, so the tokens always reconstruct the input:
+
+```python
+Segmenter.open("ko", "models/korean.model").segment("안녕하세요 반갑습니다")
+# ['안녕하세요', ' ', '반갑습니다']
+```
+
+## POS tagging
+
+```python
+seg = Segmenter.open(Language.JAPANESE, "models/japanese_pos.model")
+
+for token in seg.segment_with_pos("これはテストです。"):
+    print(token.surface, token.pos.name, token.start, token.end)
+# これ PRON 0 6
+# は ADP 6 9
+# テスト NOUN 9 18
+# です AUX 18 24
+# 。 PUNCT 24 27
+```
+
+`start` and `end` are byte offsets into the input, so `text.encode()[token.start:token.end].decode()` returns the surface. Calling `segment_with_pos` on a segmentation-only model raises `PosUnavailableError`.
+
+## API
+
+| Call | Returns |
+|------|---------|
+| `Segmenter.open(language, path)` | A segmenter loaded from a file |
+| `Segmenter.from_bytes(language, data)` | A segmenter loaded from bytes |
+| `Segmenter.from_uri(language, uri)` | A segmenter loaded from a path, `file://`, or `http(s)://` URL |
+| `segment(text)` | `list[str]` |
+| `segment_batch(texts)` | `list[list[str]]` |
+| `segment_tokens(text)` | `list[Token]` with byte offsets |
+| `segment_with_pos(text)` | `list[Token]` with tags and offsets |
+| `segment_with_pos_batch(texts)` | `list[list[Token]]` |
+| `Extractor(language).extract(...)` | Writes a features file |
+| `Extractor(language).extract_two_stage(...)` | Writes `.stage1` / `.stage2` / `.lexicon` |
+| `Trainer(threshold, iterations, features).train(model, cancel=None)` | `BinaryMetrics` |
+| `PerceptronTrainer(epochs, features).train(model, cancel=None)` | `MulticlassMetrics` |
+| `TwoStageTrainer(epochs, prefix, dominance=0.99).train(model, cancel=None)` | `TwoStageMetrics` |
+
+`Language` and `Upos` are PyO3 classes, not `enum.Enum` subclasses: their members are class attributes, so iterate them with `Language.all()` and `Upos.all()` rather than `for x in Language`.
+
+## Training
+
+```python
+from litsea import Extractor, Language, Trainer
+
+Extractor(Language.JAPANESE).extract("corpus.txt", "features.txt")
+metrics = Trainer(0.01, 10_000, "features.txt").train("japanese.model")
+print(f"accuracy: {metrics.accuracy:.2f}%")
+```
+
+A `TwoStageTrainer` can only run once — training collapses stage 1 into an AdaBoost model, which consumes the trainer. `available` reports whether it can still be used, and a second `train()` raises `InvalidArgumentError`.
+
+### Cancelling
+
+Training releases the GIL, so another thread can stop it:
+
+```python
+import threading
+from litsea import CancelToken, Trainer
+
+cancel = CancelToken()
+threading.Timer(60.0, cancel.cancel).start()
+metrics = Trainer(0.01, 100_000, "features.txt").train("japanese.model", cancel=cancel)
+```
+
+Cancelling is **not** an error: training stops at its next check point, still writes the partially trained model, and returns its metrics. The binding never installs a signal handler, so Ctrl-C handling remains the application's.
+
+## Errors
+
+Every exception derives from `LitseaError`.
+
+| Exception | Raised when |
+|-----------|-------------|
+| `InvalidArgumentError` | Unknown language name, unknown feature set, reused trainer |
+| `ModelError` | Download failed, or the file is a legacy joint POS model |
+| `IoError` | A file could not be read or written |
+| `ParseError` | The model or training data is malformed |
+| `UnsupportedError` | The scheme or operation is unavailable in this build |
+| `PosUnavailableError` | POS tagging requested from a segmentation-only model |
+
+## Threading and the GIL
+
+A `Segmenter` is immutable and safe to share between threads. `segment_batch`, `segment_with_pos_batch`, `extract`, and every `train` release the GIL.
+
+Single-sentence `segment` and `segment_with_pos` keep it. Releasing the GIL requires owning the input string (PyO3's `Ungil` bound forbids touching Python-owned memory with the GIL released), and that copy costs more than segmenting one sentence. Use the batch methods for bulk work.
+
+## Development
+
+```sh
+make setup-venv            # create the venv and install the dev tools
+make test-litsea-python    # cargo test + maturin develop + pytest
+make lint-litsea-python    # clippy + ruff
+make build-litsea-python   # build a release wheel into litsea-python/dist
+```
+
+The parity tests build the `litsea` CLI and compare the binding's output against it, so the reference implementation — not a hardcoded expectation — decides what is correct.

--- a/litsea-python/Cargo.toml
+++ b/litsea-python/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "litsea-python"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "Python binding for Litsea."
+documentation = "https://docs.rs/litsea-python"
+homepage.workspace = true
+repository.workspace = true
+readme = "README.md"
+keywords = ["word", "segmentation", "nlp", "python", "binding"]
+categories.workspace = true
+license.workspace = true
+
+[lib]
+# The last component of `module-name` in pyproject.toml: the package is a
+# mixed layout, where `python/litsea/__init__.py` re-exports this extension.
+name = "_litsea"
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+litsea.workspace = true
+litsea-binding-core = { workspace = true, features = ["remote_model"] }
+# `extension-module` is deliberately NOT enabled here: it is passed by
+# maturin (see `[tool.maturin] features` in pyproject.toml) so that plain
+# `cargo test` / `cargo clippy` still build against a linkable interpreter.
+pyo3 = { version = "0.29.2", features = ["abi3-py310", "generate-import-lib"] }
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/litsea-python/README.md
+++ b/litsea-python/README.md
@@ -1,0 +1,156 @@
+# litsea-python
+
+Python binding for [Litsea](https://github.com/mosuka/litsea), a compact word segmentation and POS (Part-of-Speech) tagging library for Japanese, Chinese, Korean, and English.
+
+[日本語のREADME](README_ja.md)
+
+## Installation
+
+```sh
+pip install litsea
+```
+
+Wheels are built with the stable ABI (abi3) and work on CPython 3.10 and later.
+
+## Models are not bundled
+
+The package ships code only. Download a pre-trained model from the [Litsea repository](https://github.com/mosuka/litsea/tree/main/models) and point the segmenter at it:
+
+| Model | Purpose | Size |
+|-------|---------|------|
+| `japanese.model`, `chinese.model`, `korean.model`, `english.model` | Segmentation | 84 KB – 2.0 MB |
+| `japanese_pos.model`, `chinese_pos.model`, `korean_pos.model`, `english_pos.model` | Segmentation + POS | 3.0 – 8.0 MB |
+
+You never have to say which kind you have: the model file identifies itself, and `has_pos` reports what the loaded model can do.
+
+## Usage
+
+### Segmentation
+
+```python
+from litsea import Language, Segmenter
+
+seg = Segmenter.open(Language.JAPANESE, "models/japanese.model")
+
+seg.segment("これはテストです。")
+# ['これ', 'は', 'テスト', 'です', '。']
+
+seg.segment_batch(["これはテストです。", "東京都から神奈川県へ引っ越した"])
+# [['これ', 'は', 'テスト', 'です', '。'],
+#  ['東京', '都', 'から', '神奈川', '県', 'へ', '引っ越し', 'た']]
+```
+
+For space-delimited languages the whitespace comes back as its own token, so the tokens always reconstruct the input:
+
+```python
+Segmenter.open("ko", "models/korean.model").segment("안녕하세요 반갑습니다")
+# ['안녕하세요', ' ', '반갑습니다']
+```
+
+Language names work anywhere a `Language` does:
+
+```python
+Segmenter.open("ja", "models/japanese.model")
+Segmenter.open("japanese", "models/japanese.model")
+```
+
+### POS tagging
+
+```python
+from litsea import Language, Segmenter
+
+seg = Segmenter.open(Language.JAPANESE, "models/japanese_pos.model")
+seg.has_pos
+# True
+
+for token in seg.segment_with_pos("これはテストです。"):
+    print(token.surface, token.pos.name, token.start, token.end)
+# これ PRON 0 6
+# は ADP 6 9
+# テスト NOUN 9 18
+# です AUX 18 24
+# 。 PUNCT 24 27
+```
+
+`start` and `end` are byte offsets into the input, so `text.encode()[token.start:token.end].decode()` gives the surface back. They are exact for both segmentation and POS output, including for space-preserving languages such as Korean and English.
+
+Calling `segment_with_pos` on a segmentation-only model raises `PosUnavailableError`.
+
+### Other model sources
+
+```python
+Segmenter.from_bytes(Language.KOREAN, open("korean.model", "rb").read())
+Segmenter.from_uri(Language.CHINESE, "https://example.com/chinese.model")
+```
+
+### Training
+
+```python
+from litsea import CancelToken, Extractor, Language, Trainer
+
+Extractor(Language.JAPANESE).extract("corpus.txt", "features.txt")
+
+metrics = Trainer(0.01, 10_000, "features.txt").train("japanese.model")
+print(f"accuracy: {metrics.accuracy:.2f}%")
+```
+
+Two-stage (segmentation + POS) training:
+
+```python
+from litsea import Extractor, Language, TwoStageTrainer
+
+Extractor(Language.JAPANESE).extract_two_stage("corpus_pos.txt", "features", feature_set="fast")
+
+metrics = TwoStageTrainer(10, "features").train("japanese_pos.model")
+print(metrics.stage1.accuracy, metrics.stage2.accuracy)
+```
+
+A `TwoStageTrainer` can only be used once — training collapses stage 1 into an AdaBoost model, which consumes the trainer. `available` reports whether it can still run.
+
+### Cancelling a training run
+
+Training releases the GIL, so another thread can stop it:
+
+```python
+import threading
+from litsea import CancelToken, Trainer
+
+cancel = CancelToken()
+trainer = Trainer(0.01, 100_000, "features.txt")
+
+threading.Timer(60.0, cancel.cancel).start()
+metrics = trainer.train("japanese.model", cancel=cancel)
+```
+
+Cancelling is **not** an error: training stops at its next check point, still writes the partially trained model, and returns its metrics.
+
+The binding never installs a signal handler, so Ctrl-C handling stays yours.
+
+## Errors
+
+Every exception derives from `LitseaError`, so one `except` clause catches them all.
+
+| Exception | Raised when |
+|-----------|-------------|
+| `InvalidArgumentError` | Unknown language name, unknown feature set, reused trainer |
+| `ModelError` | Download failed, or the file is a legacy joint POS model |
+| `IoError` | A file could not be read or written |
+| `ParseError` | The model or training data is malformed |
+| `UnsupportedError` | The scheme or operation is unavailable in this build |
+| `PosUnavailableError` | POS tagging requested from a segmentation-only model |
+
+## Threading
+
+A `Segmenter` is immutable and safe to share between threads. `segment_batch`, `segment_with_pos_batch`, `extract`, and every `train` release the GIL. Single-sentence `segment` and `segment_with_pos` keep it: releasing would require copying the input string, which costs more than segmenting one sentence.
+
+## Development
+
+```sh
+make setup-venv            # create the venv and install the dev tools
+make test-litsea-python    # cargo test + maturin develop + pytest
+make build-litsea-python   # build a release wheel
+```
+
+## License
+
+MIT. See [LICENSE](../LICENSE).

--- a/litsea-python/README_ja.md
+++ b/litsea-python/README_ja.md
@@ -1,0 +1,156 @@
+# litsea-python
+
+[Litsea](https://github.com/mosuka/litsea) の Python バインディングです。Litsea は日本語・中国語・韓国語・英語に対応した、コンパクトな単語分割と品詞（POS）タグ付けのライブラリです。
+
+[English README](README.md)
+
+## インストール
+
+```sh
+pip install litsea
+```
+
+wheel は安定 ABI（abi3）でビルドされており、CPython 3.10 以降で動作します。
+
+## モデルは同梱されません
+
+このパッケージにはコードのみが含まれます。事前学習済みモデルは [Litsea リポジトリ](https://github.com/mosuka/litsea/tree/main/models)から取得し、パスを指定して読み込んでください。
+
+| モデル | 用途 | サイズ |
+|-------|------|-------|
+| `japanese.model`, `chinese.model`, `korean.model`, `english.model` | 分割 | 84KB〜2.0MB |
+| `japanese_pos.model`, `chinese_pos.model`, `korean_pos.model`, `english_pos.model` | 分割 + POS | 3.0〜8.0MB |
+
+どちらの種別かを指定する必要はありません。モデルファイル自身が種別を持っており、読み込んだモデルで何ができるかは `has_pos` が示します。
+
+## 使い方
+
+### 分割
+
+```python
+from litsea import Language, Segmenter
+
+seg = Segmenter.open(Language.JAPANESE, "models/japanese.model")
+
+seg.segment("これはテストです。")
+# ['これ', 'は', 'テスト', 'です', '。']
+
+seg.segment_batch(["これはテストです。", "東京都から神奈川県へ引っ越した"])
+# [['これ', 'は', 'テスト', 'です', '。'],
+#  ['東京', '都', 'から', '神奈川', '県', 'へ', '引っ越し', 'た']]
+```
+
+空白区切りの言語では空白自体が 1 トークンとして返るため、トークンを連結すると常に入力が復元されます。
+
+```python
+Segmenter.open("ko", "models/korean.model").segment("안녕하세요 반갑습니다")
+# ['안녕하세요', ' ', '반갑습니다']
+```
+
+`Language` を受け取る箇所では言語名の文字列も使えます。
+
+```python
+Segmenter.open("ja", "models/japanese.model")
+Segmenter.open("japanese", "models/japanese.model")
+```
+
+### POS タグ付け
+
+```python
+from litsea import Language, Segmenter
+
+seg = Segmenter.open(Language.JAPANESE, "models/japanese_pos.model")
+seg.has_pos
+# True
+
+for token in seg.segment_with_pos("これはテストです。"):
+    print(token.surface, token.pos.name, token.start, token.end)
+# これ PRON 0 6
+# は ADP 6 9
+# テスト NOUN 9 18
+# です AUX 18 24
+# 。 PUNCT 24 27
+```
+
+`start` と `end` は入力文字列に対するバイトオフセットです。`text.encode()[token.start:token.end].decode()` で表層形が復元できます。分割・POS のどちらの出力でも正確で、空白を保持する韓国語・英語でも同様です。
+
+分割専用モデルに対して `segment_with_pos` を呼ぶと `PosUnavailableError` が送出されます。
+
+### その他のモデル読み込み方法
+
+```python
+Segmenter.from_bytes(Language.KOREAN, open("korean.model", "rb").read())
+Segmenter.from_uri(Language.CHINESE, "https://example.com/chinese.model")
+```
+
+### 学習
+
+```python
+from litsea import Extractor, Language, Trainer
+
+Extractor(Language.JAPANESE).extract("corpus.txt", "features.txt")
+
+metrics = Trainer(0.01, 10_000, "features.txt").train("japanese.model")
+print(f"accuracy: {metrics.accuracy:.2f}%")
+```
+
+二段構成（分割 + POS）の学習:
+
+```python
+from litsea import Extractor, Language, TwoStageTrainer
+
+Extractor(Language.JAPANESE).extract_two_stage("corpus_pos.txt", "features", feature_set="fast")
+
+metrics = TwoStageTrainer(10, "features").train("japanese_pos.model")
+print(metrics.stage1.accuracy, metrics.stage2.accuracy)
+```
+
+`TwoStageTrainer` は 1 度しか使えません。学習時に stage 1 が AdaBoost モデルへ collapse され、トレーナが消費されるためです。再利用可能かどうかは `available` で確認できます。
+
+### 学習のキャンセル
+
+学習中は GIL が解放されるため、別スレッドから停止できます。
+
+```python
+import threading
+from litsea import CancelToken, Trainer
+
+cancel = CancelToken()
+trainer = Trainer(0.01, 100_000, "features.txt")
+
+threading.Timer(60.0, cancel.cancel).start()
+metrics = trainer.train("japanese.model", cancel=cancel)
+```
+
+キャンセルは**エラーではありません**。次のチェックポイントで停止し、部分的に学習されたモデルを保存してメトリクスを返します。
+
+バインディング側でシグナルハンドラを登録することはないため、Ctrl-C の扱いはアプリケーション側の裁量のままです。
+
+## エラー
+
+すべての例外は `LitseaError` を継承するため、1 つの `except` で捕捉できます。
+
+| 例外 | 発生条件 |
+|------|---------|
+| `InvalidArgumentError` | 未知の言語名、未知の feature set、使用済みトレーナ |
+| `ModelError` | ダウンロード失敗、または旧 joint POS モデル |
+| `IoError` | ファイルの読み書き失敗 |
+| `ParseError` | モデルまたは学習データの形式不正 |
+| `UnsupportedError` | このビルドでは利用できないスキームや操作 |
+| `PosUnavailableError` | 分割専用モデルに対する POS タグ付けの要求 |
+
+## スレッド
+
+`Segmenter` はイミュータブルで、スレッド間で共有できます。`segment_batch`・`segment_with_pos_batch`・`extract`・各 `train` は GIL を解放します。単文の `segment` / `segment_with_pos` は GIL を保持します。解放するには入力文字列のコピーが必要で、そのコストが 1 文の分割コストを上回るためです。
+
+## 開発
+
+```sh
+make setup-venv            # venv 作成と開発ツールのインストール
+make test-litsea-python    # cargo test + maturin develop + pytest
+make build-litsea-python   # リリース wheel のビルド
+```
+
+## ライセンス
+
+MIT。[LICENSE](../LICENSE) を参照してください。

--- a/litsea-python/examples/segment.py
+++ b/litsea-python/examples/segment.py
@@ -1,0 +1,43 @@
+"""Segment a sentence, with and without POS tags.
+
+Usage:
+    python examples/segment.py ../models/japanese.model "これはテストです。"
+    python examples/segment.py ../models/japanese_pos.model "これはテストです。"
+"""
+
+from __future__ import annotations
+
+import sys
+
+from litsea import Segmenter
+
+
+def main() -> int:
+    """Run the example.
+
+    Returns:
+        0 on success, 2 when the arguments are wrong.
+    """
+    if len(sys.argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    model_path, text = sys.argv[1], sys.argv[2]
+
+    # The model file identifies its own kind, so nothing here says "this is
+    # a POS model" - `has_pos` reports what was loaded.
+    segmenter = Segmenter.open("japanese", model_path)
+    print(f"model: {model_path} (has_pos={segmenter.has_pos})")
+
+    print("tokens:", " ".join(segmenter.segment(text)))
+
+    if segmenter.has_pos:
+        print("tagged:")
+        for token in segmenter.segment_with_pos(text):
+            print(f"  {token.surface}\t{token.pos.name}\t[{token.start}:{token.end}]")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/litsea-python/examples/train.py
+++ b/litsea-python/examples/train.py
@@ -1,0 +1,63 @@
+"""Train a segmentation model, cancelling it from another thread.
+
+Usage:
+    python examples/train.py corpus.txt out.model
+
+The corpus is one sentence per line, with words separated by spaces:
+
+    これ は テスト です 。
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import threading
+from pathlib import Path
+
+from litsea import CancelToken, Extractor, Language, Trainer
+
+
+def main() -> int:
+    """Run the example.
+
+    Returns:
+        0 on success, 2 when the arguments are wrong.
+    """
+    if len(sys.argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    corpus, model = Path(sys.argv[1]), Path(sys.argv[2])
+
+    with tempfile.TemporaryDirectory() as tmp:
+        features = Path(tmp) / "features.txt"
+
+        print(f"extracting features from {corpus} ...")
+        Extractor(Language.JAPANESE).extract(corpus, features)
+
+        # Training releases the GIL, so a timer thread can stop it. Cancelling
+        # is not an error: the partially trained model is still written.
+        cancel = CancelToken()
+        timer = threading.Timer(60.0, cancel.cancel)
+        timer.start()
+
+        print("training (will stop after 60s if it has not converged) ...")
+        try:
+            metrics = Trainer(0.01, 10_000, features).train(model, cancel=cancel)
+        finally:
+            timer.cancel()
+
+    print(f"wrote {model}")
+    print(f"  accuracy:  {metrics.accuracy:.2f}%")
+    print(f"  precision: {metrics.precision:.2f}%")
+    print(f"  recall:    {metrics.recall:.2f}%")
+    print(f"  instances: {metrics.num_instances}")
+    if cancel.cancelled:
+        print("  (training was cancelled; the model is partially trained)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/litsea-python/pyproject.toml
+++ b/litsea-python/pyproject.toml
@@ -1,0 +1,48 @@
+[build-system]
+requires = ["maturin>=1.7,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "litsea"
+description = "Python binding for Litsea, a compact word segmentation and POS tagging library (no embedded models)"
+authors = [{ name = "Minoru Osuka", email = "minoru.osuka@gmail.com" }]
+license = { text = "MIT" }
+readme = "README.md"
+keywords = ["word", "segmentation", "pos", "tagging", "nlp"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Rust",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Topic :: Text Processing :: Linguistic",
+]
+requires-python = ">=3.10"
+dynamic = ["version"]
+
+[project.urls]
+Homepage = "https://github.com/mosuka/litsea"
+Repository = "https://github.com/mosuka/litsea"
+Documentation = "https://mosuka.github.io/litsea/"
+
+[tool.maturin]
+# Mixed layout: the compiled extension is `litsea._litsea`, and the Python
+# package in `python/litsea` re-exports it alongside the type stubs.
+module-name = "litsea._litsea"
+python-source = "python"
+# `extension-module` is passed here rather than declared in Cargo.toml, so
+# plain `cargo test` still links against an interpreter.
+features = ["pyo3/extension-module"]
+
+[dependency-groups]
+dev = ["maturin>=1.7,<2.0", "pytest>=8.0", "mypy>=1.10", "ruff>=0.6"]
+
+[tool.ruff]
+line-length = 119
+
+[tool.mypy]
+python_version = "3.10"
+strict = true

--- a/litsea-python/python/litsea/__init__.py
+++ b/litsea-python/python/litsea/__init__.py
@@ -1,0 +1,62 @@
+"""Python binding for Litsea, a compact word segmentation and POS tagging library.
+
+Models are not bundled with this package; download one from the Litsea
+repository and load it by path, bytes, or URL::
+
+    from litsea import Segmenter, Language
+
+    seg = Segmenter.open(Language.JAPANESE, "models/japanese.model")
+    seg.segment("すもももももももものうち")
+
+The kind of model is detected from the file, so loading a ``*_pos.model``
+gives a segmenter whose ``has_pos`` is ``True`` and whose
+``segment_with_pos`` works.
+"""
+
+from ._litsea import (
+    BinaryMetrics,
+    CancelToken,
+    Extractor,
+    InvalidArgumentError,
+    IoError,
+    Language,
+    LitseaError,
+    ModelError,
+    MulticlassMetrics,
+    ParseError,
+    PerceptronTrainer,
+    PosUnavailableError,
+    Segmenter,
+    Token,
+    Trainer,
+    TwoStageMetrics,
+    TwoStageTrainer,
+    UnsupportedError,
+    Upos,
+    __version__,
+    version,
+)
+
+__all__ = [
+    "BinaryMetrics",
+    "CancelToken",
+    "Extractor",
+    "InvalidArgumentError",
+    "IoError",
+    "Language",
+    "LitseaError",
+    "ModelError",
+    "MulticlassMetrics",
+    "ParseError",
+    "PerceptronTrainer",
+    "PosUnavailableError",
+    "Segmenter",
+    "Token",
+    "Trainer",
+    "TwoStageMetrics",
+    "TwoStageTrainer",
+    "UnsupportedError",
+    "Upos",
+    "__version__",
+    "version",
+]

--- a/litsea-python/python/litsea/_litsea.pyi
+++ b/litsea-python/python/litsea/_litsea.pyi
@@ -1,0 +1,278 @@
+"""Type stubs for the compiled `litsea._litsea` extension module."""
+
+import os
+from collections.abc import Mapping, Sequence
+from typing import ClassVar, TypeAlias
+
+__version__: str
+
+def version() -> str:
+    """Return the version of the underlying ``litsea`` crate."""
+
+class Language:
+    """A language supported by Litsea's models.
+
+    Anywhere a ``Language`` is accepted, its name works too (``"japanese"``
+    or ``"ja"``, case-insensitive).
+
+    This is a PyO3 class rather than a :class:`enum.Enum`: the members are
+    class attributes, so ``for language in Language`` does not work. Use
+    :meth:`Language.all` to enumerate them. ``str(language)`` returns the
+    canonical name.
+    """
+
+    JAPANESE: ClassVar[Language]
+    CHINESE: ClassVar[Language]
+    KOREAN: ClassVar[Language]
+    ENGLISH: ClassVar[Language]
+
+    @property
+    def name(self) -> str:
+        """The canonical lowercase name, for example ``"japanese"``."""
+
+    @staticmethod
+    def parse(name: str) -> Language:
+        """Parse a language name or ISO 639-1 code."""
+
+    @staticmethod
+    def all() -> list[Language]:
+        """Return every supported language."""
+
+    def __eq__(self, other: object) -> bool: ...
+    def __hash__(self) -> int: ...
+
+class Upos:
+    """A Universal POS tag.
+
+    Like :class:`Language`, this is a PyO3 class rather than a
+    :class:`enum.Enum`; use :meth:`Upos.all` to enumerate the tags.
+    ``str(tag)`` returns the tag name.
+    """
+
+    ADJ: ClassVar[Upos]
+    ADP: ClassVar[Upos]
+    ADV: ClassVar[Upos]
+    AUX: ClassVar[Upos]
+    CCONJ: ClassVar[Upos]
+    DET: ClassVar[Upos]
+    INTJ: ClassVar[Upos]
+    NOUN: ClassVar[Upos]
+    NUM: ClassVar[Upos]
+    PART: ClassVar[Upos]
+    PRON: ClassVar[Upos]
+    PROPN: ClassVar[Upos]
+    PUNCT: ClassVar[Upos]
+    SCONJ: ClassVar[Upos]
+    SYM: ClassVar[Upos]
+    VERB: ClassVar[Upos]
+    X: ClassVar[Upos]
+
+    @property
+    def name(self) -> str:
+        """The tag name, for example ``"NOUN"``."""
+
+    @staticmethod
+    def all() -> list[Upos]:
+        """Return all 17 tags, in UD order."""
+
+    def __eq__(self, other: object) -> bool: ...
+    def __hash__(self) -> int: ...
+
+class Token:
+    """A segmented token.
+
+    ``start`` and ``end`` are byte offsets into the input string.
+    """
+
+    @property
+    def surface(self) -> str: ...
+    @property
+    def pos(self) -> Upos | None: ...
+    @property
+    def start(self) -> int: ...
+    @property
+    def end(self) -> int: ...
+
+LanguageArg: TypeAlias = Language | str
+
+class Segmenter:
+    """A word segmenter, optionally with POS tagging."""
+
+    @staticmethod
+    def open(language: LanguageArg, path: str | os.PathLike[str]) -> Segmenter:
+        """Load a model from a filesystem path."""
+
+    @staticmethod
+    def from_bytes(language: LanguageArg, data: bytes) -> Segmenter:
+        """Load a model from raw bytes."""
+
+    @staticmethod
+    def from_uri(language: LanguageArg, uri: str) -> Segmenter:
+        """Load a model from a path, ``file://`` path, or ``http(s)://`` URL."""
+
+    @property
+    def language(self) -> Language: ...
+    @property
+    def has_pos(self) -> bool: ...
+    def segment(self, text: str) -> list[str]:
+        """Split a sentence into tokens."""
+
+    def segment_batch(self, texts: Sequence[str]) -> list[list[str]]:
+        """Split several sentences into tokens, releasing the GIL."""
+
+    def segment_tokens(self, text: str) -> list[Token]:
+        """Split a sentence into tokens carrying byte offsets."""
+
+    def segment_with_pos(self, text: str) -> list[Token]:
+        """Split a sentence into tokens and tag each with a UPOS tag."""
+
+    def segment_with_pos_batch(self, texts: Sequence[str]) -> list[list[Token]]:
+        """Split and tag several sentences, releasing the GIL."""
+
+class CancelToken:
+    """A flag that asks a running training job to stop."""
+
+    def __init__(self) -> None: ...
+    def cancel(self) -> None: ...
+    def reset(self) -> None: ...
+    @property
+    def cancelled(self) -> bool: ...
+
+class BinaryMetrics:
+    """Metrics from training a binary (segmentation) model."""
+
+    @property
+    def accuracy(self) -> float: ...
+    @property
+    def precision(self) -> float: ...
+    @property
+    def recall(self) -> float: ...
+    @property
+    def num_instances(self) -> int: ...
+    @property
+    def true_positives(self) -> int: ...
+    @property
+    def false_positives(self) -> int: ...
+    @property
+    def false_negatives(self) -> int: ...
+    @property
+    def true_negatives(self) -> int: ...
+
+class MulticlassMetrics:
+    """Metrics from training a multiclass model."""
+
+    @property
+    def accuracy(self) -> float: ...
+    @property
+    def macro_precision(self) -> float: ...
+    @property
+    def macro_recall(self) -> float: ...
+    @property
+    def num_instances(self) -> int: ...
+    @property
+    def correct_per_class(self) -> Mapping[str, int]: ...
+    @property
+    def predicted_per_class(self) -> Mapping[str, int]: ...
+    @property
+    def gold_per_class(self) -> Mapping[str, int]: ...
+
+class TwoStageMetrics:
+    """Metrics from training a two-stage model."""
+
+    @property
+    def stage1(self) -> MulticlassMetrics: ...
+    @property
+    def stage2(self) -> MulticlassMetrics: ...
+
+class Extractor:
+    """Extracts training features from a corpus."""
+
+    def __init__(self, language: LanguageArg) -> None: ...
+    def extract(
+        self,
+        corpus_path: str | os.PathLike[str],
+        features_path: str | os.PathLike[str],
+        *,
+        tsv: bool = False,
+        tag_free: bool = False,
+    ) -> None: ...
+    def extract_two_stage(
+        self,
+        corpus_path: str | os.PathLike[str],
+        output_prefix: str | os.PathLike[str],
+        *,
+        feature_set: str = "fast",
+        tsv: bool = False,
+    ) -> None: ...
+
+class Trainer:
+    """Trains a segmentation model."""
+
+    def __init__(
+        self,
+        threshold: float,
+        num_iterations: int,
+        features_path: str | os.PathLike[str],
+    ) -> None: ...
+    def load_model(self, model_uri: str) -> None: ...
+    def train(
+        self,
+        model_path: str | os.PathLike[str],
+        *,
+        cancel: CancelToken | None = None,
+    ) -> BinaryMetrics: ...
+
+class PerceptronTrainer:
+    """Trains a label-agnostic Averaged Perceptron model."""
+
+    def __init__(self, num_epochs: int, features_path: str | os.PathLike[str]) -> None: ...
+    def load_model(self, model_uri: str) -> None: ...
+    def train(
+        self,
+        model_path: str | os.PathLike[str],
+        *,
+        cancel: CancelToken | None = None,
+    ) -> MulticlassMetrics: ...
+
+class TwoStageTrainer:
+    """Trains a two-stage segmentation + POS model.
+
+    A trainer can only be used once; check ``available`` before reusing one.
+    """
+
+    def __init__(
+        self,
+        num_epochs: int,
+        features_prefix: str | os.PathLike[str],
+        *,
+        dominance: float = 0.99,
+    ) -> None: ...
+    @property
+    def available(self) -> bool: ...
+    def train(
+        self,
+        model_path: str | os.PathLike[str],
+        *,
+        cancel: CancelToken | None = None,
+    ) -> TwoStageMetrics: ...
+
+class LitseaError(Exception):
+    """Base class for every error raised by litsea."""
+
+class InvalidArgumentError(LitseaError):
+    """An argument was invalid, such as an unknown language name."""
+
+class ModelError(LitseaError):
+    """A model could not be obtained, or is not the kind the call needs."""
+
+class IoError(LitseaError):
+    """A file could not be read or written."""
+
+class ParseError(LitseaError):
+    """A model or training data file is malformed."""
+
+class UnsupportedError(LitseaError):
+    """The operation is not supported in this build or environment."""
+
+class PosUnavailableError(LitseaError):
+    """POS tagging was requested from a segmentation-only model."""

--- a/litsea-python/src/error.rs
+++ b/litsea-python/src/error.rs
@@ -1,0 +1,97 @@
+//! Exception hierarchy exposed to Python.
+//!
+//! `litsea_binding_core::ErrorKind` already categorizes every failure, so
+//! this module is a one-to-one mapping from those categories onto Python
+//! exception classes. Every class derives from `LitseaError`, so
+//! `except LitseaError` catches everything the binding can raise; no class
+//! also inherits from a builtin (single inheritance keeps that guarantee
+//! simple to reason about).
+
+use litsea_binding_core::{CoreError, ErrorKind};
+use pyo3::create_exception;
+use pyo3::exceptions::PyException;
+use pyo3::prelude::*;
+
+create_exception!(litsea, LitseaError, PyException, "Base class for every error raised by litsea.");
+create_exception!(
+    litsea,
+    InvalidArgumentError,
+    LitseaError,
+    "An argument was invalid, such as an unknown language name."
+);
+create_exception!(
+    litsea,
+    ModelError,
+    LitseaError,
+    "A model could not be obtained, or is not the kind the call needs."
+);
+create_exception!(litsea, IoError, LitseaError, "A file could not be read or written.");
+create_exception!(litsea, ParseError, LitseaError, "A model or training data file is malformed.");
+create_exception!(
+    litsea,
+    UnsupportedError,
+    LitseaError,
+    "The operation is not supported in this build or environment."
+);
+create_exception!(
+    litsea,
+    PosUnavailableError,
+    LitseaError,
+    "POS tagging was requested from a segmentation-only model."
+);
+
+/// Converts a [`CoreError`] into the matching Python exception.
+///
+/// # Arguments
+/// * `error` - The error to convert.
+///
+/// # Returns
+/// A [`PyErr`] of the class matching the error's kind;
+/// [`ErrorKind::Runtime`] maps to the `LitseaError` base class.
+pub fn to_py_err(error: CoreError) -> PyErr {
+    let message = error.message().to_string();
+    match error.kind() {
+        ErrorKind::InvalidArgument => InvalidArgumentError::new_err(message),
+        ErrorKind::Model => ModelError::new_err(message),
+        ErrorKind::Io => IoError::new_err(message),
+        ErrorKind::Parse => ParseError::new_err(message),
+        ErrorKind::Unsupported => UnsupportedError::new_err(message),
+        ErrorKind::PosUnavailable => PosUnavailableError::new_err(message),
+        ErrorKind::Runtime => LitseaError::new_err(message),
+    }
+}
+
+/// Result alias for binding methods.
+pub type PyLitseaResult<T> = Result<T, PyErr>;
+
+/// Converts a [`CoreError`] result into a Python result.
+///
+/// # Arguments
+/// * `result` - The result to convert.
+///
+/// # Returns
+/// The original value, or the mapped Python exception.
+pub fn map_err<T>(result: Result<T, CoreError>) -> PyLitseaResult<T> {
+    result.map_err(to_py_err)
+}
+
+/// Registers the exception classes on the extension module.
+///
+/// # Arguments
+/// * `m` - The module to register the classes on.
+///
+/// # Returns
+/// `()` on success.
+///
+/// # Errors
+/// Returns a [`PyErr`] if a class cannot be added to the module.
+pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("LitseaError", m.py().get_type::<LitseaError>())?;
+    m.add("InvalidArgumentError", m.py().get_type::<InvalidArgumentError>())?;
+    m.add("ModelError", m.py().get_type::<ModelError>())?;
+    m.add("IoError", m.py().get_type::<IoError>())?;
+    m.add("ParseError", m.py().get_type::<ParseError>())?;
+    m.add("UnsupportedError", m.py().get_type::<UnsupportedError>())?;
+    m.add("PosUnavailableError", m.py().get_type::<PosUnavailableError>())?;
+    Ok(())
+}

--- a/litsea-python/src/language.rs
+++ b/litsea-python/src/language.rs
@@ -1,0 +1,172 @@
+//! The `Language` enum and string coercion.
+
+use litsea::Language;
+use litsea_binding_core::{SUPPORTED_LANGUAGES, parse_language};
+use pyo3::prelude::*;
+
+use crate::error::map_err;
+
+/// A language supported by Litsea's models.
+///
+/// Exposed to Python as `litsea.Language`, with the members `JAPANESE`,
+/// `CHINESE`, `KOREAN`, and `ENGLISH`. Anywhere a `Language` is accepted,
+/// the equivalent string works too (`"japanese"` or `"ja"`, case-insensitive).
+// `eq_int` is deliberately not enabled: it would make `Language.JAPANESE == 0`
+// true, which surprises callers who never see the discriminants.
+#[pyclass(name = "Language", eq, frozen, hash, from_py_object, module = "litsea")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PyLanguage {
+    /// Japanese.
+    #[pyo3(name = "JAPANESE")]
+    Japanese,
+    /// Chinese (Simplified and Traditional).
+    #[pyo3(name = "CHINESE")]
+    Chinese,
+    /// Korean.
+    #[pyo3(name = "KOREAN")]
+    Korean,
+    /// English.
+    #[pyo3(name = "ENGLISH")]
+    English,
+}
+
+#[pymethods]
+impl PyLanguage {
+    /// Returns the canonical lowercase name, for example `"japanese"`.
+    ///
+    /// # Returns
+    /// The canonical name of this language.
+    #[getter]
+    fn name(&self) -> String {
+        Language::from(*self).to_string()
+    }
+
+    /// Parses a language name or ISO 639-1 code.
+    ///
+    /// # Arguments
+    /// * `name` - `"japanese"` or `"ja"` (case-insensitive), and likewise
+    ///   for the other languages.
+    ///
+    /// # Returns
+    /// The matching [`PyLanguage`].
+    ///
+    /// # Errors
+    /// Raises `InvalidArgumentError` if the name is not recognized.
+    #[staticmethod]
+    fn parse(name: &str) -> PyResult<Self> {
+        Ok(Self::from(map_err(parse_language(name))?))
+    }
+
+    /// Returns every supported language.
+    ///
+    /// # Returns
+    /// The supported languages, in documentation order.
+    #[staticmethod]
+    fn all() -> Vec<Self> {
+        SUPPORTED_LANGUAGES.into_iter().map(Self::from).collect()
+    }
+
+    /// Returns the canonical lowercase name.
+    ///
+    /// # Returns
+    /// The same value as the `name` property.
+    fn __str__(&self) -> String {
+        self.name()
+    }
+}
+
+impl From<PyLanguage> for Language {
+    /// Converts the Python-facing enum into `litsea`'s enum.
+    ///
+    /// # Arguments
+    /// * `language` - The Python-facing language.
+    ///
+    /// # Returns
+    /// The corresponding [`Language`].
+    fn from(language: PyLanguage) -> Self {
+        match language {
+            PyLanguage::Japanese => Language::Japanese,
+            PyLanguage::Chinese => Language::Chinese,
+            PyLanguage::Korean => Language::Korean,
+            PyLanguage::English => Language::English,
+        }
+    }
+}
+
+impl From<Language> for PyLanguage {
+    /// Converts `litsea`'s enum into the Python-facing enum.
+    ///
+    /// [`Language`] is `#[non_exhaustive]`, so a language added upstream
+    /// without a member here falls back to Japanese, `litsea`'s own default.
+    /// `test_every_supported_language_has_a_member` fails first if that ever
+    /// happens.
+    ///
+    /// # Arguments
+    /// * `language` - The `litsea` language.
+    ///
+    /// # Returns
+    /// The corresponding [`PyLanguage`].
+    fn from(language: Language) -> Self {
+        match language {
+            Language::Japanese => PyLanguage::Japanese,
+            Language::Chinese => PyLanguage::Chinese,
+            Language::Korean => PyLanguage::Korean,
+            Language::English => PyLanguage::English,
+            _ => PyLanguage::Japanese,
+        }
+    }
+}
+
+/// A language argument: either a `Language` member or its name as a string.
+///
+/// Lets `Segmenter.open(Language.JAPANESE, ...)` and
+/// `Segmenter.open("ja", ...)` both work.
+#[derive(FromPyObject)]
+pub enum LanguageArg {
+    /// A `litsea.Language` member.
+    Enum(PyLanguage),
+    /// A language name or ISO 639-1 code.
+    Name(String),
+}
+
+impl LanguageArg {
+    /// Resolves the argument to a `litsea` language.
+    ///
+    /// # Returns
+    /// The resolved [`Language`].
+    ///
+    /// # Errors
+    /// Raises `InvalidArgumentError` if a string does not name a supported
+    /// language.
+    pub fn resolve(&self) -> PyResult<Language> {
+        match self {
+            LanguageArg::Enum(language) => Ok(Language::from(*language)),
+            LanguageArg::Name(name) => map_err(parse_language(name)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_every_supported_language_has_a_member() {
+        for language in SUPPORTED_LANGUAGES {
+            let member = PyLanguage::from(language);
+            assert_eq!(
+                Language::from(member),
+                language,
+                "{language} does not round-trip through PyLanguage; add a member for it"
+            );
+        }
+    }
+
+    #[test]
+    fn test_names_round_trip() {
+        for language in SUPPORTED_LANGUAGES {
+            let member = PyLanguage::from(language);
+            assert_eq!(member.name(), language.to_string());
+        }
+    }
+}

--- a/litsea-python/src/lib.rs
+++ b/litsea-python/src/lib.rs
@@ -1,0 +1,75 @@
+//! Python binding for Litsea.
+//!
+//! The compiled extension is `litsea._litsea`; the public surface is
+//! re-exported from `python/litsea/__init__.py`, which also carries the type
+//! stubs. Everything FFI-independent lives in `litsea-binding-core`, so this
+//! crate only maps that surface onto Python types, exceptions, and GIL
+//! behaviour.
+//!
+//! ```python
+//! from litsea import Segmenter, Language
+//!
+//! seg = Segmenter.open(Language.JAPANESE, "models/japanese.model")
+//! seg.segment("すもももももももものうち")
+//! ```
+
+pub mod error;
+pub mod language;
+pub mod metrics;
+pub mod segmenter;
+pub mod trainer;
+pub mod upos;
+
+use pyo3::prelude::*;
+
+/// Returns the version of the underlying `litsea` crate.
+///
+/// # Returns
+/// The version string, for example `"0.12.0"`.
+#[pyfunction]
+fn version() -> &'static str {
+    litsea::version()
+}
+
+/// Initializes the `litsea._litsea` extension module.
+///
+/// # Arguments
+/// * `m` - The module being initialized.
+///
+/// # Returns
+/// `()` on success.
+///
+/// # Errors
+/// Returns a [`PyErr`] if a class or function cannot be registered.
+#[pymodule]
+fn _litsea(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add("__version__", litsea::version())?;
+    m.add_function(wrap_pyfunction!(version, m)?)?;
+
+    m.add_class::<language::PyLanguage>()?;
+    m.add_class::<upos::PyUpos>()?;
+    m.add_class::<upos::PyToken>()?;
+    m.add_class::<segmenter::PySegmenter>()?;
+    m.add_class::<trainer::PyCancelToken>()?;
+    m.add_class::<trainer::PyExtractor>()?;
+    m.add_class::<trainer::PyTrainer>()?;
+    m.add_class::<trainer::PyPerceptronTrainer>()?;
+    m.add_class::<trainer::PyTwoStageTrainer>()?;
+    m.add_class::<metrics::PyBinaryMetrics>()?;
+    m.add_class::<metrics::PyMulticlassMetrics>()?;
+    m.add_class::<metrics::PyTwoStageMetrics>()?;
+
+    error::register(m)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_version_matches_litsea() {
+        assert_eq!(version(), litsea::version());
+    }
+}

--- a/litsea-python/src/metrics.rs
+++ b/litsea-python/src/metrics.rs
@@ -1,0 +1,192 @@
+//! Training metric classes.
+
+use std::collections::HashMap;
+
+use litsea::{BinaryMetrics, MulticlassMetrics, TwoStageMetrics};
+use pyo3::prelude::*;
+
+/// Metrics from training a binary (segmentation) model.
+///
+/// All percentages are 0-100.
+#[pyclass(name = "BinaryMetrics", frozen, skip_from_py_object, module = "litsea")]
+#[derive(Debug, Clone)]
+pub struct PyBinaryMetrics {
+    /// Accuracy, as a percentage.
+    #[pyo3(get)]
+    accuracy: f64,
+    /// Precision, as a percentage.
+    #[pyo3(get)]
+    precision: f64,
+    /// Recall, as a percentage.
+    #[pyo3(get)]
+    recall: f64,
+    /// Number of training instances.
+    #[pyo3(get)]
+    num_instances: usize,
+    /// True positives.
+    #[pyo3(get)]
+    true_positives: usize,
+    /// False positives.
+    #[pyo3(get)]
+    false_positives: usize,
+    /// False negatives.
+    #[pyo3(get)]
+    false_negatives: usize,
+    /// True negatives.
+    #[pyo3(get)]
+    true_negatives: usize,
+}
+
+#[pymethods]
+impl PyBinaryMetrics {
+    /// Returns a readable representation.
+    ///
+    /// # Returns
+    /// For example `BinaryMetrics(accuracy=99.12%, instances=1234)`.
+    fn __repr__(&self) -> String {
+        format!(
+            "BinaryMetrics(accuracy={:.2}%, precision={:.2}%, recall={:.2}%, instances={})",
+            self.accuracy, self.precision, self.recall, self.num_instances
+        )
+    }
+}
+
+impl From<BinaryMetrics> for PyBinaryMetrics {
+    /// Converts `litsea`'s metrics into the Python-facing class.
+    ///
+    /// # Arguments
+    /// * `metrics` - The metrics to convert.
+    ///
+    /// # Returns
+    /// The corresponding [`PyBinaryMetrics`].
+    fn from(metrics: BinaryMetrics) -> Self {
+        Self {
+            accuracy: metrics.accuracy,
+            precision: metrics.precision,
+            recall: metrics.recall,
+            num_instances: metrics.num_instances,
+            true_positives: metrics.true_positives,
+            false_positives: metrics.false_positives,
+            false_negatives: metrics.false_negatives,
+            true_negatives: metrics.true_negatives,
+        }
+    }
+}
+
+/// Metrics from training a multiclass model.
+///
+/// All percentages are 0-100. The per-class counts are dictionaries keyed by
+/// the label name.
+#[pyclass(
+    name = "MulticlassMetrics",
+    frozen,
+    skip_from_py_object,
+    module = "litsea"
+)]
+#[derive(Debug, Clone)]
+pub struct PyMulticlassMetrics {
+    /// Accuracy, as a percentage.
+    #[pyo3(get)]
+    accuracy: f64,
+    /// Macro-averaged precision, as a percentage.
+    #[pyo3(get)]
+    macro_precision: f64,
+    /// Macro-averaged recall, as a percentage.
+    #[pyo3(get)]
+    macro_recall: f64,
+    /// Number of training instances.
+    #[pyo3(get)]
+    num_instances: usize,
+    /// Correct predictions per class.
+    #[pyo3(get)]
+    correct_per_class: HashMap<String, usize>,
+    /// Predictions made per class.
+    #[pyo3(get)]
+    predicted_per_class: HashMap<String, usize>,
+    /// Gold instances per class.
+    #[pyo3(get)]
+    gold_per_class: HashMap<String, usize>,
+}
+
+#[pymethods]
+impl PyMulticlassMetrics {
+    /// Returns a readable representation.
+    ///
+    /// # Returns
+    /// For example `MulticlassMetrics(accuracy=96.78%, instances=1234)`.
+    fn __repr__(&self) -> String {
+        format!(
+            "MulticlassMetrics(accuracy={:.2}%, macro_precision={:.2}%, macro_recall={:.2}%, instances={})",
+            self.accuracy, self.macro_precision, self.macro_recall, self.num_instances
+        )
+    }
+}
+
+impl From<MulticlassMetrics> for PyMulticlassMetrics {
+    /// Converts `litsea`'s metrics into the Python-facing class.
+    ///
+    /// # Arguments
+    /// * `metrics` - The metrics to convert.
+    ///
+    /// # Returns
+    /// The corresponding [`PyMulticlassMetrics`].
+    fn from(metrics: MulticlassMetrics) -> Self {
+        Self {
+            accuracy: metrics.accuracy,
+            macro_precision: metrics.macro_precision,
+            macro_recall: metrics.macro_recall,
+            num_instances: metrics.num_instances,
+            correct_per_class: metrics.correct_per_class,
+            predicted_per_class: metrics.predicted_per_class,
+            gold_per_class: metrics.gold_per_class,
+        }
+    }
+}
+
+/// Metrics from training a two-stage model: one set per stage.
+#[pyclass(
+    name = "TwoStageMetrics",
+    frozen,
+    skip_from_py_object,
+    module = "litsea"
+)]
+#[derive(Debug, Clone)]
+pub struct PyTwoStageMetrics {
+    /// Boundary-classifier (stage 1) metrics.
+    #[pyo3(get)]
+    stage1: PyMulticlassMetrics,
+    /// Word-level tagger (stage 2) metrics.
+    #[pyo3(get)]
+    stage2: PyMulticlassMetrics,
+}
+
+#[pymethods]
+impl PyTwoStageMetrics {
+    /// Returns a readable representation.
+    ///
+    /// # Returns
+    /// For example
+    /// `TwoStageMetrics(stage1=99.12%, stage2=96.78%)`.
+    fn __repr__(&self) -> String {
+        format!(
+            "TwoStageMetrics(stage1={:.2}%, stage2={:.2}%)",
+            self.stage1.accuracy, self.stage2.accuracy
+        )
+    }
+}
+
+impl From<TwoStageMetrics> for PyTwoStageMetrics {
+    /// Converts `litsea`'s metrics into the Python-facing class.
+    ///
+    /// # Arguments
+    /// * `metrics` - The metrics to convert.
+    ///
+    /// # Returns
+    /// The corresponding [`PyTwoStageMetrics`].
+    fn from(metrics: TwoStageMetrics) -> Self {
+        Self {
+            stage1: PyMulticlassMetrics::from(metrics.stage1),
+            stage2: PyMulticlassMetrics::from(metrics.stage2),
+        }
+    }
+}

--- a/litsea-python/src/segmenter.rs
+++ b/litsea-python/src/segmenter.rs
@@ -1,0 +1,196 @@
+//! The `Segmenter` class.
+
+use std::path::PathBuf;
+
+use litsea_binding_core::CoreSegmenter;
+use pyo3::prelude::*;
+
+use crate::error::map_err;
+use crate::language::{LanguageArg, PyLanguage};
+use crate::upos::PyToken;
+
+/// A word segmenter, optionally with POS tagging.
+///
+/// Construct one with `Segmenter.open`, `Segmenter.from_bytes`, or
+/// `Segmenter.from_uri`. The kind of model is detected from the file, so a
+/// two-stage POS model produces a segmenter where `has_pos` is `True` and
+/// `segment_with_pos` works; a segmentation-only model produces one where it
+/// raises `PosUnavailableError`.
+///
+/// Instances are immutable and safe to share between threads. Reusing one
+/// across calls is the intended usage: an internal scratch buffer reaches a
+/// steady state where segmentation allocates only the output strings.
+#[pyclass(name = "Segmenter", frozen, module = "litsea")]
+pub struct PySegmenter {
+    /// The wrapped core segmenter.
+    inner: CoreSegmenter,
+}
+
+#[pymethods]
+impl PySegmenter {
+    /// Loads a model from a filesystem path.
+    ///
+    /// # Arguments
+    /// * `language` - A `Language` member or its name (`"ja"`, `"japanese"`).
+    /// * `path` - Path to the model file.
+    ///
+    /// # Returns
+    /// The new `Segmenter`.
+    ///
+    /// # Errors
+    /// Raises `IoError` if the file cannot be read, `ParseError` if it is
+    /// malformed, `ModelError` if it is a legacy joint POS model, or
+    /// `InvalidArgumentError` for an unknown language.
+    #[staticmethod]
+    fn open(py: Python<'_>, language: LanguageArg, path: PathBuf) -> PyResult<Self> {
+        let language = language.resolve()?;
+        let inner = py.detach(|| map_err(CoreSegmenter::from_path(language, &path)))?;
+        Ok(Self { inner })
+    }
+
+    /// Loads a model from raw bytes.
+    ///
+    /// # Arguments
+    /// * `language` - A `Language` member or its name.
+    /// * `data` - The model file contents.
+    ///
+    /// # Returns
+    /// The new `Segmenter`.
+    ///
+    /// # Errors
+    /// Raises `ParseError` if the bytes are malformed, `ModelError` if they
+    /// are a legacy joint POS model, or `InvalidArgumentError` for an
+    /// unknown language.
+    #[staticmethod]
+    fn from_bytes(language: LanguageArg, data: &[u8]) -> PyResult<Self> {
+        let language = language.resolve()?;
+        Ok(Self {
+            inner: map_err(CoreSegmenter::from_bytes(language, data))?,
+        })
+    }
+
+    /// Loads a model from a URI, blocking until it is available.
+    ///
+    /// Accepts a filesystem path, a `file://` path, or an `http(s)://` URL.
+    /// The GIL is released while the model is fetched.
+    ///
+    /// # Arguments
+    /// * `language` - A `Language` member or its name.
+    /// * `uri` - The model URI.
+    ///
+    /// # Returns
+    /// The new `Segmenter`.
+    ///
+    /// # Errors
+    /// Raises `ModelError` if the download fails, plus the same errors as
+    /// `Segmenter.open`.
+    #[staticmethod]
+    fn from_uri(py: Python<'_>, language: LanguageArg, uri: String) -> PyResult<Self> {
+        let language = language.resolve()?;
+        let inner = py.detach(|| map_err(CoreSegmenter::from_uri_blocking(language, &uri)))?;
+        Ok(Self { inner })
+    }
+
+    /// The language this segmenter was built for.
+    #[getter]
+    fn language(&self) -> PyLanguage {
+        PyLanguage::from(self.inner.language())
+    }
+
+    /// Whether this segmenter can tag parts of speech.
+    #[getter]
+    fn has_pos(&self) -> bool {
+        self.inner.has_pos()
+    }
+
+    /// Splits a sentence into tokens.
+    ///
+    /// This method keeps the GIL: releasing it would require copying the
+    /// input string (PyO3 forbids touching Python-owned memory with the GIL
+    /// released), which costs more than segmenting one sentence. Use
+    /// `segment_batch` for bulk work, which does release it.
+    ///
+    /// # Arguments
+    /// * `text` - The sentence to segment.
+    ///
+    /// # Returns
+    /// The tokens, in order.
+    fn segment(&self, text: &str) -> Vec<String> {
+        self.inner.segment(text)
+    }
+
+    /// Splits several sentences into tokens, releasing the GIL.
+    ///
+    /// # Arguments
+    /// * `texts` - The sentences to segment.
+    ///
+    /// # Returns
+    /// One token list per input sentence, in input order.
+    fn segment_batch(&self, py: Python<'_>, texts: Vec<String>) -> Vec<Vec<String>> {
+        py.detach(|| self.inner.segment_batch(&texts))
+    }
+
+    /// Splits a sentence into tokens carrying byte offsets.
+    ///
+    /// # Arguments
+    /// * `text` - The sentence to segment.
+    ///
+    /// # Returns
+    /// The tokens, with `pos` set to `None`.
+    fn segment_tokens(&self, text: &str) -> Vec<PyToken> {
+        self.inner.segment_tokens(text).into_iter().map(PyToken::from).collect()
+    }
+
+    /// Splits a sentence into tokens and tags each with a UPOS tag.
+    ///
+    /// # Arguments
+    /// * `text` - The sentence to segment and tag.
+    ///
+    /// # Returns
+    /// The tagged tokens, with byte offsets into `text`.
+    ///
+    /// # Errors
+    /// Raises `PosUnavailableError` when this segmenter was built from a
+    /// segmentation-only model.
+    fn segment_with_pos(&self, text: &str) -> PyResult<Vec<PyToken>> {
+        Ok(map_err(self.inner.segment_with_pos(text))?
+            .into_iter()
+            .map(PyToken::from)
+            .collect())
+    }
+
+    /// Splits and tags several sentences, releasing the GIL.
+    ///
+    /// # Arguments
+    /// * `texts` - The sentences to segment and tag.
+    ///
+    /// # Returns
+    /// One tagged-token list per input sentence, in input order.
+    ///
+    /// # Errors
+    /// Raises `PosUnavailableError` when this segmenter was built from a
+    /// segmentation-only model.
+    fn segment_with_pos_batch(
+        &self,
+        py: Python<'_>,
+        texts: Vec<String>,
+    ) -> PyResult<Vec<Vec<PyToken>>> {
+        let batches = py.detach(|| map_err(self.inner.segment_with_pos_batch(&texts)))?;
+        Ok(batches
+            .into_iter()
+            .map(|tokens| tokens.into_iter().map(PyToken::from).collect())
+            .collect())
+    }
+
+    /// Returns a readable representation.
+    ///
+    /// # Returns
+    /// For example `Segmenter(language='japanese', has_pos=True)`.
+    fn __repr__(&self) -> String {
+        format!(
+            "Segmenter(language='{}', has_pos={})",
+            self.inner.language(),
+            if self.inner.has_pos() { "True" } else { "False" }
+        )
+    }
+}

--- a/litsea-python/src/trainer.rs
+++ b/litsea-python/src/trainer.rs
@@ -1,0 +1,390 @@
+//! Feature extraction, training, and cancellation classes.
+
+use std::path::PathBuf;
+
+use litsea_binding_core::{
+    CancelToken, CoreExtractor, CorePerceptronTrainer, CoreTrainer, CoreTwoStageTrainer,
+    CorpusFormat, parse_feature_set,
+};
+use pyo3::prelude::*;
+
+use crate::error::map_err;
+use crate::language::LanguageArg;
+use crate::metrics::{PyBinaryMetrics, PyMulticlassMetrics, PyTwoStageMetrics};
+
+/// A flag that asks a running training job to stop.
+///
+/// Cancelling is cooperative and is **not** an error: the trainer stops at
+/// its next check point, still writes the partially trained model, and
+/// returns its metrics normally. Training releases the GIL, so another
+/// Python thread can cancel a run in progress.
+///
+/// The binding never installs a signal handler - handling Ctrl-C is the
+/// application's decision, and Python already owns SIGINT.
+#[pyclass(name = "CancelToken", frozen, skip_from_py_object, module = "litsea")]
+#[derive(Debug, Clone, Default)]
+pub struct PyCancelToken {
+    /// The wrapped token.
+    inner: CancelToken,
+}
+
+#[pymethods]
+impl PyCancelToken {
+    /// Creates a token in the "keep running" state.
+    ///
+    /// # Returns
+    /// The new `CancelToken`.
+    #[new]
+    fn new() -> Self {
+        Self::default()
+    }
+
+    /// Requests cancellation.
+    fn cancel(&self) {
+        self.inner.cancel();
+    }
+
+    /// Returns the token to the "keep running" state.
+    fn reset(&self) {
+        self.inner.reset();
+    }
+
+    /// Whether cancellation has been requested.
+    #[getter]
+    fn cancelled(&self) -> bool {
+        self.inner.is_cancelled()
+    }
+
+    /// Returns a readable representation.
+    ///
+    /// # Returns
+    /// For example `CancelToken(cancelled=False)`.
+    fn __repr__(&self) -> String {
+        format!(
+            "CancelToken(cancelled={})",
+            if self.inner.is_cancelled() { "True" } else { "False" }
+        )
+    }
+}
+
+impl PyCancelToken {
+    /// Returns the wrapped token, or a fresh one when no token was given.
+    ///
+    /// # Arguments
+    /// * `token` - The caller-supplied token, if any.
+    ///
+    /// # Returns
+    /// The token training should observe.
+    fn resolve(token: Option<&PyCancelToken>) -> CancelToken {
+        token.map_or_else(CancelToken::new, |token| token.inner.clone())
+    }
+}
+
+/// Extracts training features from a corpus.
+#[pyclass(name = "Extractor", frozen, module = "litsea")]
+pub struct PyExtractor {
+    /// The wrapped extractor.
+    inner: CoreExtractor,
+}
+
+#[pymethods]
+impl PyExtractor {
+    /// Creates an extractor for a language.
+    ///
+    /// # Arguments
+    /// * `language` - A `Language` member or its name.
+    ///
+    /// # Returns
+    /// The new `Extractor`.
+    ///
+    /// # Errors
+    /// Raises `InvalidArgumentError` for an unknown language.
+    #[new]
+    fn new(language: LanguageArg) -> PyResult<Self> {
+        Ok(Self {
+            inner: CoreExtractor::new(language.resolve()?),
+        })
+    }
+
+    /// Extracts boundary-classification features, releasing the GIL.
+    ///
+    /// # Arguments
+    /// * `corpus_path` - Path to the training corpus.
+    /// * `features_path` - Path of the features file to write.
+    /// * `tsv` - Read the corpus in the space-preserving TSV format.
+    /// * `tag_free` - Omit tag-dependent feature templates.
+    ///
+    /// # Returns
+    /// `None` once the features file has been written.
+    ///
+    /// # Errors
+    /// Raises `IoError` if the corpus cannot be read or the output cannot be
+    /// written.
+    #[pyo3(signature = (corpus_path, features_path, *, tsv=false, tag_free=false))]
+    fn extract(
+        &self,
+        py: Python<'_>,
+        corpus_path: PathBuf,
+        features_path: PathBuf,
+        tsv: bool,
+        tag_free: bool,
+    ) -> PyResult<()> {
+        py.detach(|| {
+            map_err(self.inner.extract(
+                &corpus_path,
+                &features_path,
+                CorpusFormat::from_tsv_flag(tsv),
+                tag_free,
+            ))
+        })
+    }
+
+    /// Extracts two-stage (segmentation + POS) features, releasing the GIL.
+    ///
+    /// Writes `{output_prefix}.stage1`, `.stage2`, and `.lexicon`.
+    ///
+    /// # Arguments
+    /// * `corpus_path` - Path to the POS-tagged training corpus.
+    /// * `output_prefix` - Prefix for the three output files.
+    /// * `feature_set` - `"full"`, `"balanced"`, or `"fast"`.
+    /// * `tsv` - Read the corpus in the space-preserving TSV format.
+    ///
+    /// # Returns
+    /// `None` once all three files have been written.
+    ///
+    /// # Errors
+    /// Raises `InvalidArgumentError` for an unknown feature set, or
+    /// `IoError` if the files cannot be read or written.
+    #[pyo3(signature = (corpus_path, output_prefix, *, feature_set="fast", tsv=false))]
+    fn extract_two_stage(
+        &self,
+        py: Python<'_>,
+        corpus_path: PathBuf,
+        output_prefix: PathBuf,
+        feature_set: &str,
+        tsv: bool,
+    ) -> PyResult<()> {
+        let feature_set = map_err(parse_feature_set(feature_set))?;
+        py.detach(|| {
+            map_err(self.inner.extract_two_stage(
+                &corpus_path,
+                &output_prefix,
+                feature_set,
+                CorpusFormat::from_tsv_flag(tsv),
+            ))
+        })
+    }
+}
+
+/// Trains a segmentation model.
+#[pyclass(name = "Trainer", module = "litsea")]
+pub struct PyTrainer {
+    /// The wrapped trainer.
+    inner: CoreTrainer,
+}
+
+#[pymethods]
+impl PyTrainer {
+    /// Loads a features file and prepares training.
+    ///
+    /// # Arguments
+    /// * `threshold` - Early-stopping threshold for weak classifiers.
+    /// * `num_iterations` - Maximum number of boosting iterations.
+    /// * `features_path` - Path to the features file.
+    ///
+    /// # Returns
+    /// The new `Trainer`.
+    ///
+    /// # Errors
+    /// Raises `IoError` or `ParseError` if the features file cannot be read
+    /// or parsed.
+    #[new]
+    fn new(
+        py: Python<'_>,
+        threshold: f64,
+        num_iterations: usize,
+        features_path: PathBuf,
+    ) -> PyResult<Self> {
+        let inner =
+            py.detach(|| map_err(CoreTrainer::new(threshold, num_iterations, &features_path)))?;
+        Ok(Self { inner })
+    }
+
+    /// Loads an existing model to continue training from it.
+    ///
+    /// # Arguments
+    /// * `model_uri` - Path, `file://` path, or `http(s)://` URL.
+    ///
+    /// # Returns
+    /// `None` once the model has been merged into the learner.
+    ///
+    /// # Errors
+    /// Raises `ModelError`, `IoError`, or `ParseError` if the model cannot
+    /// be fetched or parsed.
+    fn load_model(&mut self, py: Python<'_>, model_uri: String) -> PyResult<()> {
+        py.detach(|| map_err(self.inner.load_model_blocking(&model_uri)))
+    }
+
+    /// Trains the model and writes it to `model_path`, releasing the GIL.
+    ///
+    /// # Arguments
+    /// * `model_path` - Path of the model file to write.
+    /// * `cancel` - Optional `CancelToken`; cancelling stops training early
+    ///   and still writes the partially trained model.
+    ///
+    /// # Returns
+    /// The training metrics.
+    ///
+    /// # Errors
+    /// Raises `IoError` if the model cannot be written.
+    #[pyo3(signature = (model_path, *, cancel=None))]
+    fn train(
+        &mut self,
+        py: Python<'_>,
+        model_path: PathBuf,
+        cancel: Option<&PyCancelToken>,
+    ) -> PyResult<PyBinaryMetrics> {
+        let token = PyCancelToken::resolve(cancel);
+        let metrics = py.detach(|| map_err(self.inner.train(&token, &model_path)))?;
+        Ok(PyBinaryMetrics::from(metrics))
+    }
+}
+
+/// Trains a label-agnostic Averaged Perceptron model.
+#[pyclass(name = "PerceptronTrainer", module = "litsea")]
+pub struct PyPerceptronTrainer {
+    /// The wrapped trainer.
+    inner: CorePerceptronTrainer,
+}
+
+#[pymethods]
+impl PyPerceptronTrainer {
+    /// Loads a features file and prepares training.
+    ///
+    /// # Arguments
+    /// * `num_epochs` - Number of passes over the training data.
+    /// * `features_path` - Path to the features file.
+    ///
+    /// # Returns
+    /// The new `PerceptronTrainer`.
+    ///
+    /// # Errors
+    /// Raises `IoError` or `ParseError` if the features file cannot be read
+    /// or parsed.
+    #[new]
+    fn new(py: Python<'_>, num_epochs: usize, features_path: PathBuf) -> PyResult<Self> {
+        let inner =
+            py.detach(|| map_err(CorePerceptronTrainer::new(num_epochs, &features_path)))?;
+        Ok(Self { inner })
+    }
+
+    /// Loads an existing model to continue training from it.
+    ///
+    /// # Arguments
+    /// * `model_uri` - Path, `file://` path, or `http(s)://` URL.
+    ///
+    /// # Returns
+    /// `None` once the model has been merged into the learner.
+    ///
+    /// # Errors
+    /// Raises `ModelError`, `IoError`, or `ParseError` if the model cannot
+    /// be fetched or parsed.
+    fn load_model(&mut self, py: Python<'_>, model_uri: String) -> PyResult<()> {
+        py.detach(|| map_err(self.inner.load_model_blocking(&model_uri)))
+    }
+
+    /// Trains the model and writes it to `model_path`, releasing the GIL.
+    ///
+    /// # Arguments
+    /// * `model_path` - Path of the model file to write.
+    /// * `cancel` - Optional `CancelToken`.
+    ///
+    /// # Returns
+    /// The training metrics.
+    ///
+    /// # Errors
+    /// Raises `IoError` if the model cannot be written.
+    #[pyo3(signature = (model_path, *, cancel=None))]
+    fn train(
+        &mut self,
+        py: Python<'_>,
+        model_path: PathBuf,
+        cancel: Option<&PyCancelToken>,
+    ) -> PyResult<PyMulticlassMetrics> {
+        let token = PyCancelToken::resolve(cancel);
+        let metrics = py.detach(|| map_err(self.inner.train(&token, &model_path)))?;
+        Ok(PyMulticlassMetrics::from(metrics))
+    }
+}
+
+/// Trains a two-stage segmentation + POS model.
+///
+/// A trainer can only be used once: `litsea` collapses stage 1 into an
+/// AdaBoost model during training, which consumes the trainer. Check
+/// `available` before reusing one.
+#[pyclass(name = "TwoStageTrainer", module = "litsea")]
+pub struct PyTwoStageTrainer {
+    /// The wrapped trainer.
+    inner: CoreTwoStageTrainer,
+}
+
+#[pymethods]
+impl PyTwoStageTrainer {
+    /// Loads a two-stage features prefix and prepares training.
+    ///
+    /// # Arguments
+    /// * `num_epochs` - Number of passes over the training data.
+    /// * `dominance` - Lexicon dominance threshold, in `(0.5, 1.0]`.
+    /// * `features_prefix` - Prefix of the `.stage1` / `.stage2` /
+    ///   `.lexicon` files written by `Extractor.extract_two_stage`.
+    ///
+    /// # Returns
+    /// The new `TwoStageTrainer`.
+    ///
+    /// # Errors
+    /// Raises `InvalidArgumentError` if `dominance` is out of range, or
+    /// `IoError` / `ParseError` if the feature files cannot be read.
+    #[new]
+    #[pyo3(signature = (num_epochs, features_prefix, *, dominance=0.99))]
+    fn new(
+        py: Python<'_>,
+        num_epochs: usize,
+        features_prefix: PathBuf,
+        dominance: f64,
+    ) -> PyResult<Self> {
+        let inner = py.detach(|| {
+            map_err(CoreTwoStageTrainer::new(num_epochs, dominance, &features_prefix))
+        })?;
+        Ok(Self { inner })
+    }
+
+    /// Whether this trainer can still be used.
+    #[getter]
+    fn available(&self) -> bool {
+        self.inner.is_available()
+    }
+
+    /// Trains both stages and writes the model, releasing the GIL.
+    ///
+    /// # Arguments
+    /// * `model_path` - Path of the model file to write.
+    /// * `cancel` - Optional `CancelToken`.
+    ///
+    /// # Returns
+    /// The metrics of both stages.
+    ///
+    /// # Errors
+    /// Raises `InvalidArgumentError` if the trainer has already been used,
+    /// or `IoError` if the model cannot be written.
+    #[pyo3(signature = (model_path, *, cancel=None))]
+    fn train(
+        &mut self,
+        py: Python<'_>,
+        model_path: PathBuf,
+        cancel: Option<&PyCancelToken>,
+    ) -> PyResult<PyTwoStageMetrics> {
+        let token = PyCancelToken::resolve(cancel);
+        let metrics = py.detach(|| map_err(self.inner.train(&token, &model_path)))?;
+        Ok(PyTwoStageMetrics::from(metrics))
+    }
+}

--- a/litsea-python/src/upos.rs
+++ b/litsea-python/src/upos.rs
@@ -1,0 +1,238 @@
+//! The `Upos` enum and the `Token` class.
+
+use litsea::Upos;
+use litsea_binding_core::TokenView;
+use pyo3::prelude::*;
+
+/// A Universal POS tag.
+///
+/// Exposed to Python as `litsea.Upos`, with the 17 UD tags as members
+/// (`Upos.NOUN`, `Upos.VERB`, …).
+// See the note on `Language`: no `eq_int`, so tags never compare equal to ints.
+#[pyclass(name = "Upos", eq, frozen, hash, from_py_object, module = "litsea")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[allow(clippy::upper_case_acronyms)]
+pub enum PyUpos {
+    /// Adjective.
+    ADJ,
+    /// Adposition.
+    ADP,
+    /// Adverb.
+    ADV,
+    /// Auxiliary.
+    AUX,
+    /// Coordinating conjunction.
+    CCONJ,
+    /// Determiner.
+    DET,
+    /// Interjection.
+    INTJ,
+    /// Noun.
+    NOUN,
+    /// Numeral.
+    NUM,
+    /// Particle.
+    PART,
+    /// Pronoun.
+    PRON,
+    /// Proper noun.
+    PROPN,
+    /// Punctuation.
+    PUNCT,
+    /// Subordinating conjunction.
+    SCONJ,
+    /// Symbol.
+    SYM,
+    /// Verb.
+    VERB,
+    /// Other.
+    X,
+}
+
+#[pymethods]
+impl PyUpos {
+    /// Returns the tag name, for example `"NOUN"`.
+    ///
+    /// # Returns
+    /// The canonical uppercase UPOS tag name.
+    #[getter]
+    fn name(&self) -> String {
+        Upos::from(*self).to_string()
+    }
+
+    /// Returns every UPOS tag.
+    ///
+    /// # Returns
+    /// All 17 tags, in UD order.
+    #[staticmethod]
+    fn all() -> Vec<Self> {
+        Upos::ALL.into_iter().map(Self::from).collect()
+    }
+
+    /// Returns the tag name.
+    ///
+    /// # Returns
+    /// The same value as the `name` property.
+    fn __str__(&self) -> String {
+        self.name()
+    }
+}
+
+impl From<PyUpos> for Upos {
+    /// Converts the Python-facing tag into `litsea`'s tag.
+    ///
+    /// # Arguments
+    /// * `pos` - The Python-facing tag.
+    ///
+    /// # Returns
+    /// The corresponding [`Upos`].
+    fn from(pos: PyUpos) -> Self {
+        match pos {
+            PyUpos::ADJ => Upos::ADJ,
+            PyUpos::ADP => Upos::ADP,
+            PyUpos::ADV => Upos::ADV,
+            PyUpos::AUX => Upos::AUX,
+            PyUpos::CCONJ => Upos::CCONJ,
+            PyUpos::DET => Upos::DET,
+            PyUpos::INTJ => Upos::INTJ,
+            PyUpos::NOUN => Upos::NOUN,
+            PyUpos::NUM => Upos::NUM,
+            PyUpos::PART => Upos::PART,
+            PyUpos::PRON => Upos::PRON,
+            PyUpos::PROPN => Upos::PROPN,
+            PyUpos::PUNCT => Upos::PUNCT,
+            PyUpos::SCONJ => Upos::SCONJ,
+            PyUpos::SYM => Upos::SYM,
+            PyUpos::VERB => Upos::VERB,
+            PyUpos::X => Upos::X,
+        }
+    }
+}
+
+impl From<Upos> for PyUpos {
+    /// Converts `litsea`'s tag into the Python-facing tag.
+    ///
+    /// # Arguments
+    /// * `pos` - The `litsea` tag.
+    ///
+    /// # Returns
+    /// The corresponding [`PyUpos`].
+    fn from(pos: Upos) -> Self {
+        match pos {
+            Upos::ADJ => PyUpos::ADJ,
+            Upos::ADP => PyUpos::ADP,
+            Upos::ADV => PyUpos::ADV,
+            Upos::AUX => PyUpos::AUX,
+            Upos::CCONJ => PyUpos::CCONJ,
+            Upos::DET => PyUpos::DET,
+            Upos::INTJ => PyUpos::INTJ,
+            Upos::NOUN => PyUpos::NOUN,
+            Upos::NUM => PyUpos::NUM,
+            Upos::PART => PyUpos::PART,
+            Upos::PRON => PyUpos::PRON,
+            Upos::PROPN => PyUpos::PROPN,
+            Upos::PUNCT => PyUpos::PUNCT,
+            Upos::SCONJ => PyUpos::SCONJ,
+            Upos::SYM => PyUpos::SYM,
+            Upos::VERB => PyUpos::VERB,
+            Upos::X => PyUpos::X,
+        }
+    }
+}
+
+/// A segmented token.
+///
+/// `start` and `end` are byte offsets into the input string, so
+/// `text.encode()[token.start:token.end].decode()` is `token.surface`.
+/// They are exact for both segmentation and POS output.
+#[pyclass(name = "Token", frozen, skip_from_py_object, module = "litsea")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PyToken {
+    /// The token's surface form.
+    #[pyo3(get)]
+    surface: String,
+    /// The UPOS tag, or `None` for segmentation-only output.
+    #[pyo3(get)]
+    pos: Option<PyUpos>,
+    /// Starting byte offset in the input string.
+    #[pyo3(get)]
+    start: usize,
+    /// Ending byte offset (exclusive) in the input string.
+    #[pyo3(get)]
+    end: usize,
+}
+
+#[pymethods]
+impl PyToken {
+    /// Returns a readable representation.
+    ///
+    /// # Returns
+    /// For example `Token('すもも', pos=NOUN, start=0, end=9)`.
+    fn __repr__(&self) -> String {
+        match self.pos {
+            Some(pos) => format!(
+                "Token({:?}, pos={}, start={}, end={})",
+                self.surface,
+                pos.name(),
+                self.start,
+                self.end
+            ),
+            None => format!("Token({:?}, start={}, end={})", self.surface, self.start, self.end),
+        }
+    }
+
+    /// Compares two tokens by all four fields.
+    ///
+    /// # Arguments
+    /// * `other` - The token to compare against.
+    ///
+    /// # Returns
+    /// `true` when every field is equal.
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
+impl From<TokenView> for PyToken {
+    /// Converts a core token view into the Python-facing token.
+    ///
+    /// # Arguments
+    /// * `view` - The token view.
+    ///
+    /// # Returns
+    /// The corresponding [`PyToken`].
+    fn from(view: TokenView) -> Self {
+        Self {
+            surface: view.surface,
+            pos: view.pos.map(PyUpos::from),
+            start: view.byte_start,
+            end: view.byte_end,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_every_upos_tag_round_trips() {
+        for pos in Upos::ALL {
+            let member = PyUpos::from(pos);
+            assert_eq!(Upos::from(member), pos);
+            assert_eq!(member.name(), pos.to_string());
+        }
+        assert_eq!(PyUpos::all().len(), 17);
+    }
+
+    #[test]
+    fn test_token_conversion_keeps_offsets() {
+        let view = TokenView::new("すもも", 3, 12, Some(Upos::NOUN));
+        let token = PyToken::from(view);
+        assert_eq!(token.surface, "すもも");
+        assert_eq!(token.start, 3);
+        assert_eq!(token.end, 12);
+        assert_eq!(token.pos, Some(PyUpos::NOUN));
+        assert!(token.__repr__().contains("pos=NOUN"));
+    }
+}

--- a/litsea-python/tests/conftest.py
+++ b/litsea-python/tests/conftest.py
@@ -1,0 +1,57 @@
+"""Shared fixtures.
+
+The parity tests compare the binding against the `litsea` CLI, which is the
+reference implementation for what a model should produce. The CLI is built
+once per session so the comparison always runs rather than being skipped.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODELS_DIR = REPO_ROOT / "models"
+
+
+@pytest.fixture(scope="session")
+def models_dir() -> Path:
+    """Return the directory holding the bundled models."""
+    assert MODELS_DIR.is_dir(), f"missing models directory: {MODELS_DIR}"
+    return MODELS_DIR
+
+
+@pytest.fixture(scope="session")
+def litsea_cli() -> Path:
+    """Build the `litsea` CLI and return the path to the binary."""
+    subprocess.run(
+        ["cargo", "build", "--quiet", "-p", "litsea-cli"],
+        cwd=REPO_ROOT,
+        check=True,
+    )
+    binary = REPO_ROOT / "target" / "debug" / "litsea"
+    assert binary.is_file(), f"cargo build did not produce {binary}"
+    return binary
+
+
+def run_cli(binary: Path, args: list[str], stdin: str) -> list[str]:
+    """Run the CLI over `stdin` and return its output lines.
+
+    Args:
+        binary: Path to the `litsea` binary.
+        args: Arguments after the subcommand name.
+        stdin: Text to feed on standard input.
+
+    Returns:
+        The output lines, with the trailing newline removed.
+    """
+    result = subprocess.run(
+        [str(binary), *args],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.splitlines()

--- a/litsea-python/tests/test_errors.py
+++ b/litsea-python/tests/test_errors.py
@@ -1,0 +1,89 @@
+"""Error mapping: every failure raises a typed exception, never a panic."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from litsea import (
+    Extractor,
+    InvalidArgumentError,
+    IoError,
+    Language,
+    LitseaError,
+    ModelError,
+    ParseError,
+    Segmenter,
+    Trainer,
+    TwoStageTrainer,
+)
+
+
+def test_unknown_language_name(models_dir: Path) -> None:
+    """An unknown language names the supported ones in the message."""
+    with pytest.raises(InvalidArgumentError) as excinfo:
+        Segmenter.open("klingon", models_dir / "japanese.model")
+    assert "klingon" in str(excinfo.value)
+    assert "japanese" in str(excinfo.value)
+
+
+def test_missing_model_file(tmp_path: Path) -> None:
+    """A missing model file is an I/O error, not a crash."""
+    with pytest.raises(IoError):
+        Segmenter.open(Language.JAPANESE, tmp_path / "does-not-exist.model")
+
+
+def test_malformed_model(tmp_path: Path) -> None:
+    """A model that is not parseable is a parse error."""
+    path = tmp_path / "broken.model"
+    path.write_text("this is not a model\n")
+    with pytest.raises(ParseError):
+        Segmenter.open(Language.JAPANESE, path)
+
+
+def test_empty_model(tmp_path: Path) -> None:
+    """An empty model file is rejected."""
+    path = tmp_path / "empty.model"
+    path.write_text("")
+    with pytest.raises(ParseError):
+        Segmenter.open(Language.JAPANESE, path)
+
+
+def test_legacy_joint_pos_model(tmp_path: Path) -> None:
+    """Legacy joint POS models are rejected with actionable guidance."""
+    path = tmp_path / "joint.model"
+    # A bare integer first line is the joint class-count header.
+    path.write_text("17\nfoo\t1.0\n")
+    with pytest.raises(ModelError) as excinfo:
+        Segmenter.open(Language.JAPANESE, path)
+    assert "no longer supported" in str(excinfo.value)
+
+
+def test_unknown_feature_set(tmp_path: Path) -> None:
+    """An unknown two-stage feature set names the valid values."""
+    corpus = tmp_path / "corpus.txt"
+    corpus.write_text("これ/PRON は/ADP テスト/NOUN です/AUX 。/PUNCT\n")
+    with pytest.raises(InvalidArgumentError) as excinfo:
+        Extractor(Language.JAPANESE).extract_two_stage(corpus, tmp_path / "features", feature_set="turbo")
+    assert "turbo" in str(excinfo.value)
+
+
+def test_missing_features_file(tmp_path: Path) -> None:
+    """Training without a features file is an I/O error."""
+    with pytest.raises(IoError):
+        Trainer(0.01, 10, tmp_path / "missing.txt")
+
+
+def test_dominance_out_of_range(tmp_path: Path) -> None:
+    """A dominance outside (0.5, 1.0] is rejected before any work."""
+    with pytest.raises((InvalidArgumentError, IoError)):
+        TwoStageTrainer(1, tmp_path / "features", dominance=1.5)
+
+
+def test_every_exception_derives_from_litsea_error(models_dir: Path) -> None:
+    """One `except LitseaError` is enough to catch everything."""
+    for error_type in (InvalidArgumentError, IoError, ModelError, ParseError):
+        assert issubclass(error_type, LitseaError)
+
+    with pytest.raises(LitseaError):
+        Segmenter.open("klingon", models_dir / "japanese.model")

--- a/litsea-python/tests/test_segmenter.py
+++ b/litsea-python/tests/test_segmenter.py
@@ -1,0 +1,221 @@
+"""Segmentation, POS tagging, and enum behaviour."""
+
+from __future__ import annotations
+
+import enum
+import threading
+from pathlib import Path
+
+import pytest
+from conftest import run_cli
+from litsea import Language, PosUnavailableError, Segmenter, Token, Upos
+
+# One sentence per language, with the segmentation model that handles it.
+SEGMENTATION_CASES = [
+    ("japanese", "japanese.model", "これはテストです。"),
+    ("chinese", "chinese.model", "我喜欢吃中国菜。"),
+    ("korean", "korean.model", "안녕하세요 반갑습니다"),
+    ("english", "english.model", "The quick brown fox jumps over the lazy dog."),
+]
+
+POS_CASES = [
+    ("japanese", "japanese_pos.model", "これはテストです。"),
+    ("korean", "korean_pos.model", "안녕하세요 반갑습니다"),
+]
+
+
+@pytest.mark.parametrize(("language", "model", "sentence"), SEGMENTATION_CASES)
+def test_segment_matches_the_cli(models_dir: Path, litsea_cli: Path, language: str, model: str, sentence: str) -> None:
+    """The binding must produce exactly what `litsea segment` produces.
+
+    The comparison is against the CLI's rendered line rather than a re-split
+    of it: the CLI joins tokens with a space, so for space-preserving
+    languages (Korean, English) a whitespace token cannot be recovered by
+    splitting the output again.
+    """
+    expected = run_cli(
+        litsea_cli,
+        ["segment", "-l", language, str(models_dir / model)],
+        sentence + "\n",
+    )[0]
+
+    seg = Segmenter.open(language, models_dir / model)
+    assert " ".join(seg.segment(sentence)) == expected
+
+
+@pytest.mark.parametrize(("language", "model", "sentence"), POS_CASES)
+def test_segment_with_pos_matches_the_cli(
+    models_dir: Path, litsea_cli: Path, language: str, model: str, sentence: str
+) -> None:
+    """POS output must match `litsea segment --pos`, rendered the same way."""
+    expected = run_cli(
+        litsea_cli,
+        ["segment", "-l", language, "--pos", str(models_dir / model)],
+        sentence + "\n",
+    )[0]
+
+    seg = Segmenter.open(language, models_dir / model)
+    actual = " ".join(f"{token.surface}/{token.pos.name}" for token in seg.segment_with_pos(sentence))
+    assert actual == expected
+
+
+@pytest.mark.parametrize(("language", "model", "sentence"), SEGMENTATION_CASES)
+def test_offsets_reconstruct_the_input(models_dir: Path, language: str, model: str, sentence: str) -> None:
+    """Byte offsets must tile the input exactly, with no gaps."""
+    seg = Segmenter.open(language, models_dir / model)
+    tokens = seg.segment_tokens(sentence)
+    raw = sentence.encode()
+
+    assert tokens
+    expected_start = 0
+    for token in tokens:
+        assert token.start == expected_start
+        assert raw[token.start : token.end].decode() == token.surface
+        assert token.pos is None
+        expected_start = token.end
+    assert expected_start == len(raw)
+    assert "".join(token.surface for token in tokens) == sentence
+
+
+def test_whitespace_is_its_own_token(models_dir: Path) -> None:
+    """Space-delimited languages keep the space as a token."""
+    seg = Segmenter.open(Language.KOREAN, models_dir / "korean.model")
+    assert seg.segment("안녕하세요 반갑습니다") == ["안녕하세요", " ", "반갑습니다"]
+
+
+def test_batch_matches_single_calls(models_dir: Path) -> None:
+    """`segment_batch` must agree with repeated `segment` calls."""
+    seg = Segmenter.open(Language.JAPANESE, models_dir / "japanese.model")
+    sentences = ["これはテストです。", "", "東京都から神奈川県へ引っ越した"]
+
+    assert seg.segment_batch(sentences) == [seg.segment(s) for s in sentences]
+    assert seg.segment_batch(sentences)[1] == []
+
+
+def test_pos_batch_matches_single_calls(models_dir: Path) -> None:
+    """`segment_with_pos_batch` must agree with repeated calls."""
+    seg = Segmenter.open(Language.JAPANESE, models_dir / "japanese_pos.model")
+    sentences = ["これはテストです。", "東京都から神奈川県へ引っ越した"]
+
+    batched = seg.segment_with_pos_batch(sentences)
+    assert batched == [seg.segment_with_pos(s) for s in sentences]
+
+
+def test_model_kind_is_detected(models_dir: Path) -> None:
+    """`has_pos` reflects the model that was loaded, with no flag passed."""
+    assert not Segmenter.open("ja", models_dir / "japanese.model").has_pos
+    assert Segmenter.open("ja", models_dir / "japanese_pos.model").has_pos
+
+
+def test_pos_on_segmentation_model_raises(models_dir: Path) -> None:
+    """POS tagging a segmentation-only model is a typed error."""
+    seg = Segmenter.open(Language.JAPANESE, models_dir / "japanese.model")
+    with pytest.raises(PosUnavailableError, match="two-stage POS model"):
+        seg.segment_with_pos("これはテストです。")
+
+
+def test_loading_sources_agree(models_dir: Path) -> None:
+    """`open`, `from_bytes`, and `from_uri` produce the same segmenter."""
+    path = models_dir / "japanese.model"
+    sentence = "これはテストです。"
+
+    from_path = Segmenter.open(Language.JAPANESE, path)
+    from_bytes = Segmenter.from_bytes(Language.JAPANESE, path.read_bytes())
+    from_uri = Segmenter.from_uri(Language.JAPANESE, str(path))
+
+    assert from_path.segment(sentence) == from_bytes.segment(sentence)
+    assert from_path.segment(sentence) == from_uri.segment(sentence)
+
+
+def test_language_argument_accepts_strings(models_dir: Path) -> None:
+    """A `Language` member and its names are interchangeable."""
+    path = models_dir / "japanese.model"
+    sentence = "これはテストです。"
+
+    expected = Segmenter.open(Language.JAPANESE, path).segment(sentence)
+    for name in ("ja", "JA", "japanese", "Japanese"):
+        assert Segmenter.open(name, path).segment(sentence) == expected
+
+
+def test_segmenter_properties(models_dir: Path) -> None:
+    """`language` and `repr` report the loaded configuration."""
+    seg = Segmenter.open(Language.KOREAN, models_dir / "korean.model")
+    assert seg.language == Language.KOREAN
+    assert seg.language.name == "korean"
+    assert "korean" in repr(seg)
+
+
+def test_shared_between_threads(models_dir: Path) -> None:
+    """One segmenter can serve several threads."""
+    seg = Segmenter.open(Language.JAPANESE, models_dir / "japanese.model")
+    sentence = "これはテストです。"
+    expected = seg.segment(sentence)
+    results: list[list[str]] = []
+    lock = threading.Lock()
+
+    def work() -> None:
+        result = seg.segment_batch([sentence] * 50)
+        with lock:
+            results.extend(result)
+
+    threads = [threading.Thread(target=work) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(results) == 200
+    assert all(result == expected for result in results)
+
+
+def test_language_enum() -> None:
+    """`Language` exposes its members, names, and parsing."""
+    assert Language.parse("ko") == Language.KOREAN
+    assert Language.KOREAN.name == "korean"
+    assert str(Language.ENGLISH) == "english"
+    assert [language.name for language in Language.all()] == [
+        "japanese",
+        "chinese",
+        "korean",
+        "english",
+    ]
+
+
+def test_enums_are_not_python_enums() -> None:
+    """The members are class attributes, as the type stubs describe.
+
+    PyO3 classes are not `enum.Enum` subclasses, so iterating the class
+    raises; `all()` is the supported way to enumerate. Pinning this keeps
+    the stubs honest.
+    """
+    assert not isinstance(Language.JAPANESE, enum.Enum)
+    with pytest.raises(TypeError):
+        list(Language)  # type: ignore[call-overload]
+    with pytest.raises(TypeError):
+        Language["JAPANESE"]  # type: ignore[index]
+
+
+def test_enum_members_do_not_compare_equal_to_ints() -> None:
+    """Without `eq_int`, discriminants never leak into comparisons."""
+    assert Language.JAPANESE != 0
+    assert Upos.ADJ != 0
+    assert Language.JAPANESE == Language.JAPANESE
+    assert Language.JAPANESE != Language.CHINESE
+
+
+def test_upos_enum() -> None:
+    """`Upos` exposes all 17 UD tags."""
+    assert len(Upos.all()) == 17
+    assert Upos.NOUN.name == "NOUN"
+    assert str(Upos.VERB) == "VERB"
+    assert Upos.NOUN != Upos.VERB
+
+
+def test_token_repr_and_equality(models_dir: Path) -> None:
+    """Tokens compare by value and print readably."""
+    seg = Segmenter.open(Language.JAPANESE, models_dir / "japanese_pos.model")
+    first, second = (seg.segment_with_pos("これはテストです。") for _ in range(2))
+
+    assert first == second
+    assert isinstance(first[0], Token)
+    assert "pos=" in repr(first[0])

--- a/litsea-python/tests/test_training.py
+++ b/litsea-python/tests/test_training.py
@@ -1,0 +1,186 @@
+"""Feature extraction, training, and cancellation."""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+from conftest import run_cli
+from litsea import (
+    CancelToken,
+    Extractor,
+    InvalidArgumentError,
+    Language,
+    PerceptronTrainer,
+    Segmenter,
+    Trainer,
+    TwoStageTrainer,
+)
+
+SENTENCES = [
+    "これ は テスト です 。",
+    "隣 の 客 は よく 柿 食う 客 だ",
+    "東京 都 から 神奈川 県 へ 引っ越し た",
+]
+
+POS_SENTENCES = [
+    "これ/PRON は/ADP テスト/NOUN です/AUX 。/PUNCT",
+    "隣/NOUN の/ADP 客/NOUN は/ADP よく/ADV 柿/NOUN 食う/VERB 客/NOUN だ/AUX",
+    "東京/PROPN 都/NOUN から/ADP 神奈川/PROPN 県/NOUN へ/ADP 引っ越し/VERB た/AUX",
+]
+
+
+def write_corpus(path: Path, sentences: list[str], repeats: int = 20) -> Path:
+    """Write a small corpus, repeated so training has something to learn."""
+    path.write_text("\n".join(sentences * repeats) + "\n")
+    return path
+
+
+def test_extract_then_train_round_trip(tmp_path: Path, litsea_cli: Path) -> None:
+    """A model trained from Python must load in the Rust CLI."""
+    corpus = write_corpus(tmp_path / "corpus.txt", SENTENCES)
+    features = tmp_path / "features.txt"
+    model = tmp_path / "trained.model"
+
+    Extractor(Language.JAPANESE).extract(corpus, features)
+    assert features.exists()
+
+    metrics = Trainer(0.01, 20, features).train(model)
+    assert metrics.num_instances > 0
+    assert 0.0 <= metrics.accuracy <= 100.0
+    assert "accuracy" in repr(metrics)
+
+    # The CLI is the independent check that the file is a valid model.
+    output = run_cli(litsea_cli, ["segment", "-l", "japanese", str(model)], "これはテストです。\n")
+    assert output and output[0]
+
+    # And the binding agrees with the CLI on the freshly trained model.
+    assert Segmenter.open(Language.JAPANESE, model).segment("これはテストです。") == output[0].split(" ")
+
+
+def test_tag_free_extraction_is_smaller(tmp_path: Path) -> None:
+    """`tag_free=True` drops the tag-dependent templates."""
+    corpus = write_corpus(tmp_path / "corpus.txt", SENTENCES)
+    extractor = Extractor(Language.JAPANESE)
+
+    full = tmp_path / "full.txt"
+    lean = tmp_path / "lean.txt"
+    extractor.extract(corpus, full)
+    extractor.extract(corpus, lean, tag_free=True)
+
+    assert lean.stat().st_size < full.stat().st_size
+
+
+def test_two_stage_training_round_trip(tmp_path: Path) -> None:
+    """Two-stage training produces a POS-capable model."""
+    corpus = write_corpus(tmp_path / "corpus_pos.txt", POS_SENTENCES)
+    prefix = tmp_path / "features"
+    model = tmp_path / "two_stage.model"
+
+    Extractor(Language.JAPANESE).extract_two_stage(corpus, prefix, feature_set="fast")
+    for suffix in ("stage1", "stage2", "lexicon"):
+        assert (tmp_path / f"features.{suffix}").exists()
+
+    trainer = TwoStageTrainer(3, prefix)
+    assert trainer.available
+    metrics = trainer.train(model)
+    assert metrics.stage1.num_instances > 0
+    assert metrics.stage2.num_instances > 0
+
+    seg = Segmenter.open(Language.JAPANESE, model)
+    assert seg.has_pos
+    tokens = seg.segment_with_pos("これはテストです。")
+    assert tokens
+    assert all(token.pos is not None for token in tokens)
+
+
+def test_two_stage_trainer_cannot_be_reused(tmp_path: Path) -> None:
+    """The trainer is consumed by training, and says so."""
+    corpus = write_corpus(tmp_path / "corpus_pos.txt", POS_SENTENCES)
+    prefix = tmp_path / "features"
+    model = tmp_path / "two_stage.model"
+
+    Extractor(Language.JAPANESE).extract_two_stage(corpus, prefix)
+    trainer = TwoStageTrainer(1, prefix)
+    trainer.train(model)
+
+    assert not trainer.available
+    with pytest.raises(InvalidArgumentError, match="already been used"):
+        trainer.train(model)
+
+
+def test_perceptron_trainer(tmp_path: Path) -> None:
+    """The perceptron trainer trains from stage-2 features."""
+    corpus = write_corpus(tmp_path / "corpus_pos.txt", POS_SENTENCES)
+    prefix = tmp_path / "features"
+    model = tmp_path / "perceptron.model"
+
+    Extractor(Language.JAPANESE).extract_two_stage(corpus, prefix)
+    metrics = PerceptronTrainer(2, tmp_path / "features.stage2").train(model)
+
+    assert metrics.num_instances > 0
+    assert metrics.gold_per_class
+    assert model.exists()
+
+
+def test_cancel_before_training_still_writes_a_model(tmp_path: Path) -> None:
+    """Cancelling is cooperative: it is not an error."""
+    corpus = write_corpus(tmp_path / "corpus.txt", SENTENCES)
+    features = tmp_path / "features.txt"
+    model = tmp_path / "cancelled.model"
+
+    Extractor(Language.JAPANESE).extract(corpus, features)
+
+    cancel = CancelToken()
+    cancel.cancel()
+    assert cancel.cancelled
+
+    metrics = Trainer(0.01, 100_000, features).train(model, cancel=cancel)
+    assert metrics.num_instances > 0
+    assert model.exists()
+
+
+def test_training_releases_the_gil(tmp_path: Path) -> None:
+    """Another Python thread must be able to run while training does.
+
+    If `train` held the GIL, the canceller thread could not execute until
+    training returned, so its timestamp would land after training finished.
+
+    The iteration count is bounded (~35 ms per iteration on this corpus, so
+    ~7 s uncancelled) so that a regression fails the assertion instead of
+    hanging the suite.
+    """
+    corpus = write_corpus(tmp_path / "corpus.txt", SENTENCES, repeats=400)
+    features = tmp_path / "features.txt"
+    model = tmp_path / "cancelled.model"
+
+    Extractor(Language.JAPANESE).extract(corpus, features)
+
+    cancel = CancelToken()
+    started = threading.Event()
+    cancelled_at: list[float] = []
+
+    def canceller() -> None:
+        started.wait(timeout=30.0)
+        time.sleep(0.2)
+        cancelled_at.append(time.monotonic())
+        cancel.cancel()
+
+    thread = threading.Thread(target=canceller)
+    thread.start()
+
+    trainer = Trainer(0.0, 200, features)
+    started.set()
+    train_started = time.monotonic()
+    metrics = trainer.train(model, cancel=cancel)
+    train_finished = time.monotonic()
+    thread.join(timeout=30.0)
+
+    assert cancelled_at, "the canceller thread never ran"
+    assert train_started < cancelled_at[0] < train_finished, (
+        "the canceller ran outside the training window, so the GIL was not released"
+    )
+    assert metrics.num_instances > 0
+    assert model.exists()


### PR DESCRIPTION
## Summary

Adds `litsea-python`, the Python binding, on top of `litsea-binding-core` (#201). Published to PyPI as `litsea`; the crate on crates.io stays `litsea-python`.

```python
from litsea import Language, Segmenter

seg = Segmenter.open(Language.JAPANESE, "models/japanese.model")
seg.segment("これはテストです。")
# ['これ', 'は', 'テスト', 'です', '。']
```

## Design

- **No `--pos` equivalent.** The model file identifies its own kind, so `has_pos` is a property of what was loaded rather than something the caller has to get right.
- **GIL.** `segment_batch`, `segment_with_pos_batch`, `extract`, and every `train` release it with `Python::detach` (renamed from `allow_threads` in PyO3 0.26). Single-sentence `segment` keeps it on purpose: releasing requires owning the input string (PyO3's `Ungil` bound), and that copy costs more than segmenting one sentence. Documented on the methods.
- **Cancellation.** `train(..., cancel=token)`; the binding never installs a signal handler. Because training releases the GIL, another thread can cancel a run in progress — which is what the test asserts.
- **Exceptions.** One class per `ErrorKind`, all deriving from `LitseaError`, so a single `except LitseaError` catches everything. `InvalidArgumentError` deliberately does *not* also subclass `ValueError`: multiple inheritance would undermine that guarantee.
- **Packaging.** Mixed layout (`python-source = "python"`, `module-name = "litsea._litsea"`) so the wheel carries type stubs and `py.typed`. `extension-module` is passed by maturin rather than declared in `Cargo.toml`, so plain `cargo test` still links.
- **Workspace.** The binding is a member (so `clippy --workspace` covers it) but not a default member, keeping the six-platform matrix from building a Python extension on runners without a Python dev environment.

## Verification

40 pytest tests + 5 Rust unit tests. The parity tests **build the `litsea` CLI and compare against its output** for all four languages, so the reference implementation decides what is correct.

Sabotage check on the test most at risk of being vacuous — removing `py.detach` from `Trainer.train`:

```text
E  AssertionError: the canceller ran outside the training window, so the GIL was not released
1 failed in 10.03s
```

Bounded, not hanging: the iteration count is tuned so an uncancelled run takes ~7 s.

Also green locally: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --all-features` (269), `make test-litsea-python`, `make lint-litsea-python`, `mypy` on the stubs, `markdownlint-cli2` (101 files), both mdbook builds.

## Corrections to what was previously written

1. **A doc claim merged in #207 was wrong.** It stated `japanese.model` splits `すもももももももものうち` into `["すもも", "も", "もも", …]`. Measured, the bundled model produces `すも も も も も も も もの うち`, and the CLI agrees — the binding is right, the documentation was not. All examples now use measured output, and the EN/JA binding-core pages are fixed in this PR.
2. **The type stubs claimed `enum.Enum`.** PyO3 classes are not: `list(Language)` and `Language["JAPANESE"]` both raise `TypeError`. A stub saying otherwise would typecheck code that fails at runtime. Stubs now describe plain classes with `ClassVar` members, and a test pins it.
3. **`eq_int` made `Language.JAPANESE == 0` true.** Dropped; a test covers it.

## Notes for the remaining bindings

For Korean and English the whitespace comes back as its own token (`["안녕하세요", " ", "반갑습니다"]`), which is what keeps byte offsets tiling the input exactly. Since the CLI joins tokens with a space, parity tests must compare whole rendered lines — re-splitting the CLI output cannot recover a whitespace token (the first version of the test failed for exactly that reason).

## Needs a repository-owner action

`publish-python` requires a **`PYPI_TOKEN`** secret. Until it exists the job fails at the upload step; the rest of the release is unaffected.

Closes #202
Refs #200
