### PR TITLE
chore: release 0.13.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,6 +293,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
+      - name: Run checkout
+        uses: actions/checkout@v7
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         env:
@@ -304,6 +307,22 @@ jobs:
           prerelease: false
           generate_release_notes: true
           make_latest: true
+          # The bundled models, attached uncompressed and individually so
+          # each has a stable download URL: `litsea segment -m <url>` (with
+          # the `remote_model` feature) and the WebAssembly binding's
+          # fetch-then-`fromBytes` flow can point straight at one, and a
+          # caller downloads only the language they need rather than 24 MB.
+          # Listed explicitly rather than globbed, so the legacy
+          # RWCP / JEITA compatibility models stay out.
+          files: |
+            models/chinese.model
+            models/chinese_pos.model
+            models/english.model
+            models/english_pos.model
+            models/japanese.model
+            models/japanese_pos.model
+            models/korean.model
+            models/korean_pos.model
 
   release:
     name: Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.13.0 (2026-08-23)
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,7 +1375,7 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "litsea"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "criterion",
  "reqwest",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "litsea-binding-core"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "litsea",
  "tempfile",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "litsea-cli"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "clap",
  "ctrlc",
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "litsea-nodejs"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "litsea",
  "litsea-binding-core",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "litsea-php"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "ext-php-rs",
  "litsea",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "litsea-python"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "litsea",
  "litsea-binding-core",
