### PR TITLE
feat: add litsea-ruby, the Ruby binding

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,6 +63,20 @@ updates:
           - "minor"
           - "patch"
 
+  - package-ecosystem: "bundler"
+    directory: "/litsea-ruby"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      # Same batching rationale as the cargo ecosystem above.
+      bundler-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -200,6 +200,42 @@ jobs:
       - name: Run PHP lint
         run: make lint-litsea-php
 
+  test-litsea-ruby:
+    name: Test litsea-ruby
+    needs: [format]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ["3.1", "3.3", "3.4"]
+    steps:
+      - name: Run checkout
+        uses: actions/checkout@v7
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-ruby-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+
+      - name: Run Ruby test
+        run: make test-litsea-ruby
+
+      - name: Run Ruby lint
+        run: make lint-litsea-ruby
+
   feature-check:
     name: Feature check
     needs: [format]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,9 +201,45 @@ jobs:
       - name: Run PHP lint
         run: make lint-litsea-php
 
+  test-litsea-ruby:
+    name: Test litsea-ruby
+    needs: [format]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ["3.1", "3.3", "3.4"]
+    steps:
+      - name: Run checkout
+        uses: actions/checkout@v7
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-ruby-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+
+      - name: Run Ruby test
+        run: make test-litsea-ruby
+
+      - name: Run Ruby lint
+        run: make lint-litsea-ruby
+
   create-release:
     name: Create Release
-    needs: [test, test-litsea-python, test-litsea-nodejs, test-litsea-php]
+    needs: [test, test-litsea-python, test-litsea-nodejs, test-litsea-php, test-litsea-ruby]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
@@ -521,3 +557,42 @@ jobs:
           npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-ruby:
+    name: Publish litsea to RubyGems
+    needs: [test-litsea-ruby, publish-crates]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run checkout
+        uses: actions/checkout@v7
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+
+      - name: Build gem
+        working-directory: litsea-ruby
+        run: |
+          bundle install
+          bundle exec rake build
+
+      - name: Publish to RubyGems
+        # Requires the RUBYGEMS_API_KEY repository secret; until it is set
+        # this step fails and the rest of the release is unaffected. The gem
+        # is source-only, so it compiles on the user's machine at install
+        # time.
+        working-directory: litsea-ruby
+        run: |
+          mkdir -p ~/.gem
+          printf -- "---\n:rubygems_api_key: %s\n" "${RUBYGEMS_API_KEY}" > ~/.gem/credentials
+          chmod 0600 ~/.gem/credentials
+          gem push pkg/litsea-*.gem
+        env:
+          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,9 @@ package-lock.json
 vendor/
 composer.lock
 .phpunit.cache/
+# Build artifacts of the litsea-ruby binding
+litsea-ruby/tmp/
+litsea-ruby/pkg/
+litsea-ruby/lib/litsea/*.so
+Gemfile.lock
+.bundle/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ### Added
 
+- New crate `litsea-ruby` (#205): the Ruby binding for Ruby 3.1+, built with
+  magnus and rb-sys and published to RubyGems as `litsea` (source-only; the
+  extension compiles on install). Exposes `Litsea::Segmenter`
+  (`open` / `from_bytes` / `from_uri`, `segment`, `segment_batch`,
+  `segment_tokens`, `segment_with_pos`, `segment_with_pos_batch`),
+  `Litsea::Token`, and the training pipeline, with an error hierarchy rooted
+  at `Litsea::Error` matching the Python and PHP bindings. Language arguments
+  accept a Symbol or a String. Byte offsets pair with `String#byteslice`.
+  Long-running work **releases the GVL**, so other Ruby threads keep running
+  and one of them can cancel a training run that is already going -- neither
+  magnus nor rb-sys wraps `rb_thread_call_without_gvl`, so the binding
+  declares it itself behind a panic-catching trampoline (`src/gvl.rs`), and
+  two tests pin the behaviour. The gem embeds no models.
+
 - New crate `litsea-php` (#204): the PHP binding for PHP 8.1+, built with
   ext-php-rs and distributed on Packagist as `litsea/litsea` (source plus
   build instructions -- a PHP extension is built against a specific PHP ABI,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,7 +711,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1288,6 +1306,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libbz2-rs-sys"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,6 +1419,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "litsea-ruby"
+version = "0.12.0"
+dependencies = [
+ "litsea",
+ "litsea-binding-core",
+ "magnus",
+ "rb-sys",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,6 +1456,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca93e534d1142d1d0dcca6d25fe302508a5dfb40b302802904577725ea0b695b"
 dependencies = [
  "sha2",
+]
+
+[[package]]
+name = "magnus"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b36a5b126bbe97eb0d02d07acfeb327036c6319fd816139a49824a83b7f9012"
+dependencies = [
+ "magnus-macros",
+ "rb-sys",
+ "rb-sys-env",
+ "seq-macro",
+]
+
+[[package]]
+name = "magnus-macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47607461fd8e1513cb4f2076c197d8092d921a1ea75bd08af97398f593751892"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1957,6 +2014,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rb-sys"
+version = "0.9.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02faf625bb10ba893e3ae620f19c9fb1b5f8fcae0fe4eb86bb3f2230fad75edb"
+dependencies = [
+ "rb-sys-build",
+]
+
+[[package]]
+name = "rb-sys-build"
+version = "0.9.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05be6f9c86fe5482808162826f6c047d093b3670582296c770de1d94f8066694"
+dependencies = [
+ "bindgen",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "shell-words",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "rb-sys-env"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cca7ad6a7e21e72151d56fe2495a259b5670e204c3adac41ee7ef676ea08117a"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2201,6 +2288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2264,6 +2357,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -2387,7 +2486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "litsea-python",
     "litsea-nodejs",
     "litsea-php",
+    "litsea-ruby",
 ]
 # The language bindings are members (so `cargo clippy --workspace` covers
 # them) but not default members: the six-platform regression matrix would

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ PIP             := $(PYTHON_VENV_DIR)/bin/pip
 MATURIN         := $(PYTHON_VENV_DIR)/bin/maturin
 PYTEST          := $(PYTHON_VENV_DIR)/bin/pytest
 
+# `litsea-ruby` links against libruby, and rb-sys reads the interpreter's
+# configuration from RBCONFIG_* environment variables.
+CARGO_WITH_RBCONFIG = ruby -rrbconfig -e 'RbConfig::CONFIG.each { |k, v| ENV["RBCONFIG_\#{k.upcase}"] = v }; exec(*ARGV)' --
+
 USER_AGENT ?= $(shell curl --version | head -n1 | awk '{print $1"/"$2}')
 USER ?= $(shell whoami)
 HOSTNAME ?= $(shell hostname)
@@ -20,7 +24,7 @@ help: ## Show help
 	@echo "Available targets:"
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-24s %s\n", $$1, $$2}'
 
-clean: clean-litsea-python clean-litsea-nodejs clean-litsea-php ## Clean the project
+clean: clean-litsea-python clean-litsea-nodejs clean-litsea-php clean-litsea-ruby ## Clean the project
 	cargo clean
 
 clean-litsea-python: ## Clean litsea-python build artifacts
@@ -77,6 +81,30 @@ test-litsea-php: ## Test litsea-php (Rust unit tests + PHPUnit)
 lint-litsea-php: ## Lint litsea-php (clippy)
 	cargo clippy -p litsea-php --all-targets -- -D warnings
 
+clean-litsea-ruby: ## Clean litsea-ruby build artifacts
+	rm -rf litsea-ruby/tmp
+	rm -rf litsea-ruby/pkg
+	rm -f litsea-ruby/lib/litsea/litsea_ruby.so
+	rm -f litsea-ruby/Gemfile.lock
+
+# Fails early with an actionable message when the active Ruby has no
+# bundler (rbenv's `system` Ruby often does not).
+check-bundler:
+	@bundle --version >/dev/null 2>&1 || { \
+		echo "bundler is not usable with $$(ruby --version)."; \
+		echo "A version manager's shim can exist while the selected Ruby has no bundler."; \
+		echo "Select a Ruby that has it, e.g. 'rbenv local 3.4.9', or run 'gem install bundler'."; \
+		exit 1; \
+	}
+
+test-litsea-ruby: check-bundler ## Test litsea-ruby (Rust unit tests + minitest)
+	$(CARGO_WITH_RBCONFIG) cargo test -p litsea-ruby --lib
+	cd litsea-ruby && bundle install --quiet && bundle exec rake compile && bundle exec rake test
+
+lint-litsea-ruby: check-bundler ## Lint litsea-ruby (clippy + rubocop)
+	$(CARGO_WITH_RBCONFIG) cargo clippy -p litsea-ruby --all-targets -- -D warnings
+	cd litsea-ruby && bundle exec rubocop
+
 lint-litsea-python: setup-venv ## Lint litsea-python (clippy + ruff + mypy)
 	cargo clippy -p litsea-python --all-targets -- -D warnings
 	cd litsea-python && $(abspath $(PYTHON_VENV_DIR))/bin/ruff check python/ tests/ examples/
@@ -87,6 +115,9 @@ build: ## Build the project
 
 build-litsea-python: setup-venv ## Build a release wheel for litsea-python
 	cd litsea-python && VIRTUAL_ENV=$(abspath $(PYTHON_VENV_DIR)) $(abspath $(MATURIN)) build --release --out dist
+
+build-litsea-ruby: check-bundler ## Build litsea-ruby (release)
+	cd litsea-ruby && bundle install --quiet && bundle exec rake compile -- --release
 
 build-litsea-php: ## Build litsea-php (release)
 	cargo build -p litsea-php --release

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Litsea is usable from other languages through bindings that live in this reposit
 | [`litsea-python`](litsea-python/README.md) (PyPI: `litsea`) | Python 3.10+ | Available |
 | [`litsea-nodejs`](litsea-nodejs/README.md) (npm: `litsea`) | Node.js 20+ | Available |
 | [`litsea-php`](litsea-php/README.md) (Packagist: `litsea/litsea`) | PHP 8.1+ | Available |
-| `litsea-ruby` | Ruby | Planned ([#205](https://github.com/mosuka/litsea/issues/205)) |
+| [`litsea-ruby`](litsea-ruby/README.md) (RubyGems: `litsea`) | Ruby 3.1+ | Available |
 | `litsea-wasm` | WebAssembly | Planned ([#206](https://github.com/mosuka/litsea/issues/206)) |
 
 Bindings ship code only; models are supplied by the caller as a path, bytes, or URL. `litsea-binding-core` holds the logic they share.

--- a/docs/ja/src/SUMMARY.md
+++ b/docs/ja/src/SUMMARY.md
@@ -56,6 +56,7 @@
   - [Python](bindings/python.md)
   - [Node.js](bindings/nodejs.md)
   - [PHP](bindings/php.md)
+  - [Ruby](bindings/ruby.md)
 
 # トレーニングガイド
 

--- a/docs/ja/src/bindings.md
+++ b/docs/ja/src/bindings.md
@@ -10,7 +10,7 @@ Litsea は Rust のライブラリですが、他の言語からも利用でき�
 | [`litsea-python`](bindings/python.md) | Python 3.10+ | PyO3 + maturin | 提供済み |
 | [`litsea-nodejs`](bindings/nodejs.md) | Node.js 20+ | napi-rs | 提供済み |
 | [`litsea-php`](bindings/php.md) | PHP 8.1+ | ext-php-rs | 提供済み |
-| `litsea-ruby` | Ruby 3.1+ | magnus + rb-sys | 予定（[#205](https://github.com/mosuka/litsea/issues/205)） |
+| [`litsea-ruby`](bindings/ruby.md) | Ruby 3.1+ | magnus + rb-sys | 提供済み |
 | `litsea-wasm` | ブラウザ / Deno | wasm-bindgen | 予定（[#206](https://github.com/mosuka/litsea/issues/206)） |
 
 ## 設計方針

--- a/docs/ja/src/bindings/ruby.md
+++ b/docs/ja/src/bindings/ruby.md
@@ -1,0 +1,116 @@
+# Ruby
+
+`litsea-ruby` は [magnus](https://github.com/matsadler/magnus) と rb-sys を用いて Litsea を Ruby 3.1 以降へ公開するバインディングです。RubyGems では `litsea` として配布します。
+
+## インストール
+
+```sh
+gem install litsea
+```
+
+gem はソース配布で、インストール時に拡張をコンパイルするため Rust ツールチェーンが必要です。
+
+## モデルの入手
+
+gem にモデルは含まれません。[`models/`](https://github.com/mosuka/litsea/tree/main/models) から取得してパスを渡してください（[事前学習済みモデル](../pre-trained-models.md)を参照）。モデル自身が種別を持つため、フラグの指定は不要で、読み込んだモデルで何ができるかは `has_pos?` が示します。
+
+## 分割
+
+```ruby
+require "litsea"
+
+seg = Litsea::Segmenter.open(:japanese, "models/japanese.model")
+
+seg.segment("これはテストです。")
+# => ["これ", "は", "テスト", "です", "。"]
+```
+
+言語は Symbol でも String でも指定でき、ISO 639-1 コードも使えます（`:ja` / `"japanese"`）。
+
+空白区切りの言語では空白自体が 1 トークンとして返るため、トークンを連結すると常に入力が復元されます。
+
+```ruby
+Litsea::Segmenter.open(:korean, "models/korean.model").segment("안녕하세요 반갑습니다")
+# => ["안녕하세요", " ", "반갑습니다"]
+```
+
+## POS タグ付け
+
+```ruby
+seg = Litsea::Segmenter.open(:japanese, "models/japanese_pos.model")
+
+seg.segment_with_pos("これはテストです。").each do |token|
+  puts "#{token.surface}\t#{token.pos}\t[#{token.start}..#{token.end}]"
+end
+# これ    PRON    [0..6]
+# は      ADP     [6..9]
+# テスト  NOUN    [9..18]
+# です    AUX     [18..24]
+# 。      PUNCT   [24..27]
+```
+
+`start` と `end` は**バイト**オフセットです。Ruby の `String#[]` は文字単位なので、切り出しには `byteslice` を使ってください。
+
+```ruby
+text.byteslice(token.start, token.end - token.start)   # == token.surface
+```
+
+## API
+
+| 呼び出し | 戻り値 |
+|---------|-------|
+| `Litsea::Segmenter.open(language, path)` | セグメンタ |
+| `Litsea::Segmenter.from_bytes(language, data)` | セグメンタ（バイナリ String も可） |
+| `Litsea::Segmenter.from_uri(language, uri)` | セグメンタ |
+| `#segment(text)` | `Array<String>` |
+| `#segment_batch(texts)` | `Array<Array<String>>` |
+| `#segment_tokens(text)` | バイトオフセット付き `Array<Litsea::Token>` |
+| `#segment_with_pos(text)` | タグとオフセット付き `Array<Litsea::Token>` |
+| `#segment_with_pos_batch(texts)` | `Array<Array<Litsea::Token>>` |
+| `Litsea::Extractor.new(language)#extract(...)` | `nil` |
+| `Litsea::Extractor.new(language)#extract_two_stage(...)` | `nil` |
+| `Litsea::Trainer.new(threshold, iterations, features)#train(model, cancel:)` | `BinaryMetrics` |
+| `Litsea::PerceptronTrainer.new(epochs, features)#train(model, cancel:)` | `MulticlassMetrics` |
+| `Litsea::TwoStageTrainer.new(epochs, prefix, dominance:)#train(model, cancel:)` | `TwoStageMetrics` |
+
+## GVL の解放
+
+モデルの読み込み・特徴量抽出・学習といった時間のかかる処理は、GVL（Global VM Lock）を解放した状態で実行されます。そのため他の Ruby スレッドが動き続け、キャンセルが意味を持ちます。
+
+```ruby
+cancel = Litsea::CancelToken.new
+Thread.new { sleep 60; cancel.cancel }
+
+metrics = Litsea::Trainer.new(0.01, 100_000, "features.txt").train("japanese.model", cancel: cancel)
+```
+
+キャンセルは**エラーではありません**。次のチェックポイントで停止し、部分的に学習されたモデルを保存してメトリクスを返します。バインディングはシグナルハンドラを登録しません。
+
+`rb_thread_call_without_gvl` は magnus も rb-sys もラップしていません（magnus は未バインドの C 関数一覧に挙げており、この関数は rb-sys が生成するバインディングの対象外ヘッダで宣言されています）。そのため本バインディングは `src/gvl.rs` で自ら宣言し、パニックが C フレームを越えて巻き戻らないよう `extern "C"` のトランポリンで捕捉しています。この主張は 2 つのテストで担保しています。1 つは学習中に別の Ruby スレッドが動き続けること、もう 1 つは別スレッドからのキャンセルが学習ウィンドウ内に収まることです。GVL 解放を外すと両方とも失敗します。
+
+1 文の分割は GVL を保持したままです。解放のコストの方が処理そのものより大きいためです。
+
+`TwoStageTrainer` は 1 度しか使えません。学習時に stage 1 が AdaBoost モデルへ collapse され、トレーナが消費されるためです。状態は `available?` が示し、2 回目の `train` は例外を発生させます。
+
+## エラー
+
+すべてのエラーは `Litsea::Error` を継承するため、1 つの `rescue` で捕捉できます（Python・PHP バインディングと同じ階層です）。
+
+| エラー | 発生条件 |
+|-------|---------|
+| `Litsea::InvalidArgumentError` | 未知の言語名、未知の feature set、使用済みトレーナ |
+| `Litsea::ModelError` | ダウンロード失敗、または旧 joint POS モデル |
+| `Litsea::IoError` | ファイルの読み書き失敗 |
+| `Litsea::ParseError` | モデルまたは学習データの形式不正 |
+| `Litsea::UnsupportedError` | このビルドでは利用できないスキームや操作 |
+| `Litsea::PosUnavailableError` | 分割専用モデルに対する POS タグ付けの要求 |
+
+## 開発
+
+```sh
+make test-litsea-ruby    # cargo test + rake compile + rake test
+make lint-litsea-ruby    # clippy + rubocop
+make build-litsea-ruby   # リリースビルド
+```
+
+有効な Ruby で `bundle` が使える必要があります。バージョン管理ツールの shim が存在していても、選択中のインタプリタに bundler が無い場合があるため、Makefile がその旨を検出して案内します。パリティテストは `litsea` CLI をビルドし、その出力とバインディングの出力を突き合わせます。

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -56,6 +56,7 @@
   - [Python](bindings/python.md)
   - [Node.js](bindings/nodejs.md)
   - [PHP](bindings/php.md)
+  - [Ruby](bindings/ruby.md)
 
 # Training Guide
 

--- a/docs/src/bindings.md
+++ b/docs/src/bindings.md
@@ -10,7 +10,7 @@ Litsea is a Rust library, but it is also usable from other languages. The bindin
 | [`litsea-python`](bindings/python.md) | Python 3.10+ | PyO3 + maturin | Available |
 | [`litsea-nodejs`](bindings/nodejs.md) | Node.js 20+ | napi-rs | Available |
 | [`litsea-php`](bindings/php.md) | PHP 8.1+ | ext-php-rs | Available |
-| `litsea-ruby` | Ruby 3.1+ | magnus + rb-sys | Planned ([#205](https://github.com/mosuka/litsea/issues/205)) |
+| [`litsea-ruby`](bindings/ruby.md) | Ruby 3.1+ | magnus + rb-sys | Available |
 | `litsea-wasm` | Browser / Deno | wasm-bindgen | Planned ([#206](https://github.com/mosuka/litsea/issues/206)) |
 
 ## Design principles

--- a/docs/src/bindings/ruby.md
+++ b/docs/src/bindings/ruby.md
@@ -1,0 +1,116 @@
+# Ruby
+
+`litsea-ruby` exposes Litsea to Ruby 3.1+ through [magnus](https://github.com/matsadler/magnus) and rb-sys. It is published to RubyGems as `litsea`.
+
+## Installation
+
+```sh
+gem install litsea
+```
+
+The gem is source-only and compiles the extension on install, so a Rust toolchain is required.
+
+## Getting a model
+
+The gem contains no models. Download one from the [`models/`](https://github.com/mosuka/litsea/tree/main/models) directory and pass its path — see [Pre-trained Models](../pre-trained-models.md). The model identifies its own kind, so `has_pos?` reports what was loaded and no flag is needed.
+
+## Segmentation
+
+```ruby
+require "litsea"
+
+seg = Litsea::Segmenter.open(:japanese, "models/japanese.model")
+
+seg.segment("これはテストです。")
+# => ["これ", "は", "テスト", "です", "。"]
+```
+
+The language accepts a Symbol or a String, and the ISO 639-1 code works too (`:ja`, `"japanese"`).
+
+For space-delimited languages the whitespace is returned as its own token, so the tokens always reconstruct the input:
+
+```ruby
+Litsea::Segmenter.open(:korean, "models/korean.model").segment("안녕하세요 반갑습니다")
+# => ["안녕하세요", " ", "반갑습니다"]
+```
+
+## POS tagging
+
+```ruby
+seg = Litsea::Segmenter.open(:japanese, "models/japanese_pos.model")
+
+seg.segment_with_pos("これはテストです。").each do |token|
+  puts "#{token.surface}\t#{token.pos}\t[#{token.start}..#{token.end}]"
+end
+# これ    PRON    [0..6]
+# は      ADP     [6..9]
+# テスト  NOUN    [9..18]
+# です    AUX     [18..24]
+# 。      PUNCT   [24..27]
+```
+
+`start` and `end` are **byte** offsets. Ruby's `String#[]` counts characters, so slice with `byteslice`:
+
+```ruby
+text.byteslice(token.start, token.end - token.start)   # == token.surface
+```
+
+## API
+
+| Call | Returns |
+|------|---------|
+| `Litsea::Segmenter.open(language, path)` | A segmenter |
+| `Litsea::Segmenter.from_bytes(language, data)` | A segmenter (accepts a binary String) |
+| `Litsea::Segmenter.from_uri(language, uri)` | A segmenter |
+| `#segment(text)` | `Array<String>` |
+| `#segment_batch(texts)` | `Array<Array<String>>` |
+| `#segment_tokens(text)` | `Array<Litsea::Token>` with byte offsets |
+| `#segment_with_pos(text)` | `Array<Litsea::Token>` with tags and offsets |
+| `#segment_with_pos_batch(texts)` | `Array<Array<Litsea::Token>>` |
+| `Litsea::Extractor.new(language)#extract(...)` | `nil` |
+| `Litsea::Extractor.new(language)#extract_two_stage(...)` | `nil` |
+| `Litsea::Trainer.new(threshold, iterations, features)#train(model, cancel:)` | `BinaryMetrics` |
+| `Litsea::PerceptronTrainer.new(epochs, features)#train(model, cancel:)` | `MulticlassMetrics` |
+| `Litsea::TwoStageTrainer.new(epochs, prefix, dominance:)#train(model, cancel:)` | `TwoStageMetrics` |
+
+## Releasing the GVL
+
+Long-running work — loading a model, extracting features, training — runs with the Global VM Lock released, so other Ruby threads keep going. That is what makes cancellation useful:
+
+```ruby
+cancel = Litsea::CancelToken.new
+Thread.new { sleep 60; cancel.cancel }
+
+metrics = Litsea::Trainer.new(0.01, 100_000, "features.txt").train("japanese.model", cancel: cancel)
+```
+
+Cancelling is **not** an error: training stops at its next check point, still writes the partially trained model, and returns its metrics. The binding never installs a signal handler.
+
+Neither magnus nor rb-sys wraps `rb_thread_call_without_gvl` — magnus lists it among the C functions it does not bind, and it is declared in a header outside rb-sys's generated bindings — so the binding declares it itself in `src/gvl.rs`, behind an `extern "C"` trampoline that catches panics so none can unwind across the C frame. Two tests hold that claim honest: one asserts another Ruby thread keeps ticking during training, and one asserts a cancel from another thread lands inside the training window. Removing the GVL release turns both red.
+
+Segmentation of a single sentence keeps the GVL: it is short enough that releasing it would cost more than the work.
+
+A `TwoStageTrainer` can only be used once — training collapses stage 1 into an AdaBoost model, which consumes it. `available?` reports the state, and a second `train` raises.
+
+## Errors
+
+Every error derives from `Litsea::Error`, so one `rescue` handles them all — the same hierarchy the Python and PHP bindings expose.
+
+| Error | Raised when |
+|-------|-------------|
+| `Litsea::InvalidArgumentError` | Unknown language name, unknown feature set, reused trainer |
+| `Litsea::ModelError` | Download failed, or the file is a legacy joint POS model |
+| `Litsea::IoError` | A file could not be read or written |
+| `Litsea::ParseError` | The model or training data is malformed |
+| `Litsea::UnsupportedError` | The scheme or operation is unavailable in this build |
+| `Litsea::PosUnavailableError` | POS tagging requested from a segmentation-only model |
+
+## Development
+
+```sh
+make test-litsea-ruby    # cargo test + rake compile + rake test
+make lint-litsea-ruby    # clippy + rubocop
+make build-litsea-ruby   # release build
+```
+
+`bundle` must be usable with the active Ruby; a version manager's shim can exist while the selected interpreter has no bundler, so the Makefile checks and says so. The parity tests build the `litsea` CLI and compare the binding's output against it.

--- a/litsea-ruby/.rubocop.yml
+++ b/litsea-ruby/.rubocop.yml
@@ -1,0 +1,21 @@
+AllCops:
+  TargetRubyVersion: 3.1
+  NewCops: enable
+  Exclude:
+    - "tmp/**/*"
+    - "vendor/**/*"
+
+# Tests read better with long descriptive blocks and literal corpora.
+Metrics/BlockLength:
+  Enabled: false
+Metrics/ClassLength:
+  Exclude:
+    - "test/**/*.rb"
+Metrics/MethodLength:
+  Enabled: false
+Metrics/AbcSize:
+  Enabled: false
+Layout/LineLength:
+  Max: 120
+Style/Documentation:
+  Enabled: false

