### PR TITLE
docs: state why the WASM binding has no training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 ### Added
 
 - In-memory extraction and training APIs (#218), so the whole pipeline can
-  run without a filesystem -- what `litsea-wasm` (#206) needs before it can
-  train in a browser. Every path-based method gained a twin: `Extractor`'s
+  run without a filesystem -- for embedders that have none, or that already
+  hold the corpus in memory. (The WebAssembly binding deliberately still
+  does not train; see #221.) Every path-based method gained a twin: `Extractor`'s
   six `extract*` methods gained `*_to_writer` forms (the two-stage one
   writing its three outputs to three writers), `Trainer` /
   `PerceptronTrainer` / `TwoStageTrainer` gained `from_features`

--- a/docs/ja/src/bindings/wasm.md
+++ b/docs/ja/src/bindings/wasm.md
@@ -51,10 +51,17 @@ new TextDecoder().decode(bytes.subarray(token.start, token.end))   // === token.
 | 無い機能 | 理由 |
 |---------|------|
 | `fromUri` | `cargo check --target wasm32-unknown-unknown --features remote_model` が失敗する。reqwest の wasm バックエンドには `connect_timeout` が無く、`litsea::model_io` はそれを設定しているため。代わりにページ側で fetch する（キャッシュ・CORS・進捗の制御もページ側に残る） |
-| 学習 | `Extractor` とトレーナはパス前提で、wasm32 にファイルシステムが無い。`litsea-binding-core` も wasm32 では trainer モジュールをコンパイル対象外にしている |
+| 学習 | 技術的な制約ではなく方針判断。下記を参照 |
 | `CancelToken` | 学習が無い以上、キャンセル対象が存在しない |
 
-ブラウザでの学習には `litsea` 本体に in-memory な extract/train API が必要です。`Segmenter::add_corpus_with_writer` は既にファイルシステム非依存で特徴量を書き出せるため実現可能ですが、コアライブラリ側の作業として [#218](https://github.com/mosuka/litsea/issues/218) で追跡します。
+### 学習を提供しない理由
+
+[#218](https://github.com/mosuka/litsea/issues/218) で `litsea` にファイルシステム非依存の extract/train API が入り、wasm32 でもコンパイルできるため、このバインディングでも学習を公開すること自体は可能です。それでも提供しないのは次の 2 点によります（[#221](https://github.com/mosuka/litsea/issues/221)）。
+
+- **ブラウザは学習を行う場所として適さない。** タブがコーパス・そこから抽出した特徴量（コーパスよりかなり大きい）・モデルを同時に保持することになります。API の形を決めるにはまずそのメモリ実測が必要で、実用的なコーパス規模では成立しないという結論も十分あり得ます。
+- **参照実装も持たない。** `lindera-python`・`lindera-nodejs`・`lindera-php`・`lindera-ruby` はいずれもトレーナを備えますが、`lindera-wasm` は備えていません。litsea のバインディング群もこの形に揃えています。
+
+学習は CLI かネイティブバインディングで行い、生成したモデルをここで読み込んでください。
 
 ## メモリ
 

--- a/docs/src/bindings/wasm.md
+++ b/docs/src/bindings/wasm.md
@@ -51,10 +51,17 @@ This is the most constrained of the five bindings, and each gap was measured rat
 | Missing | Why |
 |---------|-----|
 | `fromUri` | `cargo check --target wasm32-unknown-unknown --features remote_model` fails: reqwest's wasm backend has no `connect_timeout`, which `litsea::model_io` sets. The page fetches the model instead — which also keeps caching, CORS, and progress under its control. |
-| Training | `Extractor` and the trainers are path-based, and wasm32 has no filesystem. `litsea-binding-core` already compiles its trainer module out there. |
+| Training | A deliberate scope decision, not a technical limit — see below. |
 | `CancelToken` | With no training there is nothing to cancel. |
 
-Training in the browser would need in-memory extract/train APIs in `litsea` itself — `Segmenter::add_corpus_with_writer` already streams features without touching the filesystem, so it is feasible as core-library work. That is tracked in [#218](https://github.com/mosuka/litsea/issues/218).
+### Why there is no training
+
+`litsea` gained filesystem-free extract/train APIs in [#218](https://github.com/mosuka/litsea/issues/218), and they compile for `wasm32-unknown-unknown`, so this binding *could* expose training. It does not, for two reasons ([#221](https://github.com/mosuka/litsea/issues/221)):
+
+- **A browser is not where training belongs.** A tab would hold the corpus, the features extracted from it (much larger than the corpus), and the model at once. Deciding the API shape would have required measuring that first, and the measurement could well have concluded it is impractical at any useful corpus size.
+- **The reference implementation does not either.** `lindera-python`, `lindera-nodejs`, `lindera-php`, and `lindera-ruby` all ship a trainer; `lindera-wasm` ships none. Litsea's bindings match that shape.
+
+Train with the CLI or one of the native bindings, and load the resulting model here.
 
 ## Memory
 

--- a/litsea-wasm/README.md
+++ b/litsea-wasm/README.md
@@ -75,7 +75,7 @@ It falls back to a plain fetch when Cache Storage is unavailable (an insecure co
 | | Why |
 |---|---|
 | No `fromUri` | reqwest's wasm backend cannot build with Litsea's timeouts; fetch in JS instead |
-| No training | `Extractor` and the trainers are path-based, and wasm32 has no filesystem — tracked in [#218](https://github.com/mosuka/litsea/issues/218) |
+| No training | A deliberate scope decision ([#221](https://github.com/mosuka/litsea/issues/221)), not a technical limit: `litsea` has filesystem-free extract/train APIs since [#218](https://github.com/mosuka/litsea/issues/218). A browser tab would hold the corpus, its features, and the model at once, and `lindera-wasm` does not train either |
 | No `CancelToken` | With no training there is nothing to cancel |
 
 ## Errors

--- a/litsea-wasm/README_ja.md
+++ b/litsea-wasm/README_ja.md
@@ -75,7 +75,7 @@ Cache Storage が使えない環境（非セキュアコンテキストなど）
 | | 理由 |
 |---|---|
 | `fromUri` なし | reqwest の wasm バックエンドが Litsea のタイムアウト設定でビルドできない。JS 側で fetch する |
-| 学習なし | `Extractor` とトレーナはパス前提で、wasm32 にファイルシステムが無い（コア側の in-memory API は [#218](https://github.com/mosuka/litsea/issues/218) で追跡） |
+| 学習なし | 技術的な制約ではなく方針判断（[#221](https://github.com/mosuka/litsea/issues/221)）。[#218](https://github.com/mosuka/litsea/issues/218) 以降 `litsea` にはファイルシステム非依存の extract/train API があるが、ブラウザのタブがコーパス・特徴量・モデルを同時に抱えることになり、参照実装の `lindera-wasm` も学習を持たない |
 | `CancelToken` なし | 学習が無い以上、キャンセル対象が存在しない |
 
 ## エラー

--- a/litsea-wasm/src/lib.rs
+++ b/litsea-wasm/src/lib.rs
@@ -9,8 +9,12 @@
 //! - **No `fromUri`.** reqwest's wasm backend cannot build with the timeouts
 //!   `litsea::model_io` sets, so the page fetches the model and passes the
 //!   bytes to [`Segmenter::from_bytes`].
-//! - **No training.** `litsea`'s extractor and trainers are path-based, and
-//!   wasm32 has no filesystem.
+//! - **No training**, by choice rather than by necessity. `litsea` gained
+//!   filesystem-free extract/train APIs in #218, so this binding *could*
+//!   train; it does not, because a browser is not where training belongs -
+//!   a tab would hold the corpus, its features (much larger), and the model
+//!   at once - and because the reference implementation this binding set
+//!   follows, `lindera-wasm`, does not train either (#221).
 //!
 //! ```js
 //! import init, { Segmenter } from 'litsea-wasm'


### PR DESCRIPTION
## Summary

Documentation correction following the decision recorded on #221 (closed as not planned): the WebAssembly binding stays without training.

Five places justified the absence of training like this:

> `Extractor` and the trainers are path-based, and wasm32 has no filesystem — tracked in #218

That was accurate when #206 shipped. #218 then landed the filesystem-free extract/train APIs, so the first half stopped being true, and the issue it points readers at is closed. Left as-is, the docs would tell a reader that a technical limitation prevents something that a scope decision prevents.

## What the docs say now

The reason is a deliberate choice, for two stated reasons:

- **A browser is not where training belongs.** A tab would hold the corpus, the features extracted from it (much larger than the corpus), and the model at once. Settling the API shape would have meant measuring that first, and the measurement could well have concluded it is impractical at any useful corpus size.
- **The reference implementation does not either.** Verified rather than assumed:

  | Binding | `src/trainer.rs` | `train` feature |
  |---------|------------------|-----------------|
  | `lindera-python` / `-nodejs` / `-php` / `-ruby` | present | `default = ["train"]` |
  | `lindera-wasm` | absent | absent |

Readers are pointed at the CLI or a native binding for training.

## Files

`litsea-wasm/README.md`, `README_ja.md`, `src/lib.rs`, `docs/src/bindings/wasm.md`, `docs/ja/src/bindings/wasm.md`, and the `CHANGELOG.md` entry for #218 — which framed the in-memory APIs as what the WASM binding needs before it can train. They stand on their own as a filesystem-free path for any embedder, and the entry now says that.

Docs only; no code change. `markdownlint-cli2` clean, both mdbook builds pass, and `cargo clippy -p litsea-wasm --target wasm32-unknown-unknown -- -D warnings` is clean (the module docs changed).

Refs #221, #218, #206