@@ -1438,7 +1438,7 @@ dependencies = [
 
 [[package]]
 name = "litsea-ruby"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "litsea",
  "litsea-binding-core",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "litsea-wasm"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "js-sys",
  "litsea",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ lto = "thin"
 codegen-units = 1
 
 [workspace.package]
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.87"
 description = "Litsea is an extremely compact word segmentation and model training tool implemented in Rust."
@@ -53,5 +53,5 @@ criterion = { version = "0.8.2", default-features = false, features = [
     "html_reports",
 ] }
 
-litsea = { version = "0.12.0", path = "./litsea" }
-litsea-binding-core = { version = "0.12.0", path = "./litsea-binding-core" }
+litsea = { version = "0.13.0", path = "./litsea" }
+litsea-binding-core = { version = "0.13.0", path = "./litsea-binding-core" }

--- a/docs/ja/src/README.md
+++ b/docs/ja/src/README.md
@@ -48,7 +48,7 @@ Output: 今日/NOUN は/ADP いい/ADJ 天気/NOUN です/AUX ね/PART 。/PUNCT
 
 ## 現在のバージョン
 
-Litsea v0.12.0 -- Rust Edition 2024、最低 Rust バージョン 1.87。
+Litsea v0.13.0 -- Rust Edition 2024、最低 Rust バージョン 1.87。
 
 ## リンク
 

--- a/docs/ja/src/advanced/remote-model-loading.md
+++ b/docs/ja/src/advanced/remote-model-loading.md
@@ -34,7 +34,7 @@ learner.load_model("https://example.com/models/japanese.model").await?;
 0.6.0 以降、`remote_model` フィーチャーは**オプトイン**です（ライブラリのデフォルトはローカル読み込みのみとし、依存関係のツリーをコンパクトに保っています）。CLI ではこのフィーチャーが有効化されているため、`litsea segment https://...` はそのまま動作します。ライブラリ利用者は以下が必要です:
 
 ```toml
-litsea = { version = "0.12.0", features = ["remote_model"] }
+litsea = { version = "0.13.0", features = ["remote_model"] }
 ```
 
 ## 実装の詳細

--- a/docs/ja/src/bindings/binding-core.md
+++ b/docs/ja/src/bindings/binding-core.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-litsea-binding-core = "0.12.0"
+litsea-binding-core = "0.13.0"
 ```
 
 ## モジュール構成

--- a/docs/ja/src/getting-started/installation.md
+++ b/docs/ja/src/getting-started/installation.md
@@ -35,13 +35,13 @@ cargo build --release
 
 ```toml
 [dependencies]
-litsea = "0.12.0"
+litsea = "0.13.0"
 ```
 
 http(s) 経由のリモートモデル読み込みはオプトイン（opt-in）です。必要な場合は `remote_model` フィーチャーを有効にしてください:
 
 ```toml
-litsea = { version = "0.12.0", features = ["remote_model"] }
+litsea = { version = "0.13.0", features = ["remote_model"] }
 ```
 
 > **注意:** ローカルファイルからのモデル読み込み（`load_model_from_path`）は同期処理のため、非同期ランタイムは不要です。非同期ランタイム（`tokio` など）が必要になるのは、非同期の `load_model` メソッドを使って HTTP/HTTPS 経由でモデルを読み込む場合のみです（オプトインの `remote_model` フィーチャーを有効にした場合にのみ利用できます）。

--- a/docs/ja/src/litsea.md
+++ b/docs/ja/src/litsea.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-litsea = "0.12.0"
+litsea = "0.13.0"
 ```
 
 ローカルファイルからのモデル読み込みは同期 API（`load_model_from_path`）で行えるため、tokio などの非同期ランタイムは不要です。HTTP(S) からのリモートモデル取得など async API（`load_model`）を使う場合のみ、非同期ランタイムを追加してください（例えば `TwoStageLearner::load_model` も常に同じ非同期経路でモデル URI を解決するため、これに該当します）。

--- a/docs/ja/src/pre-trained-models.md
+++ b/docs/ja/src/pre-trained-models.md
@@ -2,6 +2,23 @@
 
 Litsea は `models/` ディレクトリに複数の事前学習済みモデルを同梱しています。
 
+## モデルの入手
+
+モデルはリポジトリの [`models/`](https://github.com/mosuka/litsea/tree/main/models) ディレクトリにあります。加えて、各リリースでは 8 つの言語モデルを個別のアセットとして添付しています。
+
+```text
+https://github.com/mosuka/litsea/releases/download/<tag>/japanese.model
+https://github.com/mosuka/litsea/releases/download/<tag>/japanese_pos.model
+...
+```
+
+これらの URL はリリースごとに固定で、必要な言語だけを取得できます（8 個すべてで 24MB に対し、1 つあたり 84KB〜8MB）。これにより次の 2 つが可能になります。
+
+- `remote_model` feature を有効にすれば、CLI やライブラリが URL を直接受け取れます: `litsea segment -l japanese https://github.com/mosuka/litsea/releases/download/<tag>/japanese.model`
+- `fromUri` を持たない [WebAssembly バインディング](bindings/wasm.md)でも、ページ側で `fetch` してバイト列を `Segmenter.fromBytes` に渡せます
+
+`main` ではなくリリースタグを指定しておくと、デプロイ先のモデル重みが固定されます。モデルはリリース間で再学習されることがあり、held-out スコアもそれに伴って変わります。
+
 ## モデルカタログ
 
 単語分割モデルは、学習コーパスの held-out テスト分割（学習に使用していない文）で

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -48,7 +48,7 @@ There is a small plant called *Litsea cubeba* (Aomoji) in the same Lauraceae fam
 
 ## Current Version
 
-Litsea v0.12.0 -- Rust Edition 2024, minimum Rust version 1.87.
+Litsea v0.13.0 -- Rust Edition 2024, minimum Rust version 1.87.
 
 ## Links
 

--- a/docs/src/advanced/remote-model-loading.md
+++ b/docs/src/advanced/remote-model-loading.md
@@ -37,7 +37,7 @@ so `litsea segment https://...` keeps working out of the box; library users
 need:
 
 ```toml
-litsea = { version = "0.12.0", features = ["remote_model"] }
+litsea = { version = "0.13.0", features = ["remote_model"] }
 ```
 
 ## Implementation Details

--- a/docs/src/bindings/binding-core.md
+++ b/docs/src/bindings/binding-core.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-litsea-binding-core = "0.12.0"
+litsea-binding-core = "0.13.0"
 ```
 
 ## Module Map

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -35,14 +35,14 @@ Add Litsea to your project's `Cargo.toml`:
 
 ```toml
 [dependencies]
-litsea = "0.12.0"
+litsea = "0.13.0"
 ```
 
 Remote model loading over http(s) is opt-in; enable the `remote_model`
 feature if you need it:
 
 ```toml
-litsea = { version = "0.12.0", features = ["remote_model"] }
+litsea = { version = "0.13.0", features = ["remote_model"] }
 ```
 
 > **Note:** Loading models from local files (`load_model_from_path`) is synchronous, so no async runtime is needed. An async runtime such as `tokio` is only required if you load models over HTTP/HTTPS with the async `load_model` method (available only when the opt-in `remote_model` feature is enabled).

--- a/docs/src/litsea.md
+++ b/docs/src/litsea.md
@@ -6,7 +6,7 @@ The `litsea` crate provides a Rust API for word segmentation, model training, an
 
 ```toml
 [dependencies]
-litsea = "0.12.0"
+litsea = "0.13.0"
 ```
 
 Loading models from local files is synchronous and needs no async runtime. An async runtime such as `tokio` is only required when loading models over HTTP/HTTPS with the async `load_model` method (for example `TwoStageLearner::load_model`, which always resolves the model URI through the same async path).

--- a/docs/src/pre-trained-models.md
+++ b/docs/src/pre-trained-models.md
@@ -2,6 +2,23 @@
 
 Litsea ships with several pre-trained models in the `models/` directory.
 
+## Downloading a model
+
+The models live in the [`models/`](https://github.com/mosuka/litsea/tree/main/models) directory of the repository, and each release attaches the eight language models as individual assets:
+
+```text
+https://github.com/mosuka/litsea/releases/download/<tag>/japanese.model
+https://github.com/mosuka/litsea/releases/download/<tag>/japanese_pos.model
+...
+```
+
+Those URLs are stable per release, and small enough to fetch only what you need (84 KB to 8 MB each, rather than 24 MB for all eight). Two consequences:
+
+- With the `remote_model` feature, the CLI and the library take one directly: `litsea segment -l japanese https://github.com/mosuka/litsea/releases/download/<tag>/japanese.model`.
+- The [WebAssembly binding](bindings/wasm.md), which has no `fromUri`, can `fetch` one in the page and pass the bytes to `Segmenter.fromBytes`.
+
+Pinning a release tag rather than `main` keeps a deployment on one set of model weights; the models are retrained between releases, and held-out scores move with them.
+
 ## Model Catalog
 
 The word segmentation models are evaluated on the held-out test split of

--- a/litsea-nodejs/index.js
+++ b/litsea-nodejs/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('litsea-android-arm64')
         const bindingPackageVersion = require('litsea-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('litsea-android-arm-eabi')
         const bindingPackageVersion = require('litsea-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('litsea-win32-x64-gnu')
         const bindingPackageVersion = require('litsea-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('litsea-win32-x64-msvc')
         const bindingPackageVersion = require('litsea-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('litsea-win32-ia32-msvc')
         const bindingPackageVersion = require('litsea-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('litsea-win32-arm64-msvc')
         const bindingPackageVersion = require('litsea-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('litsea-darwin-universal')
       const bindingPackageVersion = require('litsea-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('litsea-darwin-x64')
         const bindingPackageVersion = require('litsea-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('litsea-darwin-arm64')
         const bindingPackageVersion = require('litsea-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('litsea-freebsd-x64')
         const bindingPackageVersion = require('litsea-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('litsea-freebsd-arm64')
         const bindingPackageVersion = require('litsea-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('litsea-linux-x64-musl')
           const bindingPackageVersion = require('litsea-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('litsea-linux-x64-gnu')
           const bindingPackageVersion = require('litsea-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('litsea-linux-arm64-musl')
           const bindingPackageVersion = require('litsea-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('litsea-linux-arm64-gnu')
           const bindingPackageVersion = require('litsea-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('litsea-linux-arm-musleabihf')
           const bindingPackageVersion = require('litsea-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('litsea-linux-arm-gnueabihf')
           const bindingPackageVersion = require('litsea-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('litsea-linux-loong64-musl')
           const bindingPackageVersion = require('litsea-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('litsea-linux-loong64-gnu')
           const bindingPackageVersion = require('litsea-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('litsea-linux-riscv64-musl')
           const bindingPackageVersion = require('litsea-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('litsea-linux-riscv64-gnu')
           const bindingPackageVersion = require('litsea-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('litsea-linux-ppc64-gnu')
         const bindingPackageVersion = require('litsea-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('litsea-linux-s390x-gnu')
         const bindingPackageVersion = require('litsea-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('litsea-openharmony-arm64')
         const bindingPackageVersion = require('litsea-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('litsea-openharmony-x64')
         const bindingPackageVersion = require('litsea-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('litsea-openharmony-arm')
         const bindingPackageVersion = require('litsea-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.12.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -648,8 +648,8 @@ if (!nativeBinding || forceWasi) {
       if (!candidateFailed) {
         if (process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           const bindingPackageVersion = require('litsea-wasm32-wasi/package.json').version
-          if (bindingPackageVersion !== '0.12.0') {
-            throw new Error(`WASI binding package version mismatch, expected 0.12.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.13.0') {
+            throw new Error(`WASI binding package version mismatch, expected 0.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
         }
         wasiBinding = require('litsea-wasm32-wasi')

--- a/litsea-nodejs/package.json
+++ b/litsea-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "litsea",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Node.js binding for Litsea, a compact word segmentation and POS tagging library (no embedded models)",
   "main": "index.js",
   "types": "index.d.ts",

--- a/litsea-ruby/lib/litsea/version.rb
+++ b/litsea-ruby/lib/litsea/version.rb
@@ -3,5 +3,5 @@
 module Litsea
   # Kept in lockstep with the `litsea` crate; `Litsea.version` reports the
   # version the native extension was built from.
-  VERSION = '0.12.0'
+  VERSION = '0.13.0'
 end

--- a/scripts/bump_up_version.sh
+++ b/scripts/bump_up_version.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+#
+# Bumps the workspace version everywhere it is stated, in preparation for a
+# release.
+#
+# Usage:
+#   scripts/bump_up_version.sh 0.14.0
+#   scripts/bump_up_version.sh 0.14.0 --keep-changelog
+#
+# What it touches:
+#
+#   Cargo.toml                          workspace.package.version, plus the two
+#                                       [workspace.dependencies] entries that
+#                                       duplicate it
+#   Cargo.lock                          via `cargo update --workspace`
+#   litsea-nodejs/package.json          npm restates the version
+#   litsea-ruby/lib/litsea/version.rb   Litsea::VERSION, read by the gemspec
+#   docs/{src,ja/src}/...               dependency snippets, 6 files per language
+#   CHANGELOG.md                        `## Unreleased` -> `## <version> (<date>)`
+#
+# Three bindings need no edit and are deliberately absent from the list:
+# litsea-python takes the version from Cargo through maturin's
+# `dynamic = ["version"]`, litsea-wasm from Cargo.toml, and litsea-php has no
+# version field at all - Packagist reads the git tag.
+#
+# The script finishes by grepping the tree for the old version. Anything it
+# reports is a place this script does not know about yet: add it to FILES
+# rather than editing it by hand, so the next bump stays a one-liner.
+
+set -euo pipefail
+
+readonly REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Every file that states the version literally.
+readonly FILES=(
+  "Cargo.toml"
+  "litsea-nodejs/package.json"
+  "litsea-ruby/lib/litsea/version.rb"
+  "docs/src/litsea.md"
+  "docs/src/README.md"
+  "docs/src/bindings/binding-core.md"
+  "docs/src/getting-started/installation.md"
+  "docs/src/advanced/remote-model-loading.md"
+  "docs/ja/src/litsea.md"
+  "docs/ja/src/README.md"
+  "docs/ja/src/bindings/binding-core.md"
+  "docs/ja/src/getting-started/installation.md"
+  "docs/ja/src/advanced/remote-model-loading.md"
+)
+
+usage() {
+  cat >&2 <<'EOF'
+usage: scripts/bump_up_version.sh <new-version> [--keep-changelog]
+
+  <new-version>      the version to move to, e.g. 0.14.0
+  --keep-changelog   leave the `## Unreleased` heading alone
+
+Run from anywhere; paths are resolved relative to the repository root.
+EOF
+  exit 2
+}
+
+new_version=""
+keep_changelog=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --keep-changelog) keep_changelog=true ;;
+    -h | --help) usage ;;
+    -*) echo "unknown option: $1" >&2; usage ;;
+    *)
+      [ -n "${new_version}" ] && { echo "unexpected argument: $1" >&2; usage; }
+      new_version="$1"
+      ;;
+  esac
+  shift
+done
+
+[ -n "${new_version}" ] || usage
+
+# Semver, optionally with a pre-release suffix (0.14.0-rc.1).
+if ! printf '%s' "${new_version}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+  echo "not a version: ${new_version}" >&2
+  exit 1
+fi
+
+cd "${REPO_ROOT}"
+
+# The workspace version is the source of truth for what we are moving from.
+current_version="$(
+  grep -m1 -E '^version = "' Cargo.toml | sed -E 's/^version = "(.*)"/\1/'
+)"
+
+if [ -z "${current_version}" ]; then
+  echo "could not read the current version from Cargo.toml" >&2
+  exit 1
+fi
+
+if [ "${current_version}" = "${new_version}" ]; then
+  echo "already at ${new_version}; nothing to do" >&2
+  exit 1
+fi
+
+echo "bumping ${current_version} -> ${new_version}"
+
+for file in "${FILES[@]}"; do
+  if [ ! -f "${file}" ]; then
+    echo "  missing: ${file} (has it moved? update FILES in this script)" >&2
+    exit 1
+  fi
+
+  count="$(grep -c -F "${current_version}" "${file}" || true)"
+  if [ "${count}" -eq 0 ]; then
+    echo "  ${file}: no occurrence (update FILES in this script if it no longer states the version)" >&2
+    continue
+  fi
+
+  # -F is not available to sed, so the version is escaped for the pattern;
+  # only the dots need it.
+  escaped_current="$(printf '%s' "${current_version}" | sed 's/\./\\./g')"
+  sed -i "s/${escaped_current}/${new_version}/g" "${file}"
+  echo "  ${file}: ${count}"
+done
+
+# Refresh the lockfile's workspace members. `--workspace` leaves third-party
+# dependencies where they are, so a version bump does not smuggle in updates.
+echo "updating Cargo.lock"
+cargo update --workspace --quiet
+
+if [ "${keep_changelog}" = false ]; then
+  if grep -q '^## Unreleased$' CHANGELOG.md; then
+    today="$(date +%Y-%m-%d)"
+    sed -i "0,/^## Unreleased$/s//## ${new_version} (${today})/" CHANGELOG.md
+    echo "CHANGELOG.md: ## Unreleased -> ## ${new_version} (${today})"
+  else
+    echo "CHANGELOG.md: no '## Unreleased' heading; left alone" >&2
+  fi
+fi
+
+# napi writes the package version into the loader it generates, so the
+# committed entry point goes stale on every bump - and CI's freshness check
+# fails on the difference. Regenerate it here when the toolchain is available;
+# the leftover check below is what catches it if this does not happen.
+if grep -q -F "${current_version}" litsea-nodejs/index.js 2>/dev/null; then
+  if command -v npx >/dev/null 2>&1; then
+    echo "regenerating litsea-nodejs/index.js (napi embeds the version)"
+    (
+      cd litsea-nodejs
+      npm install --silent --no-audit --no-fund
+      npx napi build --platform -p litsea-nodejs
+    ) >/dev/null 2>&1 || echo "  regeneration failed; see the command below" >&2
+  else
+    echo "npx not found; cannot regenerate litsea-nodejs/index.js" >&2
+  fi
+fi
+
+# Anything left is a place this script does not know about.
+#
+# Only tracked files are searched: build output states versions of its own
+# (a Python venv's dependency metadata, wasm-pack's generated package.json,
+# vendored PHP packages) and none of it is ours to edit. `git ls-files` gets
+# that right by construction, where an ignore list would drift.
+#
+# CHANGELOG.md and Cargo.lock are excluded too: the former names older
+# versions in its history on purpose, and the latter was just regenerated
+# but still lists third-party crates that happen to share the number.
+echo
+echo "checking for leftovers"
+leftovers="$(
+  git ls-files -z |
+    grep -zZv -E '^(CHANGELOG\.md|Cargo\.lock)$' |
+    xargs -0 grep -n -F "${current_version}" /dev/null 2>/dev/null || true
+)"
+
+if [ -n "${leftovers}" ]; then
+  echo "${leftovers}" >&2
+  cat >&2 <<EOF
+
+The lines above still name ${current_version}.
+
+If litsea-nodejs/index.js is among them, it is generated - regenerate and
+commit it, or CI's freshness check will fail:
+
+    cd litsea-nodejs && npm install && npx napi build --platform -p litsea-nodejs
+
+Anything else is a place this script does not know about: add its file to
+FILES here, so the next bump covers it.
+EOF
+  exit 1
+fi
+
+echo "  none"
+echo
+echo "done. Next:"
+echo "  1. review the diff"
+echo "  2. cargo test --all-features && cargo clippy --workspace --all-targets -- -D warnings"
+echo "  3. commit, and tag once merged"


### PR DESCRIPTION
## Summary

Prepares 0.13.0, attaches the bundled models to the release, and adds a script so the next bump is one command.

## 1. Bump to 0.13.0

0.13.0 rather than 0.12.1 because `Unreleased` carries a breaking change — the joint POS architecture was removed in favour of two-stage (#190). It also collects the five language bindings and their shared crate (#200–#206), the in-memory extract/train APIs (#218), and the training-reproducibility fix those uncovered.

Seventeen places state the version: three in the root manifest (the workspace version plus the two `[workspace.dependencies]` entries that duplicate it), two in bindings that restate it (`package.json`, `version.rb`), and twelve in docs snippets across EN and JA. Three bindings derive it instead — `litsea-python` through maturin's `dynamic = ["version"]`, `litsea-wasm` from `Cargo.toml`, and `litsea-php` not at all, since Packagist reads the git tag.

**Verified by asking each binding at runtime rather than by reading the diff**, since the three that derive it would only fail at publish time:

```text
Python 0.13.0 · Node.js 0.13.0 · PHP 0.13.0 · Ruby 0.13.0 · WASM 0.13.0
```

`litsea-nodejs/index.js` moves with the bump — napi embeds the package version in the generated loader — and is committed, which is what CI's freshness check requires. Its diff is version strings only (54 lines).

## 2. Attach the models to the release

`create-release` gains a checkout step and the eight language models:

- **Uncompressed and individual**, so each has a stable per-release URL. Two existing features consume those directly: `litsea segment -m <url>` with the `remote_model` feature, and the WebAssembly binding's fetch-then-`fromBytes` flow (it has no `fromUri`). A caller also takes 84 KB rather than 24 MB when they want Korean.
- **Listed explicitly, not globbed**, so the legacy RWCP and JEITA compatibility models stay out.
- **In `create-release`, not the `release` matrix** — that job runs once; the matrix runs six times and would upload them six times over.

`pre-trained-models.md` (EN/JA) documents the URLs and notes that pinning a tag keeps a deployment on one set of weights, since models are retrained between releases.

## 3. `scripts/bump_up_version.sh`

Doing seventeen strings by hand is how one gets left behind. The script rewrites them all, refreshes the lockfile's workspace members, closes the `## Unreleased` heading with today's date, and regenerates the napi loader.

It then greps the tree for the old version and **fails if anything remains** — so a file that starts stating the version in future is reported rather than skipped, and the fix is one line at the top of the script. The search covers tracked files only (`git ls-files`): build output carries versions of its own, and an ignore list for that would drift.

Verified by running it: 0.13.0 → 0.14.0 updated 15 files, left every crate on one version, regenerated the loader, reported no leftovers — then reverted.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --all-features` (7 suites), `markdownlint-cli2` (118 files), both mdbook builds, and the five bindings' runtime versions above.

The workflow change itself only executes on a tag push, so it is reviewed rather than exercised here.

Closes #223