--- a/litsea-ruby/Cargo.toml
+++ b/litsea-ruby/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "litsea-ruby"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "Ruby binding for Litsea."
+documentation = "https://docs.rs/litsea-ruby"
+homepage.workspace = true
+repository.workspace = true
+readme = "README.md"
+keywords = ["word", "segmentation", "nlp", "ruby", "binding"]
+categories.workspace = true
+license.workspace = true
+
+[lib]
+name = "litsea_ruby"
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+litsea.workspace = true
+litsea-binding-core = { workspace = true, features = ["remote_model"] }
+magnus = { version = "0.8.2", features = ["rb-sys"] }
+# Used only to link against libruby; the GVL entry point is declared by
+# hand in `gvl.rs` because neither magnus nor rb-sys exposes it.
+rb-sys = "0.9.130"

--- a/litsea-ruby/Gemfile
+++ b/litsea-ruby/Gemfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gemspec
+
+gem 'minitest', '~> 5.0'
+gem 'rake', '~> 13.0'
+gem 'rake-compiler', '~> 1.2'
+gem 'rb_sys', '~> 0.9'
+gem 'rubocop', '~> 1.60', require: false

--- a/litsea-ruby/README.md
+++ b/litsea-ruby/README.md
@@ -1,0 +1,137 @@
+# litsea-ruby
+
+Ruby binding for [Litsea](https://github.com/mosuka/litsea), a compact word segmentation and POS (Part-of-Speech) tagging library for Japanese, Chinese, Korean, and English.
+
+[日本語のREADME](README_ja.md)
+
+## Installation
+
+```sh
+gem install litsea
+```
+
+The gem compiles the native extension on install, so a Rust toolchain is required. Ruby 3.1 or later.
+
+## Models are not bundled
+
+The gem ships code only. Download a pre-trained model from the [Litsea repository](https://github.com/mosuka/litsea/tree/main/models) and point the segmenter at it:
+
+| Model | Purpose | Size |
+|-------|---------|------|
+| `japanese.model`, `chinese.model`, `korean.model`, `english.model` | Segmentation | 84 KB – 2.0 MB |
+| `japanese_pos.model`, `chinese_pos.model`, `korean_pos.model`, `english_pos.model` | Segmentation + POS | 3.0 – 8.0 MB |
+
+You never have to say which kind you have: the model file identifies itself, and `has_pos?` reports what the loaded model can do.
+
+## Usage
+
+### Segmentation
+
+```ruby
+require "litsea"
+
+seg = Litsea::Segmenter.open(:japanese, "models/japanese.model")
+
+seg.segment("これはテストです。")
+# => ["これ", "は", "テスト", "です", "。"]
+
+seg.segment_batch(["これはテストです。", "東京都から神奈川県へ引っ越した"])
+```
+
+The language accepts a Symbol or a String, and the ISO 639-1 code works too: `:ja`, `"japanese"`.
+
+For space-delimited languages the whitespace comes back as its own token, so the tokens always reconstruct the input:
+
+```ruby
+Litsea::Segmenter.open(:korean, "models/korean.model").segment("안녕하세요 반갑습니다")
+# => ["안녕하세요", " ", "반갑습니다"]
+```
+
+### POS tagging
+
+```ruby
+seg = Litsea::Segmenter.open(:japanese, "models/japanese_pos.model")
+
+seg.segment_with_pos("これはテストです。").each do |token|
+  puts "#{token.surface}\t#{token.pos}\t[#{token.start}..#{token.end}]"
+end
+# これ    PRON    [0..6]
+# は      ADP     [6..9]
+# テスト  NOUN    [9..18]
+# です    AUX     [18..24]
+# 。      PUNCT   [24..27]
+```
+
+`start` and `end` are **byte** offsets, so slice with `byteslice` — Ruby's `String#[]` counts characters:
+
+```ruby
+text.byteslice(token.start, token.end - token.start)   # == token.surface
+```
+
+Calling `segment_with_pos` on a segmentation-only model raises `Litsea::PosUnavailableError`.
+
+### Other model sources
+
+```ruby
+Litsea::Segmenter.from_bytes(:korean, File.binread("korean.model"))
+Litsea::Segmenter.from_uri(:chinese, "https://example.com/chinese.model")
+```
+
+### Training
+
+```ruby
+Litsea::Extractor.new(:japanese).extract("corpus.txt", "features.txt")
+
+metrics = Litsea::Trainer.new(0.01, 10_000, "features.txt").train("japanese.model")
+puts format("accuracy: %.2f%%", metrics.accuracy)
+```
+
+Two-stage (segmentation + POS) training:
+
+```ruby
+Litsea::Extractor.new(:japanese).extract_two_stage("corpus_pos.txt", "features", feature_set: "fast")
+
+metrics = Litsea::TwoStageTrainer.new(10, "features").train("japanese_pos.model")
+puts metrics.stage1.accuracy, metrics.stage2.accuracy
+```
+
+A `TwoStageTrainer` can only be used once — training collapses stage 1 into an AdaBoost model, which consumes it. `available?` reports whether it can still run, and a second `train` raises.
+
+### Cancelling a training run
+
+Training releases the GVL, so other Ruby threads keep running — which means one of them can stop a run that is already going:
+
+```ruby
+cancel = Litsea::CancelToken.new
+Thread.new { sleep 60; cancel.cancel }
+
+metrics = Litsea::Trainer.new(0.01, 100_000, "features.txt").train("japanese.model", cancel: cancel)
+```
+
+Cancelling is **not** an error: training stops at its next check point, still writes the partially trained model, and returns its metrics. The binding never installs a signal handler.
+
+## Errors
+
+Every error derives from `Litsea::Error`, so one `rescue` handles them all.
+
+| Error | Raised when |
+|-------|-------------|
+| `Litsea::InvalidArgumentError` | Unknown language name, unknown feature set, reused trainer |
+| `Litsea::ModelError` | Download failed, or the file is a legacy joint POS model |
+| `Litsea::IoError` | A file could not be read or written |
+| `Litsea::ParseError` | The model or training data is malformed |
+| `Litsea::UnsupportedError` | The scheme or operation is unavailable in this build |
+| `Litsea::PosUnavailableError` | POS tagging requested from a segmentation-only model |
+
+## Development
+
+```sh
+make test-litsea-ruby    # cargo test + rake compile + rake test
+make build-litsea-ruby   # release build
+```
+
+The parity tests build the `litsea` CLI and compare the binding's output against it. Note that `bundle` must be available for the active Ruby; with rbenv, `rbenv local 3.4.9` (or any installed 3.1+) is enough.
+
+## License
+
+MIT. See [LICENSE](../LICENSE).

--- a/litsea-ruby/README_ja.md
+++ b/litsea-ruby/README_ja.md
@@ -1,0 +1,137 @@
+# litsea-ruby
+
+[Litsea](https://github.com/mosuka/litsea) の Ruby バインディングです。Litsea は日本語・中国語・韓国語・英語に対応した、コンパクトな単語分割と品詞（POS）タグ付けのライブラリです。
+
+[English README](README.md)
+
+## インストール
+
+```sh
+gem install litsea
+```
+
+インストール時にネイティブ拡張をコンパイルするため、Rust ツールチェーンが必要です。Ruby 3.1 以降に対応しています。
+
+## モデルは同梱されません
+
+gem にはコードのみが含まれます。事前学習済みモデルは [Litsea リポジトリ](https://github.com/mosuka/litsea/tree/main/models)から取得し、パスを指定して読み込んでください。
+
+| モデル | 用途 | サイズ |
+|-------|------|-------|
+| `japanese.model`, `chinese.model`, `korean.model`, `english.model` | 分割 | 84KB〜2.0MB |
+| `japanese_pos.model`, `chinese_pos.model`, `korean_pos.model`, `english_pos.model` | 分割 + POS | 3.0〜8.0MB |
+
+どちらの種別かを指定する必要はありません。モデルファイル自身が種別を持っており、読み込んだモデルで何ができるかは `has_pos?` が示します。
+
+## 使い方
+
+### 分割
+
+```ruby
+require "litsea"
+
+seg = Litsea::Segmenter.open(:japanese, "models/japanese.model")
+
+seg.segment("これはテストです。")
+# => ["これ", "は", "テスト", "です", "。"]
+
+seg.segment_batch(["これはテストです。", "東京都から神奈川県へ引っ越した"])
+```
+
+言語は Symbol でも String でも指定でき、ISO 639-1 コードも使えます（`:ja` / `"japanese"`）。
+
+空白区切りの言語では空白自体が 1 トークンとして返るため、トークンを連結すると常に入力が復元されます。
+
+```ruby
+Litsea::Segmenter.open(:korean, "models/korean.model").segment("안녕하세요 반갑습니다")
+# => ["안녕하세요", " ", "반갑습니다"]
+```
+
+### POS タグ付け
+
+```ruby
+seg = Litsea::Segmenter.open(:japanese, "models/japanese_pos.model")
+
+seg.segment_with_pos("これはテストです。").each do |token|
+  puts "#{token.surface}\t#{token.pos}\t[#{token.start}..#{token.end}]"
+end
+# これ    PRON    [0..6]
+# は      ADP     [6..9]
+# テスト  NOUN    [9..18]
+# です    AUX     [18..24]
+# 。      PUNCT   [24..27]
+```
+
+`start` と `end` は**バイト**オフセットです。Ruby の `String#[]` は文字単位なので、切り出しには `byteslice` を使ってください。
+
+```ruby
+text.byteslice(token.start, token.end - token.start)   # == token.surface
+```
+
+分割専用モデルに対して `segment_with_pos` を呼ぶと `Litsea::PosUnavailableError` が発生します。
+
+### その他のモデル読み込み方法
+
+```ruby
+Litsea::Segmenter.from_bytes(:korean, File.binread("korean.model"))
+Litsea::Segmenter.from_uri(:chinese, "https://example.com/chinese.model")
+```
+
+### 学習
+
+```ruby
+Litsea::Extractor.new(:japanese).extract("corpus.txt", "features.txt")
+
+metrics = Litsea::Trainer.new(0.01, 10_000, "features.txt").train("japanese.model")
+puts format("accuracy: %.2f%%", metrics.accuracy)
+```
+
+二段構成（分割 + POS）の学習:
+
+```ruby
+Litsea::Extractor.new(:japanese).extract_two_stage("corpus_pos.txt", "features", feature_set: "fast")
+
+metrics = Litsea::TwoStageTrainer.new(10, "features").train("japanese_pos.model")
+puts metrics.stage1.accuracy, metrics.stage2.accuracy
+```
+
+`TwoStageTrainer` は 1 度しか使えません。学習時に stage 1 が AdaBoost モデルへ collapse され、トレーナが消費されるためです。再利用可能かどうかは `available?` が示し、2 回目の `train` は例外を発生させます。
+
+### 学習のキャンセル
+
+学習は GVL を解放するため、他の Ruby スレッドが動き続けます。つまり、実行中の学習を別スレッドから停止できます。
+
+```ruby
+cancel = Litsea::CancelToken.new
+Thread.new { sleep 60; cancel.cancel }
+
+metrics = Litsea::Trainer.new(0.01, 100_000, "features.txt").train("japanese.model", cancel: cancel)
+```
+
+キャンセルは**エラーではありません**。次のチェックポイントで停止し、部分的に学習されたモデルを保存してメトリクスを返します。バインディングはシグナルハンドラを登録しません。
+
+## エラー
+
+すべてのエラーは `Litsea::Error` を継承するため、1 つの `rescue` で捕捉できます。
+
+| エラー | 発生条件 |
+|-------|---------|
+| `Litsea::InvalidArgumentError` | 未知の言語名、未知の feature set、使用済みトレーナ |
+| `Litsea::ModelError` | ダウンロード失敗、または旧 joint POS モデル |
+| `Litsea::IoError` | ファイルの読み書き失敗 |
+| `Litsea::ParseError` | モデルまたは学習データの形式不正 |
+| `Litsea::UnsupportedError` | このビルドでは利用できないスキームや操作 |
+| `Litsea::PosUnavailableError` | 分割専用モデルに対する POS タグ付けの要求 |
+
+## 開発
+
+```sh
+make test-litsea-ruby    # cargo test + rake compile + rake test
+make build-litsea-ruby   # リリースビルド
+```
+
+パリティテストは `litsea` CLI をビルドし、その出力とバインディングの出力を突き合わせます。なお、有効な Ruby に `bundle` が入っている必要があります（rbenv なら `rbenv local 3.4.9` などで 3.1 以降を選択してください）。
+
+## ライセンス
+
+MIT。[LICENSE](../LICENSE) を参照してください。

--- a/litsea-ruby/Rakefile
+++ b/litsea-ruby/Rakefile
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+require 'rb_sys/extensiontask'
+
+GEMSPEC = Gem::Specification.load('litsea.gemspec')
+
+RbSys::ExtensionTask.new('litsea-ruby', GEMSPEC) do |ext|
+  ext.lib_dir = 'lib/litsea'
+end
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/test_*.rb']
+  t.warning = false
+end
+
+task default: %i[compile test]

--- a/litsea-ruby/examples/segment.rb
+++ b/litsea-ruby/examples/segment.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Segment a sentence, with and without POS tags.
+#
+# Usage:
+#   bundle exec ruby -Ilib examples/segment.rb ../models/japanese.model "これはテストです。"
+
+require 'litsea'
+
+model_path, text = ARGV
+if model_path.nil? || text.nil?
+  warn 'usage: ruby examples/segment.rb <model> <text>'
+  exit 2
+end
+
+# The model file identifies its own kind, so nothing here declares whether
+# this is a POS model - has_pos? reports what was loaded.
+segmenter = Litsea::Segmenter.open(:japanese, model_path)
+puts "model: #{model_path} (has_pos?=#{segmenter.has_pos?})"
+puts "tokens: #{segmenter.segment(text).join(' ')}"
+
+return unless segmenter.has_pos?
+
+puts 'tagged:'
+segmenter.segment_with_pos(text).each do |token|
+  puts format("  %<surface>s\t%<pos>s\t[%<start>d:%<end>d]",
+              surface: token.surface, pos: token.pos, start: token.start, end: token.end)
+end

--- a/litsea-ruby/examples/train.rb
+++ b/litsea-ruby/examples/train.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Train a segmentation model, cancelling it from another thread.
+#
+# Usage:
+#   bundle exec ruby -Ilib examples/train.rb corpus.txt out.model
+#
+# The corpus is one sentence per line, with words separated by spaces:
+#
+#   これ は テスト です 。
+
+require 'litsea'
+require 'tmpdir'
+
+corpus, model = ARGV
+if corpus.nil? || model.nil?
+  warn 'usage: ruby examples/train.rb <corpus> <model>'
+  exit 2
+end
+
+work_dir = Dir.mktmpdir('litsea-')
+features = File.join(work_dir, 'features.txt')
+
+puts "extracting features from #{corpus} ..."
+Litsea::Extractor.new(:japanese).extract(corpus, features)
+
+# Training releases the GVL, so this thread keeps running and can stop the
+# run. Cancelling is not an error: the partial model is still written.
+cancel = Litsea::CancelToken.new
+watchdog = Thread.new do
+  sleep 60
+  cancel.cancel
+end
+
+puts 'training (stops after 60s if it has not converged) ...'
+metrics = Litsea::Trainer.new(0.01, 10_000, features).train(model, cancel: cancel)
+watchdog.kill
+
+puts "wrote #{model}"
+puts format('  accuracy:  %.2f%%', metrics.accuracy)
+puts format('  precision: %.2f%%', metrics.precision)
+puts format('  recall:    %.2f%%', metrics.recall)
+puts "  instances: #{metrics.num_instances}"
+puts '  (training was cancelled; the model is partially trained)' if cancel.cancelled?

--- a/litsea-ruby/extconf.rb
+++ b/litsea-ruby/extconf.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'mkmf'
+require 'rb_sys/mkmf'
+
+# The crate lives at the gem root (it is also a workspace member of the
+# Litsea repository), so no ext_dir override is needed.
+create_rust_makefile('litsea/litsea_ruby')

--- a/litsea-ruby/lib/litsea.rb
+++ b/litsea-ruby/lib/litsea.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative 'litsea/version'
+
+# Loads the compiled extension, preferring a version-specific build when
+# rake-compiler produced one.
+begin
+  RUBY_VERSION =~ /(\d+\.\d+)/
+  require "litsea/#{Regexp.last_match(1)}/litsea_ruby"
+rescue LoadError
+  require 'litsea/litsea_ruby'
+end
+
+# Word segmentation and POS tagging.
+#
+# See {Litsea::Segmenter} to get started; every class is defined by the
+# native extension.
+module Litsea
+end

--- a/litsea-ruby/lib/litsea/version.rb
+++ b/litsea-ruby/lib/litsea/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Litsea
+  # Kept in lockstep with the `litsea` crate; `Litsea.version` reports the
+  # version the native extension was built from.
+  VERSION = '0.12.0'
+end

--- a/litsea-ruby/litsea.gemspec
+++ b/litsea-ruby/litsea.gemspec
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative 'lib/litsea/version'
+
+Gem::Specification.new do |spec|
+  spec.name = 'litsea'
+  spec.version = Litsea::VERSION
+  spec.authors = ['Minoru Osuka']
+  spec.summary = 'Ruby binding for Litsea, a compact word segmentation and POS tagging library'
+  spec.description = 'Ruby binding for Litsea: word segmentation and Universal POS tagging ' \
+                     'for Japanese, Chinese, Korean, and English. Models are not bundled.'
+  spec.homepage = 'https://github.com/mosuka/litsea'
+  spec.license = 'MIT'
+  spec.required_ruby_version = '>= 3.1'
+
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = spec.homepage
+  spec.metadata['bug_tracker_uri'] = "#{spec.homepage}/issues"
+  spec.metadata['rubygems_mfa_required'] = 'true'
+
+  spec.files = Dir[
+    'lib/**/*.rb',
+    'extconf.rb',
+    'src/**/*.rs',
+    'Cargo.toml',
+    'README.md',
+    'README_ja.md'
+  ]
+  spec.extensions = ['extconf.rb']
+  spec.require_paths = ['lib']
+
+  spec.add_dependency 'rb_sys', '~> 0.9'
+end

--- a/litsea-ruby/src/error.rs
+++ b/litsea-ruby/src/error.rs
@@ -1,0 +1,120 @@
+//! The Ruby exception hierarchy.
+//!
+//! Mirrors the Python and PHP bindings: one class per [`ErrorKind`], all
+//! below `Litsea::Error`, so `rescue Litsea::Error` catches everything the
+//! binding raises.
+
+use litsea_binding_core::{CoreError, ErrorKind};
+use magnus::{Module, RModule, Ruby, error::Error, exception::ExceptionClass};
+
+/// Holds the exception classes, looked up from the `Litsea` module.
+///
+/// Ruby classes are values, not types, so they are resolved on demand rather
+/// than stored in Rust statics (a `Ruby` handle is only valid on a Ruby
+/// thread).
+struct Exceptions {
+    /// `Litsea::Error`, the base class.
+    base: ExceptionClass,
+    /// `Litsea::InvalidArgumentError`.
+    invalid_argument: ExceptionClass,
+    /// `Litsea::ModelError`.
+    model: ExceptionClass,
+    /// `Litsea::IoError`.
+    io: ExceptionClass,
+    /// `Litsea::ParseError`.
+    parse: ExceptionClass,
+    /// `Litsea::UnsupportedError`.
+    unsupported: ExceptionClass,
+    /// `Litsea::PosUnavailableError`.
+    pos_unavailable: ExceptionClass,
+}
+
+/// Looks up the exception classes defined by [`define_exceptions`].
+///
+/// # Arguments
+/// * `ruby` - The Ruby handle for the current thread.
+///
+/// # Returns
+/// The exception classes, or `None` if the module has not been defined yet.
+fn exceptions(ruby: &Ruby) -> Option<Exceptions> {
+    let module: RModule = ruby.class_object().const_get("Litsea").ok()?;
+    Some(Exceptions {
+        base: module.const_get("Error").ok()?,
+        invalid_argument: module.const_get("InvalidArgumentError").ok()?,
+        model: module.const_get("ModelError").ok()?,
+        io: module.const_get("IoError").ok()?,
+        parse: module.const_get("ParseError").ok()?,
+        unsupported: module.const_get("UnsupportedError").ok()?,
+        pos_unavailable: module.const_get("PosUnavailableError").ok()?,
+    })
+}
+
+/// Defines `Litsea::Error` and its subclasses on the given module.
+///
+/// # Arguments
+/// * `ruby` - The Ruby handle for the current thread.
+/// * `module` - The `Litsea` module to define the classes on.
+///
+/// # Returns
+/// `()` on success.
+///
+/// # Errors
+/// Returns a Ruby exception if a class cannot be defined.
+pub fn define_exceptions(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
+    let base = module.define_error("Error", ruby.exception_standard_error())?;
+    module.define_error("InvalidArgumentError", base)?;
+    module.define_error("ModelError", base)?;
+    module.define_error("IoError", base)?;
+    module.define_error("ParseError", base)?;
+    module.define_error("UnsupportedError", base)?;
+    module.define_error("PosUnavailableError", base)?;
+    Ok(())
+}
+
+/// Converts a [`CoreError`] into the matching Ruby exception.
+///
+/// # Arguments
+/// * `error` - The error to convert.
+///
+/// # Returns
+/// A magnus [`Error`] carrying the class that matches the error's kind;
+/// [`ErrorKind::Runtime`] uses `Litsea::Error` itself.
+pub fn to_ruby_error(error: CoreError) -> Error {
+    let message = error.message().to_string();
+    let Ok(ruby) = Ruby::get() else {
+        // Not on a Ruby thread, which cannot happen for a call that came
+        // from Ruby - but the type system does not know that. The
+        // handle-based replacement for this constructor needs the very
+        // handle we just failed to get, so the deprecated free function is
+        // the only way to build an error here.
+        #[allow(deprecated)]
+        return Error::new(magnus::exception::fatal(), message);
+    };
+
+    let Some(classes) = exceptions(&ruby) else {
+        return Error::new(ruby.exception_runtime_error(), message);
+    };
+
+    let class = match error.kind() {
+        ErrorKind::InvalidArgument => classes.invalid_argument,
+        ErrorKind::Model => classes.model,
+        ErrorKind::Io => classes.io,
+        ErrorKind::Parse => classes.parse,
+        ErrorKind::Unsupported => classes.unsupported,
+        ErrorKind::PosUnavailable => classes.pos_unavailable,
+        ErrorKind::Runtime => classes.base,
+    };
+
+    Error::new(class, message)
+}
+
+/// Maps a core result onto a Ruby result.
+///
+/// # Arguments
+/// * `result` - The result to convert.
+///
+/// # Returns
+/// The original value, or the mapped Ruby exception.
+pub fn map_err<T>(result: Result<T, CoreError>) -> Result<T, Error> {
+    result.map_err(to_ruby_error)
+}

--- a/litsea-ruby/src/gvl.rs
+++ b/litsea-ruby/src/gvl.rs
@@ -1,0 +1,112 @@
+//! Releasing the GVL around long-running work.
+//!
+//! Ruby is genuinely multi-threaded, so a `train()` that holds the Global VM
+//! Lock blocks every other Ruby thread in the process - including the one
+//! that would cancel it. Releasing the lock is what makes
+//! `Litsea::CancelToken` usable while training runs, exactly as
+//! `Python::detach` does for the Python binding.
+//!
+//! Neither magnus nor `rb-sys` exposes `rb_thread_call_without_gvl`: magnus
+//! lists it among the C functions it does not wrap, and it is declared in
+//! `ruby/thread.h`, which is outside the bindings `rb-sys` generates. The
+//! declaration below is therefore written by hand. The symbol resolves
+//! because the extension links against libruby regardless.
+
+use std::ffi::c_void;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+unsafe extern "C" {
+    /// Runs `func` with the GVL released.
+    ///
+    /// `ubf` is the "unblocking function" Ruby calls to interrupt the work;
+    /// passing null selects Ruby's default, which defers interrupts until
+    /// the call returns. That is what we want: the work is pure computation
+    /// with no blocking syscall to interrupt, and it stops on its own when
+    /// the cancellation flag is cleared.
+    fn rb_thread_call_without_gvl(
+        func: unsafe extern "C" fn(*mut c_void) -> *mut c_void,
+        data1: *mut c_void,
+        ubf: *const c_void,
+        data2: *mut c_void,
+    ) -> *mut c_void;
+}
+
+/// State handed to the trampoline and filled in with the closure's result.
+struct Payload<F, R> {
+    /// The closure to run, taken by the trampoline.
+    func: Option<F>,
+    /// Where the result lands; `None` if the closure panicked.
+    result: Option<R>,
+}
+
+/// The `extern "C"` entry point Ruby calls with the GVL released.
+///
+/// # Safety
+/// `data` must be a valid `*mut Payload<F, R>` that outlives the call, which
+/// [`without_gvl`] guarantees by keeping the payload on its own stack frame
+/// for the duration of `rb_thread_call_without_gvl`.
+unsafe extern "C" fn trampoline<F, R>(data: *mut c_void) -> *mut c_void
+where
+    F: FnOnce() -> R,
+{
+    // SAFETY: `without_gvl` passes a pointer to a live `Payload<F, R>` and
+    // does not touch it until this function returns.
+    let payload = unsafe { &mut *(data as *mut Payload<F, R>) };
+
+    if let Some(func) = payload.func.take() {
+        // A panic must not unwind across the C frame Ruby put on the stack:
+        // that is undefined behaviour. Catch it here and report it as a
+        // missing result, which `without_gvl` turns back into a panic on the
+        // Rust side of the boundary.
+        payload.result = catch_unwind(AssertUnwindSafe(func)).ok();
+    }
+
+    std::ptr::null_mut()
+}
+
+/// Runs `func` with the GVL released, so other Ruby threads keep running.
+///
+/// The closure runs on the calling thread, not a new one. It **must not**
+/// touch the Ruby API - doing so without the GVL is undefined behaviour.
+/// Every caller in this crate passes pure Rust work (segmentation or
+/// training) that only reaches `litsea`.
+///
+/// # Arguments
+/// * `func` - The work to run without the GVL.
+///
+/// # Returns
+/// Whatever `func` returns.
+///
+/// # Panics
+/// Re-panics on the Rust side if `func` panicked, after the panic has been
+/// contained inside the C call.
+pub fn without_gvl<F, R>(func: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    let mut payload = Payload {
+        func: Some(func),
+        result: None,
+    };
+
+    // SAFETY: `trampoline::<F, R>` matches the signature Ruby expects, and
+    // `&mut payload` stays valid for the whole call because
+    // `rb_thread_call_without_gvl` returns before this frame is dropped. A
+    // null unblocking function selects Ruby's default deferred-interrupt
+    // behaviour, which is correct for non-blocking computation.
+    unsafe {
+        rb_thread_call_without_gvl(
+            trampoline::<F, R>,
+            std::ptr::addr_of_mut!(payload) as *mut c_void,
+            std::ptr::null(),
+            std::ptr::null_mut(),
+        );
+    }
+
+    match payload.result.take() {
+        Some(result) => result,
+        // The closure panicked; the panic was contained in the trampoline so
+        // it could not unwind through C, and is re-raised here.
+        None => panic!("a Litsea operation panicked while the GVL was released"),
+    }
+}

--- a/litsea-ruby/src/language.rs
+++ b/litsea-ruby/src/language.rs
@@ -1,0 +1,31 @@
+//! Language arguments.
+//!
+//! Ruby callers reach for a Symbol (`:japanese`) as readily as a String, and
+//! magnus converts neither into the other automatically, so both are
+//! accepted here.
+
+use litsea::Language;
+use litsea_binding_core::parse_language;
+use magnus::{Symbol, TryConvert, Value, error::Error};
+
+use crate::error::map_err;
+
+/// Converts a Ruby String or Symbol into a [`Language`].
+///
+/// # Arguments
+/// * `value` - The language name or ISO 639-1 code, as a String or Symbol.
+///
+/// # Returns
+/// The parsed language.
+///
+/// # Errors
+/// Raises `Litsea::InvalidArgumentError` for an unknown language, or a
+/// `TypeError` if the value is neither a String nor a Symbol.
+pub fn language_from_value(value: Value) -> Result<Language, Error> {
+    let name = match Symbol::from_value(value) {
+        Some(symbol) => symbol.name()?.to_string(),
+        None => String::try_convert(value)?,
+    };
+
+    map_err(parse_language(&name))
+}

--- a/litsea-ruby/src/lib.rs
+++ b/litsea-ruby/src/lib.rs
@@ -1,0 +1,84 @@
+//! Ruby binding for Litsea.
+//!
+//! Built with [magnus](https://github.com/matsadler/magnus). Everything
+//! FFI-independent lives in `litsea-binding-core`, so this crate only maps
+//! that surface onto Ruby classes and exceptions.
+//!
+//! Long-running work releases the GVL (see [`gvl`]), so other Ruby threads
+//! keep running during training - which is what lets one of them cancel a
+//! run that is already going.
+//!
+//! ```ruby
+//! require "litsea"
+//!
+//! seg = Litsea::Segmenter.open("japanese", "models/japanese.model")
+//! seg.segment("これはテストです。")
+//! ```
+
+pub mod error;
+pub mod gvl;
+pub mod language;
+pub mod metrics;
+pub mod segmenter;
+pub mod token;
+pub mod trainer;
+
+use magnus::{Ruby, error::Error, function};
+
+/// Returns the version of the underlying `litsea` crate.
+///
+/// # Returns
+/// The version string, for example `"0.12.0"`.
+fn version() -> String {
+    litsea::version().to_string()
+}
+
+/// Returns the names of every supported language.
+///
+/// # Returns
+/// The canonical names, in documentation order.
+fn supported_languages() -> Vec<String> {
+    litsea_binding_core::supported_language_names()
+}
+
+/// Entry point Ruby calls when the extension is required.
+///
+/// # Arguments
+/// * `ruby` - The Ruby handle for the current thread.
+///
+/// # Returns
+/// `()` once every class has been defined.
+///
+/// # Errors
+/// Returns a Ruby exception if a class cannot be defined.
+#[magnus::init]
+fn init(ruby: &Ruby) -> Result<(), Error> {
+    let module = ruby.define_module("Litsea")?;
+
+    // Exceptions first: everything else raises through them.
+    error::define_exceptions(ruby, &module)?;
+    token::define(ruby, &module)?;
+    metrics::define(ruby, &module)?;
+    segmenter::define(ruby, &module)?;
+    trainer::define(ruby, &module)?;
+
+    module.define_module_function("version", function!(version, 0))?;
+    module.define_module_function("supported_languages", function!(supported_languages, 0))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_version_matches_litsea() {
+        assert_eq!(version(), litsea::version());
+    }
+
+    #[test]
+    fn test_supported_languages() {
+        assert_eq!(supported_languages(), vec!["japanese", "chinese", "korean", "english"]);
+    }
+}

--- a/litsea-ruby/src/metrics.rs
+++ b/litsea-ruby/src/metrics.rs
@@ -1,0 +1,250 @@
+//! Training metric classes.
+
+use litsea::{BinaryMetrics, MulticlassMetrics, TwoStageMetrics};
+use magnus::{Module, RModule, Ruby, error::Error};
+
+/// Metrics from training a binary (segmentation) model.
+///
+/// All percentages are 0-100.
+#[magnus::wrap(class = "Litsea::BinaryMetrics", free_immediately, size)]
+pub struct RbBinaryMetrics {
+    /// The wrapped metrics.
+    inner: BinaryMetrics,
+}
+
+impl RbBinaryMetrics {
+    /// Accuracy, as a percentage.
+    fn accuracy(&self) -> f64 {
+        self.inner.accuracy
+    }
+
+    /// Precision, as a percentage.
+    fn precision(&self) -> f64 {
+        self.inner.precision
+    }
+
+    /// Recall, as a percentage.
+    fn recall(&self) -> f64 {
+        self.inner.recall
+    }
+
+    /// Number of training instances.
+    fn num_instances(&self) -> usize {
+        self.inner.num_instances
+    }
+
+    /// True positives.
+    fn true_positives(&self) -> usize {
+        self.inner.true_positives
+    }
+
+    /// False positives.
+    fn false_positives(&self) -> usize {
+        self.inner.false_positives
+    }
+
+    /// False negatives.
+    fn false_negatives(&self) -> usize {
+        self.inner.false_negatives
+    }
+
+    /// True negatives.
+    fn true_negatives(&self) -> usize {
+        self.inner.true_negatives
+    }
+
+    /// Returns a readable representation.
+    ///
+    /// # Returns
+    /// For example `#<Litsea::BinaryMetrics accuracy=99.12% instances=1234>`.
+    fn inspect(&self) -> String {
+        format!(
+            "#<Litsea::BinaryMetrics accuracy={:.2}% instances={}>",
+            self.inner.accuracy, self.inner.num_instances
+        )
+    }
+}
+
+impl From<BinaryMetrics> for RbBinaryMetrics {
+    /// Wraps `litsea`'s metrics for Ruby.
+    ///
+    /// # Arguments
+    /// * `inner` - The metrics to wrap.
+    ///
+    /// # Returns
+    /// The corresponding [`RbBinaryMetrics`].
+    fn from(inner: BinaryMetrics) -> Self {
+        Self { inner }
+    }
+}
+
+/// Metrics from training a multiclass model.
+///
+/// All percentages are 0-100.
+#[magnus::wrap(class = "Litsea::MulticlassMetrics", free_immediately, size)]
+pub struct RbMulticlassMetrics {
+    /// The wrapped metrics.
+    inner: MulticlassMetrics,
+}
+
+impl RbMulticlassMetrics {
+    /// Accuracy, as a percentage.
+    fn accuracy(&self) -> f64 {
+        self.inner.accuracy
+    }
+
+    /// Macro-averaged precision, as a percentage.
+    fn macro_precision(&self) -> f64 {
+        self.inner.macro_precision
+    }
+
+    /// Macro-averaged recall, as a percentage.
+    fn macro_recall(&self) -> f64 {
+        self.inner.macro_recall
+    }
+
+    /// Number of training instances.
+    fn num_instances(&self) -> usize {
+        self.inner.num_instances
+    }
+
+    /// Gold instances per class, as a Hash keyed by the label name.
+    fn gold_per_class(&self) -> std::collections::HashMap<String, usize> {
+        self.inner.gold_per_class.clone()
+    }
+
+    /// Correct predictions per class.
+    fn correct_per_class(&self) -> std::collections::HashMap<String, usize> {
+        self.inner.correct_per_class.clone()
+    }
+
+    /// Predictions made per class.
+    fn predicted_per_class(&self) -> std::collections::HashMap<String, usize> {
+        self.inner.predicted_per_class.clone()
+    }
+
+    /// Returns a readable representation.
+    ///
+    /// # Returns
+    /// For example `#<Litsea::MulticlassMetrics accuracy=97.30% instances=999>`.
+    fn inspect(&self) -> String {
+        format!(
+            "#<Litsea::MulticlassMetrics accuracy={:.2}% instances={}>",
+            self.inner.accuracy, self.inner.num_instances
+        )
+    }
+}
+
+impl From<MulticlassMetrics> for RbMulticlassMetrics {
+    /// Wraps `litsea`'s metrics for Ruby.
+    ///
+    /// # Arguments
+    /// * `inner` - The metrics to wrap.
+    ///
+    /// # Returns
+    /// The corresponding [`RbMulticlassMetrics`].
+    fn from(inner: MulticlassMetrics) -> Self {
+        Self { inner }
+    }
+}
+
+/// Metrics from training a two-stage model: one set per stage.
+#[magnus::wrap(class = "Litsea::TwoStageMetrics", free_immediately, size)]
+pub struct RbTwoStageMetrics {
+    /// The wrapped metrics.
+    inner: TwoStageMetrics,
+}
+
+impl RbTwoStageMetrics {
+    /// Stage-1 (boundary classifier) metrics.
+    fn stage1(&self) -> RbMulticlassMetrics {
+        RbMulticlassMetrics::from(self.inner.stage1.clone())
+    }
+
+    /// Stage-2 (word tagger) metrics.
+    fn stage2(&self) -> RbMulticlassMetrics {
+        RbMulticlassMetrics::from(self.inner.stage2.clone())
+    }
+
+    /// Returns a readable representation.
+    ///
+    /// # Returns
+    /// For example `#<Litsea::TwoStageMetrics stage1=99.10% stage2=95.40%>`.
+    fn inspect(&self) -> String {
+        format!(
+            "#<Litsea::TwoStageMetrics stage1={:.2}% stage2={:.2}%>",
+            self.inner.stage1.accuracy, self.inner.stage2.accuracy
+        )
+    }
+}
+
+impl From<TwoStageMetrics> for RbTwoStageMetrics {
+    /// Wraps `litsea`'s metrics for Ruby.
+    ///
+    /// # Arguments
+    /// * `inner` - The metrics to wrap.
+    ///
+    /// # Returns
+    /// The corresponding [`RbTwoStageMetrics`].
+    fn from(inner: TwoStageMetrics) -> Self {
+        Self { inner }
+    }
+}
+
+/// Defines the metric classes.
+///
+/// # Arguments
+/// * `ruby` - The Ruby handle for the current thread.
+/// * `module` - The `Litsea` module to define the classes on.
+///
+/// # Returns
+/// `()` on success.
+///
+/// # Errors
+/// Returns a Ruby exception if a class cannot be defined.
+pub fn define(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
+    let binary = module.define_class("BinaryMetrics", ruby.class_object())?;
+    binary.define_method("accuracy", magnus::method!(RbBinaryMetrics::accuracy, 0))?;
+    binary.define_method("precision", magnus::method!(RbBinaryMetrics::precision, 0))?;
+    binary.define_method("recall", magnus::method!(RbBinaryMetrics::recall, 0))?;
+    binary.define_method("num_instances", magnus::method!(RbBinaryMetrics::num_instances, 0))?;
+    binary.define_method("true_positives", magnus::method!(RbBinaryMetrics::true_positives, 0))?;
+    binary
+        .define_method("false_positives", magnus::method!(RbBinaryMetrics::false_positives, 0))?;
+    binary
+        .define_method("false_negatives", magnus::method!(RbBinaryMetrics::false_negatives, 0))?;
+    binary.define_method("true_negatives", magnus::method!(RbBinaryMetrics::true_negatives, 0))?;
+    binary.define_method("inspect", magnus::method!(RbBinaryMetrics::inspect, 0))?;
+    binary.define_method("to_s", magnus::method!(RbBinaryMetrics::inspect, 0))?;
+
+    let multiclass = module.define_class("MulticlassMetrics", ruby.class_object())?;
+    multiclass.define_method("accuracy", magnus::method!(RbMulticlassMetrics::accuracy, 0))?;
+    multiclass.define_method(
+        "macro_precision",
+        magnus::method!(RbMulticlassMetrics::macro_precision, 0),
+    )?;
+    multiclass
+        .define_method("macro_recall", magnus::method!(RbMulticlassMetrics::macro_recall, 0))?;
+    multiclass
+        .define_method("num_instances", magnus::method!(RbMulticlassMetrics::num_instances, 0))?;
+    multiclass
+        .define_method("gold_per_class", magnus::method!(RbMulticlassMetrics::gold_per_class, 0))?;
+    multiclass.define_method(
+        "correct_per_class",
+        magnus::method!(RbMulticlassMetrics::correct_per_class, 0),
+    )?;
+    multiclass.define_method(
+        "predicted_per_class",
+        magnus::method!(RbMulticlassMetrics::predicted_per_class, 0),
+    )?;
+    multiclass.define_method("inspect", magnus::method!(RbMulticlassMetrics::inspect, 0))?;
+    multiclass.define_method("to_s", magnus::method!(RbMulticlassMetrics::inspect, 0))?;
+
+    let two_stage = module.define_class("TwoStageMetrics", ruby.class_object())?;
+    two_stage.define_method("stage1", magnus::method!(RbTwoStageMetrics::stage1, 0))?;
+    two_stage.define_method("stage2", magnus::method!(RbTwoStageMetrics::stage2, 0))?;
+    two_stage.define_method("inspect", magnus::method!(RbTwoStageMetrics::inspect, 0))?;
+    two_stage.define_method("to_s", magnus::method!(RbTwoStageMetrics::inspect, 0))?;
+
+    Ok(())
+}

--- a/litsea-ruby/src/segmenter.rs
+++ b/litsea-ruby/src/segmenter.rs
@@ -1,0 +1,241 @@
+//! The `Litsea::Segmenter` class.
+
+use std::path::Path;
+
+use litsea_binding_core::{CoreSegmenter, TokenView};
+use magnus::{Module, Object, RArray, RModule, RString, Ruby, Value, error::Error};
+
+use crate::error::map_err;
+use crate::gvl::without_gvl;
+use crate::language::language_from_value;
+use crate::token::Token;
+
+/// A word segmenter, optionally with POS tagging.
+///
+/// Build one with `Segmenter.open`, `Segmenter.from_bytes`, or
+/// `Segmenter.from_uri`. The kind of model is detected from the file itself,
+/// so `has_pos?` describes what was loaded rather than something the caller
+/// declares.
+#[magnus::wrap(class = "Litsea::Segmenter", free_immediately, size)]
+pub struct Segmenter {
+    /// The wrapped core segmenter.
+    inner: CoreSegmenter,
+}
+
+impl Segmenter {
+    /// Loads a model from a filesystem path.
+    ///
+    /// # Arguments
+    /// * `language` - A language name or ISO 639-1 code, as a String or Symbol.
+    /// * `path` - Path to the model file.
+    ///
+    /// # Returns
+    /// The new segmenter.
+    ///
+    /// # Errors
+    /// Raises `Litsea::InvalidArgumentError`, `Litsea::IoError`,
+    /// `Litsea::ParseError`, or `Litsea::ModelError`.
+    fn open(language: Value, path: String) -> Result<Self, Error> {
+        let language = language_from_value(language)?;
+        // Reading and compiling a model is measurable work; let other Ruby
+        // threads run while it happens.
+        let inner = without_gvl(|| CoreSegmenter::from_path(language, Path::new(&path)));
+        Ok(Self {
+            inner: map_err(inner)?,
+        })
+    }
+
+    /// Loads a model from a raw byte string.
+    ///
+    /// Takes the bytes as they are, so a String read with `File.binread`
+    /// (ASCII-8BIT) works as well as one read as UTF-8.
+    ///
+    /// # Arguments
+    /// * `language` - A language name or ISO 639-1 code, as a String or Symbol.
+    /// * `data` - The model file contents.
+    ///
+    /// # Returns
+    /// The new segmenter.
+    ///
+    /// # Errors
+    /// Raises `Litsea::InvalidArgumentError`, `Litsea::ParseError`, or
+    /// `Litsea::ModelError`.
+    fn from_bytes(language: Value, data: RString) -> Result<Self, Error> {
+        let language = language_from_value(language)?;
+        // SAFETY: the slice is used only within this call, and nothing here
+        // runs Ruby code that could move or free the string in the meantime
+        // (`from_bytes` parses into owned Rust structures).
+        let bytes = unsafe { data.as_slice() };
+        Ok(Self {
+            inner: map_err(CoreSegmenter::from_bytes(language, bytes))?,
+        })
+    }
+
+    /// Loads a model from a URI.
+    ///
+    /// Accepts a filesystem path, a `file://` path, or an `http(s)://` URL.
+    /// The GVL is released while the model is fetched.
+    ///
+    /// # Arguments
+    /// * `language` - A language name or ISO 639-1 code, as a String or Symbol.
+    /// * `uri` - The model URI.
+    ///
+    /// # Returns
+    /// The new segmenter.
+    ///
+    /// # Errors
+    /// Raises `Litsea::ModelError` if the download fails, plus the same
+    /// errors as `open`.
+    fn from_uri(language: Value, uri: String) -> Result<Self, Error> {
+        let language = language_from_value(language)?;
+        let inner = without_gvl(|| CoreSegmenter::from_uri_blocking(language, &uri));
+        Ok(Self {
+            inner: map_err(inner)?,
+        })
+    }
+
+    /// Returns the language this segmenter was built for.
+    ///
+    /// # Returns
+    /// The canonical language name, for example `"japanese"`.
+    fn language(&self) -> String {
+        self.inner.language().to_string()
+    }
+
+    /// Returns whether this segmenter can tag parts of speech.
+    ///
+    /// # Returns
+    /// `true` when a two-stage POS model was loaded.
+    fn has_pos(&self) -> bool {
+        self.inner.has_pos()
+    }
+
+    /// Splits a sentence into tokens.
+    ///
+    /// # Arguments
+    /// * `text` - The sentence to segment.
+    ///
+    /// # Returns
+    /// The tokens, in order.
+    fn segment(&self, text: String) -> Vec<String> {
+        self.inner.segment(&text)
+    }
+
+    /// Splits several sentences into tokens, releasing the GVL.
+    ///
+    /// # Arguments
+    /// * `texts` - The sentences to segment.
+    ///
+    /// # Returns
+    /// One token array per input sentence, in input order.
+    fn segment_batch(&self, texts: Vec<String>) -> Vec<Vec<String>> {
+        without_gvl(|| self.inner.segment_batch(&texts))
+    }
+
+    /// Splits a sentence into tokens carrying byte offsets.
+    ///
+    /// # Arguments
+    /// * `ruby` - The Ruby handle for the current thread.
+    /// * `text` - The sentence to segment.
+    ///
+    /// # Returns
+    /// The tokens, with `pos` set to `nil`.
+    ///
+    /// # Errors
+    /// Returns a Ruby exception if the result array cannot be built.
+    fn segment_tokens(ruby: &Ruby, rb_self: &Self, text: String) -> Result<RArray, Error> {
+        tokens_to_array(ruby, rb_self.inner.segment_tokens(&text))
+    }
+
+    /// Splits a sentence into tokens and tags each with a UPOS tag.
+    ///
+    /// # Arguments
+    /// * `text` - The sentence to segment and tag.
+    ///
+    /// # Returns
+    /// The tagged tokens, with byte offsets into `text`.
+    ///
+    /// # Errors
+    /// Raises `Litsea::PosUnavailableError` when this segmenter was built
+    /// from a segmentation-only model.
+    fn segment_with_pos(ruby: &Ruby, rb_self: &Self, text: String) -> Result<RArray, Error> {
+        let tokens = map_err(rb_self.inner.segment_with_pos(&text))?;
+        tokens_to_array(ruby, tokens)
+    }
+
+    /// Splits and tags several sentences, releasing the GVL.
+    ///
+    /// # Arguments
+    /// * `texts` - The sentences to segment and tag.
+    ///
+    /// # Returns
+    /// One tagged-token array per input sentence, in input order.
+    ///
+    /// # Errors
+    /// Raises `Litsea::PosUnavailableError` when this segmenter was built
+    /// from a segmentation-only model.
+    fn segment_with_pos_batch(
+        ruby: &Ruby,
+        rb_self: &Self,
+        texts: Vec<String>,
+    ) -> Result<RArray, Error> {
+        let batches = without_gvl(|| rb_self.inner.segment_with_pos_batch(&texts));
+        let outer = ruby.ary_new_capa(texts.len());
+        for tokens in map_err(batches)? {
+            outer.push(tokens_to_array(ruby, tokens)?)?;
+        }
+        Ok(outer)
+    }
+}
+
+/// Builds a Ruby array of [`Token`] objects.
+///
+/// Wrapped types satisfy `IntoValue` but not `IntoValueFromNative`, which is
+/// what `Vec<T>` conversion requires, so the array is built element by
+/// element.
+///
+/// # Arguments
+/// * `ruby` - The Ruby handle for the current thread.
+/// * `tokens` - The token views to wrap.
+///
+/// # Returns
+/// A Ruby array of `Litsea::Token` objects.
+///
+/// # Errors
+/// Returns a Ruby exception if an element cannot be pushed.
+fn tokens_to_array(ruby: &Ruby, tokens: Vec<TokenView>) -> Result<RArray, Error> {
+    let array = ruby.ary_new_capa(tokens.len());
+    for view in tokens {
+        array.push(Token::from(view))?;
+    }
+    Ok(array)
+}
+
+/// Defines `Litsea::Segmenter`.
+///
+/// # Arguments
+/// * `ruby` - The Ruby handle for the current thread.
+/// * `module` - The `Litsea` module to define the class on.
+///
+/// # Returns
+/// `()` on success.
+///
+/// # Errors
+/// Returns a Ruby exception if the class cannot be defined.
+pub fn define(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
+    let class = module.define_class("Segmenter", ruby.class_object())?;
+    class.define_singleton_method("open", magnus::function!(Segmenter::open, 2))?;
+    class.define_singleton_method("from_bytes", magnus::function!(Segmenter::from_bytes, 2))?;
+    class.define_singleton_method("from_uri", magnus::function!(Segmenter::from_uri, 2))?;
+    class.define_method("language", magnus::method!(Segmenter::language, 0))?;
+    class.define_method("has_pos?", magnus::method!(Segmenter::has_pos, 0))?;
+    class.define_method("segment", magnus::method!(Segmenter::segment, 1))?;
+    class.define_method("segment_batch", magnus::method!(Segmenter::segment_batch, 1))?;
+    class.define_method("segment_tokens", magnus::method!(Segmenter::segment_tokens, 1))?;
+    class.define_method("segment_with_pos", magnus::method!(Segmenter::segment_with_pos, 1))?;
+    class.define_method(
+        "segment_with_pos_batch",
+        magnus::method!(Segmenter::segment_with_pos_batch, 1),
+    )?;
+    Ok(())
+}

--- a/litsea-ruby/src/token.rs
+++ b/litsea-ruby/src/token.rs
@@ -1,0 +1,135 @@
+//! The token class handed to Ruby.
+
+use litsea_binding_core::TokenView;
+use magnus::{Module, RModule, Ruby, error::Error};
+
+/// A segmented token.
+///
+/// `start` and `end` are byte offsets into the input string, so
+/// `text.byteslice(token.start, token.end - token.start)` returns the
+/// surface. Ruby's `String#[]` works in characters, hence `byteslice`.
+#[magnus::wrap(class = "Litsea::Token", free_immediately, size)]
+pub struct Token {
+    /// The token's surface form.
+    surface: String,
+    /// The UPOS tag name (for example `"NOUN"`), or `nil` when the segmenter
+    /// has no POS model.
+    pos: Option<String>,
+    /// Starting byte offset in the input string.
+    start: usize,
+    /// Ending byte offset (exclusive) in the input string.
+    end: usize,
+}
+
+impl Token {
+    /// Returns the token's surface form.
+    ///
+    /// # Returns
+    /// The surface string.
+    fn surface(&self) -> String {
+        self.surface.clone()
+    }
+
+    /// Returns the UPOS tag name.
+    ///
+    /// # Returns
+    /// The tag name, or `nil` for segmentation-only output.
+    fn pos(&self) -> Option<String> {
+        self.pos.clone()
+    }
+
+    /// Returns the starting byte offset.
+    ///
+    /// # Returns
+    /// The offset into the input string.
+    fn start(&self) -> usize {
+        self.start
+    }
+
+    /// Returns the ending byte offset (exclusive).
+    ///
+    /// # Returns
+    /// The offset into the input string.
+    fn end(&self) -> usize {
+        self.end
+    }
+
+    /// Returns a readable representation.
+    ///
+    /// # Returns
+    /// For example `#<Litsea::Token これ/PRON [0..6]>`.
+    fn inspect(&self) -> String {
+        match &self.pos {
+            Some(pos) => {
+                format!("#<Litsea::Token {}/{} [{}..{}]>", self.surface, pos, self.start, self.end)
+            }
+            None => format!("#<Litsea::Token {} [{}..{}]>", self.surface, self.start, self.end),
+        }
+    }
+}
+
+impl From<TokenView> for Token {
+    /// Converts a core token view into the Ruby-facing token.
+    ///
+    /// # Arguments
+    /// * `view` - The token view.
+    ///
+    /// # Returns
+    /// The corresponding [`Token`].
+    fn from(view: TokenView) -> Self {
+        Self {
+            surface: view.surface,
+            // The tag travels as its name, matching the other bindings'
+            // token shape.
+            pos: view.pos.map(|pos| pos.to_string()),
+            start: view.byte_start,
+            end: view.byte_end,
+        }
+    }
+}
+
+/// Defines `Litsea::Token`.
+///
+/// # Arguments
+/// * `ruby` - The Ruby handle for the current thread.
+/// * `module` - The `Litsea` module to define the class on.
+///
+/// # Returns
+/// `()` on success.
+///
+/// # Errors
+/// Returns a Ruby exception if the class cannot be defined.
+pub fn define(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
+    let class = module.define_class("Token", ruby.class_object())?;
+    class.define_method("surface", magnus::method!(Token::surface, 0))?;
+    class.define_method("pos", magnus::method!(Token::pos, 0))?;
+    class.define_method("start", magnus::method!(Token::start, 0))?;
+    class.define_method("end", magnus::method!(Token::end, 0))?;
+    class.define_method("inspect", magnus::method!(Token::inspect, 0))?;
+    class.define_method("to_s", magnus::method!(Token::inspect, 0))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use litsea::Upos;
+
+    use super::*;
+
+    #[test]
+    fn test_conversion_keeps_offsets_and_tag_name() {
+        let token = Token::from(TokenView::new("テスト", 9, 18, Some(Upos::NOUN)));
+        assert_eq!(token.surface(), "テスト");
+        assert_eq!(token.pos().as_deref(), Some("NOUN"));
+        assert_eq!(token.start(), 9);
+        assert_eq!(token.end(), 18);
+        assert_eq!(token.inspect(), "#<Litsea::Token テスト/NOUN [9..18]>");
+    }
+
+    #[test]
+    fn test_untagged_token() {
+        let token = Token::from(TokenView::new("テスト", 0, 9, None));
+        assert_eq!(token.pos(), None);
+        assert_eq!(token.inspect(), "#<Litsea::Token テスト [0..9]>");
+    }
+}

--- a/litsea-ruby/src/trainer.rs
+++ b/litsea-ruby/src/trainer.rs
@@ -1,0 +1,421 @@
+//! Feature extraction, training, and cancellation.
+//!
+//! Training releases the GVL (see [`crate::gvl`]), so other Ruby threads keep
+//! running while it works - which is what makes [`CancelToken`] usable while
+//! a run is already going, as in the Python and Node.js bindings.
+
+use std::cell::RefCell;
+use std::path::PathBuf;
+
+use litsea_binding_core::{
+    CancelToken as CoreCancelToken, CoreExtractor, CorePerceptronTrainer, CoreTrainer,
+    CoreTwoStageTrainer, CorpusFormat, parse_feature_set,
+};
+use magnus::{
+    Module, Object, RModule, Ruby, Value, error::Error, function, method, scan_args::scan_args,
+};
+
+use crate::error::map_err;
+use crate::gvl::without_gvl;
+use crate::language::language_from_value;
+use crate::metrics::{RbBinaryMetrics, RbMulticlassMetrics, RbTwoStageMetrics};
+
+/// A flag that asks a running training job to stop.
+///
+/// Cancelling is cooperative and is **not** an error: training stops at its
+/// next check point, still writes the partially trained model, and returns
+/// its metrics. Because training releases the GVL, another Ruby thread can
+/// cancel a run that is already going.
+#[magnus::wrap(class = "Litsea::CancelToken", free_immediately, size)]
+pub struct CancelToken {
+    /// The wrapped token; clones share one flag.
+    inner: CoreCancelToken,
+}
+
+impl CancelToken {
+    /// Creates a token in the "keep running" state.
+    ///
+    /// # Returns
+    /// The new token.
+    fn new() -> Self {
+        Self {
+            inner: CoreCancelToken::new(),
+        }
+    }
+
+    /// Requests cancellation.
+    fn cancel(&self) {
+        self.inner.cancel();
+    }
+
+    /// Returns the token to the "keep running" state.
+    fn reset(&self) {
+        self.inner.reset();
+    }
+
+    /// Returns whether cancellation has been requested.
+    ///
+    /// # Returns
+    /// `true` once `cancel` has been called.
+    fn is_cancelled(&self) -> bool {
+        self.inner.is_cancelled()
+    }
+
+    /// Returns the flag a training run should observe.
+    ///
+    /// # Arguments
+    /// * `token` - The caller-supplied token, if any.
+    ///
+    /// # Returns
+    /// A clone of the supplied token, or a fresh one.
+    fn resolve(token: Option<&CancelToken>) -> CoreCancelToken {
+        token.map_or_else(CoreCancelToken::new, |token| token.inner.clone())
+    }
+}
+
+/// Reads the optional `cancel:` keyword argument.
+///
+/// magnus cannot express an optional keyword argument in a `method!` arity,
+/// so the trainers take their arguments through `scan_args`.
+///
+/// # Arguments
+/// * `args` - The raw Ruby arguments.
+///
+/// # Returns
+/// The model path and the cancellation flag to observe.
+///
+/// # Errors
+/// Returns a Ruby `ArgumentError` if the arguments do not match.
+fn scan_train_args(args: &[magnus::Value]) -> Result<(PathBuf, CoreCancelToken), Error> {
+    let args = scan_args::<(String,), (), (), (), _, ()>(args)?;
+    let (model_path,) = args.required;
+    let kwargs = magnus::scan_args::get_kwargs::<_, (), (Option<Option<&CancelToken>>,), ()>(
+        args.keywords,
+        &[],
+        &["cancel"],
+    )?;
+    let (cancel,) = kwargs.optional;
+
+    Ok((PathBuf::from(model_path), CancelToken::resolve(cancel.flatten())))
+}
+
+/// Extracts training features from a corpus.
+#[magnus::wrap(class = "Litsea::Extractor", free_immediately, size)]
+pub struct Extractor {
+    /// The wrapped extractor.
+    inner: CoreExtractor,
+}
+
+impl Extractor {
+    /// Creates an extractor for a language.
+    ///
+    /// # Arguments
+    /// * `language` - A language name or ISO 639-1 code, as a String or Symbol.
+    ///
+    /// # Returns
+    /// The new extractor.
+    ///
+    /// # Errors
+    /// Raises `Litsea::InvalidArgumentError` for an unknown language.
+    fn new(language: Value) -> Result<Self, Error> {
+        Ok(Self {
+            inner: CoreExtractor::new(language_from_value(language)?),
+        })
+    }
+
+    /// Extracts boundary-classification features.
+    ///
+    /// Accepts `tsv:` and `tag_free:` keyword arguments.
+    ///
+    /// # Arguments
+    /// * `args` - `corpus_path`, `features_path`, and the keywords.
+    ///
+    /// # Returns
+    /// `nil`; the features file is written.
+    ///
+    /// # Errors
+    /// Raises `Litsea::IoError` if the corpus cannot be read or the output
+    /// cannot be written.
+    fn extract(&self, args: &[magnus::Value]) -> Result<(), Error> {
+        let args = scan_args::<(String, String), (), (), (), _, ()>(args)?;
+        let (corpus_path, features_path) = args.required;
+        let kwargs = magnus::scan_args::get_kwargs::<_, (), (Option<bool>, Option<bool>), ()>(
+            args.keywords,
+            &[],
+            &["tsv", "tag_free"],
+        )?;
+        let (tsv, tag_free) = kwargs.optional;
+
+        let extracted = without_gvl(|| {
+            self.inner.extract(
+                std::path::Path::new(&corpus_path),
+                std::path::Path::new(&features_path),
+                CorpusFormat::from_tsv_flag(tsv.unwrap_or(false)),
+                tag_free.unwrap_or(false),
+            )
+        });
+        map_err(extracted)
+    }
+
+    /// Extracts two-stage (segmentation + POS) features.
+    ///
+    /// Writes `{output_prefix}.stage1`, `.stage2`, and `.lexicon`. Accepts
+    /// `feature_set:` and `tsv:` keyword arguments.
+    ///
+    /// # Arguments
+    /// * `args` - `corpus_path`, `output_prefix`, and the keywords.
+    ///
+    /// # Returns
+    /// `nil`; the three files are written.
+    ///
+    /// # Errors
+    /// Raises `Litsea::InvalidArgumentError` for an unknown feature set, or
+    /// `Litsea::IoError` on I/O failure.
+    fn extract_two_stage(&self, args: &[magnus::Value]) -> Result<(), Error> {
+        let args = scan_args::<(String, String), (), (), (), _, ()>(args)?;
+        let (corpus_path, output_prefix) = args.required;
+        let kwargs = magnus::scan_args::get_kwargs::<_, (), (Option<String>, Option<bool>), ()>(
+            args.keywords,
+            &[],
+            &["feature_set", "tsv"],
+        )?;
+        let (feature_set, tsv) = kwargs.optional;
+
+        let feature_set = map_err(parse_feature_set(feature_set.as_deref().unwrap_or("fast")))?;
+
+        let extracted = without_gvl(|| {
+            self.inner.extract_two_stage(
+                std::path::Path::new(&corpus_path),
+                std::path::Path::new(&output_prefix),
+                feature_set,
+                CorpusFormat::from_tsv_flag(tsv.unwrap_or(false)),
+            )
+        });
+        map_err(extracted)
+    }
+}
+
+/// Trains a segmentation model.
+#[magnus::wrap(class = "Litsea::Trainer", free_immediately, size)]
+pub struct Trainer {
+    /// The wrapped trainer; `RefCell` because Ruby methods take `&self`.
+    inner: RefCell<CoreTrainer>,
+}
+
+impl Trainer {
+    /// Loads a features file and prepares training.
+    ///
+    /// # Arguments
+    /// * `threshold` - Early-stopping threshold for weak classifiers.
+    /// * `num_iterations` - Maximum number of boosting iterations.
+    /// * `features_path` - Path to the features file.
+    ///
+    /// # Returns
+    /// The new trainer.
+    ///
+    /// # Errors
+    /// Raises `Litsea::IoError` or `Litsea::ParseError` if the features file
+    /// cannot be read.
+    fn new(threshold: f64, num_iterations: usize, features_path: String) -> Result<Self, Error> {
+        let inner = map_err(CoreTrainer::new(
+            threshold,
+            num_iterations,
+            std::path::Path::new(&features_path),
+        ))?;
+        Ok(Self {
+            inner: RefCell::new(inner),
+        })
+    }
+
+    /// Loads an existing model to continue training from it.
+    ///
+    /// # Arguments
+    /// * `model_uri` - Path, `file://` path, or `http(s)://` URL.
+    ///
+    /// # Returns
+    /// `nil`; the model is merged into the learner.
+    ///
+    /// # Errors
+    /// Raises `Litsea::ModelError`, `Litsea::IoError`, or
+    /// `Litsea::ParseError`.
+    fn load_model(&self, model_uri: String) -> Result<(), Error> {
+        let loaded = without_gvl(|| self.inner.borrow_mut().load_model_blocking(&model_uri));
+        map_err(loaded)
+    }
+
+    /// Trains the model and writes it to `model_path`.
+    ///
+    /// The GVL is released while training runs, so another Ruby thread can
+    /// cancel it through the `cancel:` token.
+    ///
+    /// # Arguments
+    /// * `args` - `model_path` and an optional `cancel:` token.
+    ///
+    /// # Returns
+    /// The training metrics.
+    ///
+    /// # Errors
+    /// Raises `Litsea::IoError` if the model cannot be written.
+    fn train(&self, args: &[magnus::Value]) -> Result<RbBinaryMetrics, Error> {
+        let (model_path, cancel) = scan_train_args(args)?;
+        let trained = without_gvl(|| self.inner.borrow_mut().train(&cancel, &model_path));
+        Ok(RbBinaryMetrics::from(map_err(trained)?))
+    }
+}
+
+/// Trains a label-agnostic Averaged Perceptron model.
+#[magnus::wrap(class = "Litsea::PerceptronTrainer", free_immediately, size)]
+pub struct PerceptronTrainer {
+    /// The wrapped trainer.
+    inner: RefCell<CorePerceptronTrainer>,
+}
+
+impl PerceptronTrainer {
+    /// Loads a features file and prepares training.
+    ///
+    /// # Arguments
+    /// * `num_epochs` - Number of passes over the training data.
+    /// * `features_path` - Path to the features file.
+    ///
+    /// # Returns
+    /// The new trainer.
+    ///
+    /// # Errors
+    /// Raises `Litsea::IoError` or `Litsea::ParseError` if the features file
+    /// cannot be read.
+    fn new(num_epochs: usize, features_path: String) -> Result<Self, Error> {
+        let inner =
+            map_err(CorePerceptronTrainer::new(num_epochs, std::path::Path::new(&features_path)))?;
+        Ok(Self {
+            inner: RefCell::new(inner),
+        })
+    }
+
+    /// Trains the model and writes it to `model_path`.
+    ///
+    /// # Arguments
+    /// * `args` - `model_path` and an optional `cancel:` token.
+    ///
+    /// # Returns
+    /// The training metrics.
+    ///
+    /// # Errors
+    /// Raises `Litsea::IoError` if the model cannot be written.
+    fn train(&self, args: &[magnus::Value]) -> Result<RbMulticlassMetrics, Error> {
+        let (model_path, cancel) = scan_train_args(args)?;
+        let trained = without_gvl(|| self.inner.borrow_mut().train(&cancel, &model_path));
+        Ok(RbMulticlassMetrics::from(map_err(trained)?))
+    }
+}
+
+/// Trains a two-stage segmentation + POS model.
+///
+/// A trainer can only be used once: training collapses stage 1 into an
+/// AdaBoost model, which consumes it. `available?` reports the state, and a
+/// second `train` raises.
+#[magnus::wrap(class = "Litsea::TwoStageTrainer", free_immediately, size)]
+pub struct TwoStageTrainer {
+    /// The wrapped trainer.
+    inner: RefCell<CoreTwoStageTrainer>,
+}
+
+impl TwoStageTrainer {
+    /// Loads a two-stage features prefix and prepares training.
+    ///
+    /// Accepts a `dominance:` keyword argument.
+    ///
+    /// # Arguments
+    /// * `args` - `num_epochs`, `features_prefix`, and the keyword.
+    ///
+    /// # Returns
+    /// The new trainer.
+    ///
+    /// # Errors
+    /// Raises `Litsea::InvalidArgumentError` if `dominance` is out of range,
+    /// or `Litsea::IoError` / `Litsea::ParseError` if the feature files
+    /// cannot be read.
+    fn new(args: &[magnus::Value]) -> Result<Self, Error> {
+        let args = scan_args::<(usize, String), (), (), (), _, ()>(args)?;
+        let (num_epochs, features_prefix) = args.required;
+        let kwargs = magnus::scan_args::get_kwargs::<_, (), (Option<f64>,), ()>(
+            args.keywords,
+            &[],
+            &["dominance"],
+        )?;
+        let (dominance,) = kwargs.optional;
+
+        let inner = map_err(CoreTwoStageTrainer::new(
+            num_epochs,
+            dominance.unwrap_or(0.99),
+            std::path::Path::new(&features_prefix),
+        ))?;
+        Ok(Self {
+            inner: RefCell::new(inner),
+        })
+    }
+
+    /// Returns whether this trainer can still be used.
+    ///
+    /// # Returns
+    /// `false` once `train` has run.
+    fn is_available(&self) -> bool {
+        self.inner.borrow().is_available()
+    }
+
+    /// Trains both stages and writes the model.
+    ///
+    /// # Arguments
+    /// * `args` - `model_path` and an optional `cancel:` token.
+    ///
+    /// # Returns
+    /// The metrics of both stages.
+    ///
+    /// # Errors
+    /// Raises `Litsea::InvalidArgumentError` if the trainer has already been
+    /// used, or `Litsea::IoError` if the model cannot be written.
+    fn train(&self, args: &[magnus::Value]) -> Result<RbTwoStageMetrics, Error> {
+        let (model_path, cancel) = scan_train_args(args)?;
+        let trained = without_gvl(|| self.inner.borrow_mut().train(&cancel, &model_path));
+        Ok(RbTwoStageMetrics::from(map_err(trained)?))
+    }
+}
+
+/// Defines the training classes.
+///
+/// # Arguments
+/// * `ruby` - The Ruby handle for the current thread.
+/// * `module` - The `Litsea` module to define the classes on.
+///
+/// # Returns
+/// `()` on success.
+///
+/// # Errors
+/// Returns a Ruby exception if a class cannot be defined.
+pub fn define(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
+    let cancel = module.define_class("CancelToken", ruby.class_object())?;
+    cancel.define_singleton_method("new", function!(CancelToken::new, 0))?;
+    cancel.define_method("cancel", method!(CancelToken::cancel, 0))?;
+    cancel.define_method("reset", method!(CancelToken::reset, 0))?;
+    cancel.define_method("cancelled?", method!(CancelToken::is_cancelled, 0))?;
+
+    let extractor = module.define_class("Extractor", ruby.class_object())?;
+    extractor.define_singleton_method("new", function!(Extractor::new, 1))?;
+    extractor.define_method("extract", method!(Extractor::extract, -1))?;
+    extractor.define_method("extract_two_stage", method!(Extractor::extract_two_stage, -1))?;
+
+    let trainer = module.define_class("Trainer", ruby.class_object())?;
+    trainer.define_singleton_method("new", function!(Trainer::new, 3))?;
+    trainer.define_method("load_model", method!(Trainer::load_model, 1))?;
+    trainer.define_method("train", method!(Trainer::train, -1))?;
+
+    let perceptron = module.define_class("PerceptronTrainer", ruby.class_object())?;
+    perceptron.define_singleton_method("new", function!(PerceptronTrainer::new, 2))?;
+    perceptron.define_method("train", method!(PerceptronTrainer::train, -1))?;
+
+    let two_stage = module.define_class("TwoStageTrainer", ruby.class_object())?;
+    two_stage.define_singleton_method("new", function!(TwoStageTrainer::new, -1))?;
+    two_stage.define_method("available?", method!(TwoStageTrainer::is_available, 0))?;
+    two_stage.define_method("train", method!(TwoStageTrainer::train, -1))?;
+
+    Ok(())
+}

--- a/litsea-ruby/test/test_helper.rb
+++ b/litsea-ruby/test/test_helper.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'open3'
+require 'tmpdir'
+require 'litsea'
+
+# Shared helpers: model paths and the CLI the parity tests compare against.
+class LitseaTest < Minitest::Test
+  REPO_ROOT = File.expand_path('../..', __dir__)
+
+  # Absolute path to a bundled model.
+  def model_path(name)
+    File.join(REPO_ROOT, 'models', name)
+  end
+
+  # Builds the `litsea` CLI once and returns the path to the binary.
+  #
+  # The parity tests compare against the CLI rather than hardcoded output,
+  # so the reference implementation decides what is correct.
+  def litsea_cli
+    binary = File.join(REPO_ROOT, 'target', 'debug', 'litsea')
+    unless File.exist?(binary)
+      _, stderr, status = Open3.capture3('cargo', 'build', '--quiet', '-p', 'litsea-cli', chdir: REPO_ROOT)
+      raise "failed to build the litsea CLI: #{stderr}" unless status.success?
+    end
+    binary
+  end
+
+  # Runs the CLI over +input+ and returns its output lines.
+  def run_cli(args, input)
+    stdout, stderr, status = Open3.capture3(litsea_cli, *args, stdin_data: input)
+    raise "the CLI failed: #{stderr}" unless status.success?
+
+    stdout.split("\n").reject(&:empty?)
+  end
+
+  # Writes a small corpus, repeated so training has something to learn.
+  def write_corpus(path, sentences, repeats: 20)
+    File.write(path, "#{(sentences * repeats).join("\n")}\n")
+    path
+  end
+
+  SENTENCES = [
+    'これ は テスト です 。',
+    '隣 の 客 は よく 柿 食う 客 だ',
+    '東京 都 から 神奈川 県 へ 引っ越し た'
+  ].freeze
+
+  POS_SENTENCES = [
+    'これ/PRON は/ADP テスト/NOUN です/AUX 。/PUNCT',
+    '隣/NOUN の/ADP 客/NOUN は/ADP よく/ADV 柿/NOUN 食う/VERB 客/NOUN だ/AUX',
+    '東京/PROPN 都/NOUN から/ADP 神奈川/PROPN 県/NOUN へ/ADP 引っ越し/VERB た/AUX'
+  ].freeze
+end

--- a/litsea-ruby/test/test_segmenter.rb
+++ b/litsea-ruby/test/test_segmenter.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+# Segmentation, POS tagging, and the exception hierarchy.
+class TestSegmenter < LitseaTest
+  SEGMENTATION_CASES = [
+    ['japanese', 'japanese.model', 'これはテストです。'],
+    ['chinese', 'chinese.model', '我喜欢吃中国菜。'],
+    ['korean', 'korean.model', '안녕하세요 반갑습니다'],
+    ['english', 'english.model', 'The quick brown fox jumps over the lazy dog.']
+  ].freeze
+
+  POS_CASES = [
+    ['japanese', 'japanese_pos.model', 'これはテストです。'],
+    ['korean', 'korean_pos.model', '안녕하세요 반갑습니다']
+  ].freeze
+
+  def test_segment_matches_the_cli
+    SEGMENTATION_CASES.each do |language, model, sentence|
+      # Compare the rendered line rather than a re-split of it: the CLI joins
+      # tokens with a space, so for Korean and English -- where whitespace is
+      # its own token -- splitting the output again cannot recover them.
+      expected = run_cli(['segment', '-l', language, model_path(model)], "#{sentence}\n").first
+      seg = Litsea::Segmenter.open(language, model_path(model))
+      assert_equal expected, seg.segment(sentence).join(' '), language
+    end
+  end
+
+  def test_segment_with_pos_matches_the_cli
+    POS_CASES.each do |language, model, sentence|
+      expected = run_cli(['segment', '-l', language, '--pos', model_path(model)], "#{sentence}\n").first
+      seg = Litsea::Segmenter.open(language, model_path(model))
+      rendered = seg.segment_with_pos(sentence).map { |t| "#{t.surface}/#{t.pos}" }.join(' ')
+      assert_equal expected, rendered, language
+    end
+  end
+
+  def test_byte_offsets_reconstruct_the_input
+    SEGMENTATION_CASES.each do |language, model, sentence|
+      seg = Litsea::Segmenter.open(language, model_path(model))
+      tokens = seg.segment_tokens(sentence)
+
+      refute_empty tokens
+      expected_start = 0
+      tokens.each do |token|
+        assert_equal expected_start, token.start, "#{language}: tokens must tile the input"
+        # Ruby's String#[] counts characters, so slice by bytes.
+        assert_equal token.surface, sentence.byteslice(token.start, token.end - token.start)
+        assert_nil token.pos
+        expected_start = token.end
+      end
+      assert_equal sentence.bytesize, expected_start
+      assert_equal sentence, tokens.map(&:surface).join
+    end
+  end
+
+  def test_whitespace_is_its_own_token
+    seg = Litsea::Segmenter.open(:korean, model_path('korean.model'))
+    assert_equal ['안녕하세요', ' ', '반갑습니다'], seg.segment('안녕하세요 반갑습니다')
+  end
+
+  def test_segment_batch_matches_single_calls
+    seg = Litsea::Segmenter.open(:japanese, model_path('japanese.model'))
+    sentences = ['これはテストです。', '', '東京都から神奈川県へ引っ越した']
+
+    batched = seg.segment_batch(sentences)
+    assert_equal sentences.map { |s| seg.segment(s) }, batched
+    assert_empty batched[1]
+  end
+
+  def test_segment_with_pos_batch_matches_single_calls
+    seg = Litsea::Segmenter.open(:japanese, model_path('japanese_pos.model'))
+    sentences = ['これはテストです。', '東京都から神奈川県へ引っ越した']
+
+    batched = seg.segment_with_pos_batch(sentences)
+    assert_equal 2, batched.length
+    sentences.each_with_index do |sentence, index|
+      expected = seg.segment_with_pos(sentence).map { |t| "#{t.surface}/#{t.pos}" }
+      assert_equal(expected, batched[index].map { |t| "#{t.surface}/#{t.pos}" })
+    end
+  end
+
+  def test_model_kind_is_detected
+    refute Litsea::Segmenter.open(:ja, model_path('japanese.model')).has_pos?
+    assert Litsea::Segmenter.open(:ja, model_path('japanese_pos.model')).has_pos?
+  end
+
+  def test_language_accepts_symbols_and_strings
+    expected = Litsea::Segmenter.open('japanese', model_path('japanese.model')).segment('これはテストです。')
+    [:ja, :japanese, 'ja', 'JA', 'Japanese'].each do |name|
+      seg = Litsea::Segmenter.open(name, model_path('japanese.model'))
+      assert_equal expected, seg.segment('これはテストです。'), name.inspect
+    end
+  end
+
+  def test_loading_sources_agree
+    path = model_path('japanese.model')
+    sentence = 'これはテストです。'
+
+    from_path = Litsea::Segmenter.open(:japanese, path)
+    from_bytes = Litsea::Segmenter.from_bytes(:japanese, File.binread(path))
+    from_uri = Litsea::Segmenter.from_uri(:japanese, path)
+
+    assert_equal from_path.segment(sentence), from_bytes.segment(sentence)
+    assert_equal from_path.segment(sentence), from_uri.segment(sentence)
+  end
+
+  def test_language_accessor
+    assert_equal 'korean', Litsea::Segmenter.open(:korean, model_path('korean.model')).language
+  end
+
+  def test_pos_on_segmentation_model_raises
+    seg = Litsea::Segmenter.open(:japanese, model_path('japanese.model'))
+    error = assert_raises(Litsea::PosUnavailableError) { seg.segment_with_pos('これはテストです。') }
+    assert_match(/two-stage POS model/, error.message)
+  end
+
+  def test_unknown_language_raises
+    error = assert_raises(Litsea::InvalidArgumentError) do
+      Litsea::Segmenter.open(:klingon, model_path('japanese.model'))
+    end
+    assert_match(/klingon/, error.message)
+  end
+
+  def test_missing_model_raises
+    assert_raises(Litsea::IoError) { Litsea::Segmenter.open(:japanese, model_path('nope.model')) }
+  end
+
+  def test_malformed_model_raises
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, 'broken.model')
+      File.write(path, "this is not a model\n")
+      assert_raises(Litsea::ParseError) { Litsea::Segmenter.open(:japanese, path) }
+    end
+  end
+
+  def test_legacy_joint_model_raises
+    Dir.mktmpdir do |dir|
+      path = File.join(dir, 'joint.model')
+      # A bare integer first line is the joint class-count header.
+      File.write(path, "17\nfoo\t1.0\n")
+      error = assert_raises(Litsea::ModelError) { Litsea::Segmenter.open(:japanese, path) }
+      assert_match(/no longer supported/, error.message)
+    end
+  end
+
+  def test_every_error_derives_from_the_base
+    [
+      Litsea::InvalidArgumentError,
+      Litsea::IoError,
+      Litsea::ModelError,
+      Litsea::ParseError,
+      Litsea::UnsupportedError,
+      Litsea::PosUnavailableError
+    ].each do |klass|
+      assert_operator klass, :<, Litsea::Error, klass.name
+    end
+
+    # One rescue is enough for anything the binding raises.
+    assert_raises(Litsea::Error) { Litsea::Segmenter.open(:klingon, model_path('japanese.model')) }
+  end
+
+  def test_module_functions
+    assert_match(/\A\d+\.\d+\.\d+\z/, Litsea.version)
+    assert_equal %w[japanese chinese korean english], Litsea.supported_languages
+    assert_equal Litsea::VERSION, Litsea.version
+  end
+end

--- a/litsea-ruby/test/test_training.rb
+++ b/litsea-ruby/test/test_training.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+# Feature extraction, training, cancellation, and GVL behaviour.
+class TestTraining < LitseaTest
+  def test_extract_then_train_round_trip
+    Dir.mktmpdir do |dir|
+      corpus = write_corpus(File.join(dir, 'corpus.txt'), SENTENCES)
+      features = File.join(dir, 'features.txt')
+      model = File.join(dir, 'trained.model')
+
+      Litsea::Extractor.new(:japanese).extract(corpus, features)
+      assert_operator File.size(features), :>, 0
+
+      metrics = Litsea::Trainer.new(0.01, 20, features).train(model)
+      assert_operator metrics.num_instances, :>, 0
+      assert_includes 0.0..100.0, metrics.accuracy
+
+      # The CLI is the independent check that the file is a valid model.
+      line = run_cli(['segment', '-l', 'japanese', model], "これはテストです。\n").first
+      refute_empty line
+      assert_equal line, Litsea::Segmenter.open(:japanese, model).segment('これはテストです。').join(' ')
+    end
+  end
+
+  def test_tag_free_extraction_is_smaller
+    Dir.mktmpdir do |dir|
+      corpus = write_corpus(File.join(dir, 'corpus.txt'), SENTENCES)
+      extractor = Litsea::Extractor.new(:japanese)
+
+      extractor.extract(corpus, File.join(dir, 'full.txt'))
+      extractor.extract(corpus, File.join(dir, 'lean.txt'), tag_free: true)
+
+      assert_operator File.size(File.join(dir, 'lean.txt')), :<, File.size(File.join(dir, 'full.txt'))
+    end
+  end
+
+  def test_two_stage_training_round_trip
+    Dir.mktmpdir do |dir|
+      corpus = write_corpus(File.join(dir, 'corpus_pos.txt'), POS_SENTENCES)
+      prefix = File.join(dir, 'features')
+      model = File.join(dir, 'two_stage.model')
+
+      Litsea::Extractor.new(:japanese).extract_two_stage(corpus, prefix, feature_set: 'fast')
+      %w[stage1 stage2 lexicon].each { |suffix| assert_path_exists "#{prefix}.#{suffix}" }
+
+      trainer = Litsea::TwoStageTrainer.new(3, prefix)
+      assert trainer.available?
+      metrics = trainer.train(model)
+      assert_operator metrics.stage1.num_instances, :>, 0
+      assert_operator metrics.stage2.num_instances, :>, 0
+
+      seg = Litsea::Segmenter.open(:japanese, model)
+      assert seg.has_pos?
+      tokens = seg.segment_with_pos('これはテストです。')
+      refute_empty tokens
+      assert(tokens.all? { |token| !token.pos.nil? })
+    end
+  end
+
+  def test_two_stage_trainer_cannot_be_reused
+    Dir.mktmpdir do |dir|
+      corpus = write_corpus(File.join(dir, 'corpus_pos.txt'), POS_SENTENCES)
+      prefix = File.join(dir, 'features')
+      model = File.join(dir, 'two_stage.model')
+
+      Litsea::Extractor.new(:japanese).extract_two_stage(corpus, prefix)
+      trainer = Litsea::TwoStageTrainer.new(1, prefix)
+      trainer.train(model)
+      refute trainer.available?
+
+      error = assert_raises(Litsea::InvalidArgumentError) { trainer.train(model) }
+      assert_match(/already been used/, error.message)
+    end
+  end
+
+  def test_perceptron_trainer
+    Dir.mktmpdir do |dir|
+      corpus = write_corpus(File.join(dir, 'corpus_pos.txt'), POS_SENTENCES)
+      prefix = File.join(dir, 'features')
+      model = File.join(dir, 'perceptron.model')
+
+      Litsea::Extractor.new(:japanese).extract_two_stage(corpus, prefix)
+      metrics = Litsea::PerceptronTrainer.new(2, "#{prefix}.stage2").train(model)
+
+      assert_operator metrics.num_instances, :>, 0
+      refute_empty metrics.gold_per_class
+      assert_path_exists model
+    end
+  end
+
+  def test_cancelling_before_training_still_writes_a_model
+    Dir.mktmpdir do |dir|
+      corpus = write_corpus(File.join(dir, 'corpus.txt'), SENTENCES)
+      features = File.join(dir, 'features.txt')
+      model = File.join(dir, 'cancelled.model')
+
+      Litsea::Extractor.new(:japanese).extract(corpus, features)
+
+      token = Litsea::CancelToken.new
+      token.cancel
+      assert token.cancelled?
+
+      # Cancelling is cooperative, not an error.
+      metrics = Litsea::Trainer.new(0.01, 100_000, features).train(model, cancel: token)
+      assert_operator metrics.num_instances, :>, 0
+      assert_path_exists model
+    end
+  end
+
+  def test_cancel_token_reset
+    token = Litsea::CancelToken.new
+    refute token.cancelled?
+    token.cancel
+    assert token.cancelled?
+    token.reset
+    refute token.cancelled?
+  end
+
+  def test_training_releases_the_gvl
+    # If training held the GVL, no other Ruby thread could run while it
+    # worked and `ticks` would stay at 0. Neither magnus nor rb-sys wraps
+    # `rb_thread_call_without_gvl`, so this is what proves the hand-written
+    # FFI in `src/gvl.rs` does its job.
+    Dir.mktmpdir do |dir|
+      corpus = write_corpus(File.join(dir, 'corpus.txt'), SENTENCES, repeats: 400)
+      features = File.join(dir, 'features.txt')
+      Litsea::Extractor.new(:japanese).extract(corpus, features)
+
+      ticks = 0
+      ticker = Thread.new do
+        loop do
+          ticks += 1
+          sleep 0.005
+        end
+      end
+
+      begin
+        Litsea::Trainer.new(0.0, 40, features).train(File.join(dir, 'trained.model'))
+      ensure
+        ticker.kill
+      end
+
+      assert_operator ticks, :>, 0, "the GVL was held during training (ticks=#{ticks})"
+    end
+  end
+
+  def test_a_ruby_thread_can_cancel_training_in_flight
+    Dir.mktmpdir do |dir|
+      corpus = write_corpus(File.join(dir, 'corpus.txt'), SENTENCES, repeats: 400)
+      features = File.join(dir, 'features.txt')
+      Litsea::Extractor.new(:japanese).extract(corpus, features)
+
+      token = Litsea::CancelToken.new
+      cancelled_at = nil
+      canceller = Thread.new do
+        sleep 0.15
+        cancelled_at = Time.now
+        token.cancel
+      end
+
+      started_at = Time.now
+      # A high iteration count so the run cannot finish before the cancel.
+      metrics = Litsea::Trainer.new(0.0, 2000, features).train(File.join(dir, 'm.model'), cancel: token)
+      finished_at = Time.now
+      canceller.join
+
+      assert_operator metrics.num_instances, :>, 0
+      assert token.cancelled?
+      # The cancel must land inside the training window, not before or after
+      # it -- that is what makes this a test of in-flight cancellation.
+      assert_operator cancelled_at, :>, started_at
+      assert_operator cancelled_at, :<, finished_at
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `litsea-ruby`, the Ruby binding, on top of `litsea-binding-core` (#201). Published to RubyGems as `litsea`; the crate on crates.io stays `litsea-ruby`.

```ruby
require "litsea"

seg = Litsea::Segmenter.open(:japanese, "models/japanese.model")
seg.segment("これはテストです。")
# => ["これ", "は", "テスト", "です", "。"]
```

## The GVL, and why this PR contains raw FFI

The issue's plan said to release the GVL with "magnus `without_gvl`". **That API does not exist**: magnus lists `rb_thread_call_without_gvl` among the C functions it does not wrap, rb-sys does not publish it either (it is declared in a header outside the generated bindings), and `lindera-ruby` does not release the GVL at all.

Ruby, unlike PHP (#204), is genuinely multi-threaded, so holding the GVL through a long `train()` would block the very thread that would cancel it. `src/gvl.rs` therefore declares the C entry point itself and calls it behind an `extern "C"` trampoline that catches panics — unwinding across the C frame would be undefined behaviour.

The claim is measured, not asserted:

```text
training took 367ms, other thread ticked 27 times

training window: 11.135 .. 11.652
cancelled at:    11.644          => inside the window
elapsed 517ms of a 2000-iteration run
```

Sabotage check — removing the release from `Trainer#train`:

```text
1) Failure: TestTraining#test_a_ruby_thread_can_cancel_training_in_flight
   Expected 2026-08-22 20:56:07.298 to be < 2026-08-22 20:56:07.147
2) Failure: TestTraining#test_training_releases_the_gvl
   the GVL was held during training (ticks=0). Expected 0 to be > 0.
```

Segmentation of a single sentence keeps the GVL: it is short enough that releasing it would cost more than the work.

## Design

- **Errors** mirror the Python and PHP hierarchies (`Litsea::Error` as the base), so one `rescue` covers everything.
- **Language arguments accept a Symbol or a String** — magnus converts between neither, and `:japanese` is what a Ruby caller reaches for first.
- **Byte offsets** pair with `String#byteslice`, since Ruby's `String#[]` counts characters.
- **Gem layout** follows rb_sys/rake-compiler: `extconf.rb` at the gem root, extension installed to `lib/litsea/`.

## Verification

26 minitest tests (194 assertions) + 4 Rust unit tests on Ruby 3.4.9. Parity is measured against the `litsea` CLI for all four languages, comparing its rendered line (same reason as #202–#204: the CLI joins tokens with a space, so a whitespace token cannot be recovered by re-splitting).

Also green locally: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --all-features`, `make test-litsea-ruby`, `rubocop` (no offenses), `markdownlint-cli2` (114 files), both mdbook builds.

## Two things measurement corrected

1. **`Vec<T>` does not convert to a Ruby Array for wrapped types** — magnus wants `IntoValueFromNative`, which `#[magnus::wrap]` types do not implement. Token arrays are built element by element.
2. **`from_bytes` takes an `RString` read as raw bytes** — `File.binread` yields ASCII-8BIT, which magnus rejects for a `String` parameter. The test caught it, and raw bytes are the right contract for a model file.

## Notes for review

- `src/gvl.rs` is the only unsafe code in the bindings so far; each block carries a SAFETY comment covering the trampoline's pointer validity and the "must not call the Ruby API without the GVL" invariant.
- `make test-litsea-ruby` guards on `bundle --version` rather than `command -v bundle`: a version manager's shim can exist while the selected Ruby has no bundler, which otherwise fails with a bare exit 127.
- CI runs Ruby 3.1 / 3.3 / 3.4.

## Needs a repository-owner action

`publish-ruby` requires a **`RUBYGEMS_API_KEY`** secret, joining `PYPI_TOKEN` (#202) and `NPM_TOKEN` (#203).

Closes #205
Refs #200
